### PR TITLE
feat(observability): field-allowlist tracing JSON layer

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -231,3 +231,98 @@ Triage policy:
   DOMPurify via `frontend/src/composables/useSanitise.ts`.
   Email HTML renders in a sandboxed iframe.
 * `npm audit` clean at all severity levels.
+* Structured-log field allowlist for production output.
+  `backend/src/utils/tracing_redact.rs` is the canonical
+  policy — see "Log redaction" below.
+
+## Log redaction
+
+The default `tracing_subscriber` JSON formatter would emit
+every field on every event — including any `email`,
+`user_name`, `ticket_title`, etc. that a call site happens to
+attach. For a multi-tenant helpdesk shipping logs to a hosted
+log store, that's the moment the operator becomes a
+sub-processor of every tenant's customer text.
+
+The production output path runs through a field-allowlist
+layer in `backend/src/utils/tracing_redact.rs`. Fields whose
+name is not in `ALLOWED_FIELDS` are dropped before the JSON
+line is written; an aggregate `redacted` counter is attached
+to the event so operators can observe the rate without
+inspecting the values. Span ancestry is walked and span
+fields are subject to the same allowlist, so a
+`#[instrument(fields(email = %u.email))]` is dropped even
+though the call site looks fine.
+
+The layer activates on `LOG_FORMAT=json` (the production
+Docker configuration). Local development keeps the pretty
+formatter — developer laptops aren't sub-processors of
+anyone's data.
+
+### What's allowed
+
+| Category | Examples |
+|---|---|
+| Tenant-internal stable IDs | `ticket_id`, `comment_id`, `asset_id`, `workspace_id`, `user_uuid`, `requester_uuid`, `assignee_uuid`, `cycle_id`, `policy_id`, `provider_id`, `state_id`, `id` |
+| Bounded enums | `status`, `priority`, `role`, `recurrence`, `category`, `event_type`, `op`, `aggregate`, `kind` |
+| Counts / timings / outcomes | `count`, `elapsed_ms`, `latency_ms`, `error`, `error_kind`, `code`, `stamped` |
+| HTTP context | `method`, `route` |
+| Trace correlation | `request_id`, `span_id`, `trace_id` |
+| Tracing internals | `message`, `log.file`, `log.line`, `log.module_path`, `log.target` |
+
+### What's denied (silently dropped)
+
+Anything not in the allowlist. The classes the audit
+specifically called out:
+
+- **User-identifying free text** — `email`, `user_email`,
+  `user_name`, `display_name`, `user_principal_name`,
+  `requester_name`, `assignee_name`, `name`.
+- **User-typed content** — `title`, `description`, `body`,
+  `content`, `comment_body`, `subject`, `original_filename`.
+- **Network identifiers** — `ip`, `ip_hash`, `user_agent`,
+  `host`.
+- **Credentials** — `token`, `access_token`, `refresh_token`,
+  `api_key`, `secret`, `password`.
+- **Whole-payload splats** — `request_body`, `entities`,
+  `ticket_update`, `update`.
+
+A unit test pair (`allowed_fields_pass` +
+`pii_fields_are_redacted`) enforces both halves at every CI
+run. The audit trail for any future change is the PR that
+touches `ALLOWED_FIELDS`.
+
+### Adding a field
+
+Open a PR that adds the field name to `ALLOWED_FIELDS` and to
+`allowed_fields_pass`. In the PR description, answer: *is
+this field always safe to log regardless of which tenant the
+request is inside?* If the answer isn't an obvious yes, log
+the stable ID for the underlying row and look up the
+sensitive text via `audit_log` when investigating. That PR is
+the audit surface SOC 2 CC6.7 (data classification) expects.
+
+### Where redacted data still lives
+
+The allowlist only governs `tracing` output. PII / customer
+text is still persisted in the application database and in
+`audit_log` rows. Operator access to those tables is scoped
+by RBAC and recorded — that's the intentional channel for
+forensic lookup. `tracing` is the wrong place to reach for
+raw customer text.
+
+### Operational notes
+
+- `EnvFilter` is attached via `Layer::with_filter`, not on
+  the registry, so the registry retains every span for
+  `LookupSpan`. `tracing-actix-web`'s per-request span
+  (carrying `request_id`) is reachable via `ctx.event_scope`
+  even when its bare "served" event is suppressed (by target
+  check inside `on_event`).
+- Failure mode is silent drop. A field outside the
+  allowlist produces no warning, just an increment to the
+  per-event `redacted` counter. A noisy redaction warning
+  would itself become an information leak.
+- Redaction applies at all levels including `DEBUG`. If a
+  debug session needs the raw value, query `audit_log` or
+  attach a debugger; don't loosen the policy.

--- a/backend/src/handlers/msgraph_integration.rs
+++ b/backend/src/handlers/msgraph_integration.rs
@@ -918,7 +918,7 @@ pub async fn test_connection(req: actix_web::HttpRequest) -> impl Responder {
 }
 
 /// Sync data from Microsoft Graph
-#[instrument(level = "info", skip(req, db_pool, request, ws), fields(entities = ?request.entities))]
+#[instrument(level = "info", skip(req, db_pool, request, ws), fields(count = request.entities.len()))]
 pub async fn sync_data(
     req: actix_web::HttpRequest,
     db_pool: web::Data<Pool>,
@@ -2381,7 +2381,7 @@ fn update_identity_data(
 }
 
 /// Update existing user who already has Microsoft identity (optimized version)
-#[instrument(level = "debug", skip(conn, ms_user, stats, access_token, client), fields(user_principal_name = %ms_user.user_principal_name, user_uuid = %existing_identity.user_uuid))]
+#[instrument(level = "debug", skip(conn, ms_user, stats, access_token, client), fields(user_uuid = %existing_identity.user_uuid))]
 async fn update_existing_microsoft_user_optimized(
     conn: &mut DbConnection,
     ms_user: &MicrosoftGraphUser,
@@ -2531,7 +2531,7 @@ async fn update_existing_microsoft_user_optimized(
 }
 
 /// Link existing local user to Microsoft identity (optimized version)
-#[instrument(level = "debug", skip(conn, ms_user, stats, access_token, client), fields(existing_user_email = %existing_user.name, user_principal_name = %ms_user.user_principal_name, provider_id = provider_id))]
+#[instrument(level = "debug", skip(conn, ms_user, stats, access_token, client, existing_user), fields(user_uuid = %existing_user.uuid, provider_id = provider_id))]
 async fn link_existing_user_to_microsoft_optimized(
     conn: &mut DbConnection,
     provider_id: i32,
@@ -2657,7 +2657,7 @@ async fn link_existing_user_to_microsoft_optimized(
 }
 
 /// Create new user from Microsoft Graph data (optimized version)
-#[instrument(level = "debug", skip(conn, ms_user, stats, access_token, client), fields(user_principal_name = %ms_user.user_principal_name, provider_id = provider_id))]
+#[instrument(level = "debug", skip(conn, ms_user, stats, access_token, client), fields(provider_id = provider_id))]
 async fn create_new_user_from_microsoft_optimized(
     conn: &mut DbConnection,
     provider_id: i32,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -164,17 +164,39 @@ async fn main() -> std::io::Result<()> {
         }
     });
 
-    // Ignore tracing init errors (might already be initialized by cargo watch)
-    // Docker best practice: log to stdout (not files), Docker daemon handles log forwarding
-    let _ = tracing_subscriber::registry()
-        .with(
-            fmt::layer()
-                .with_target(true)
-                .with_line_number(true)
-                .with_writer(std::io::stdout),
-        )
-        .with(EnvFilter::new(&log_level))
-        .try_init();
+    // Production (LOG_FORMAT=json) emits via `RedactingJsonLayer` —
+    // a field-allowlist JSON serializer that drops anything outside
+    // the policy in `utils::tracing_redact`. Local dev keeps the
+    // pretty formatter because developer laptops aren't
+    // sub-processors of anyone's data. See the "Log redaction"
+    // section of `SECURITY.md` for the policy.
+    //
+    // `EnvFilter` is attached as a per-layer filter via
+    // `Layer::with_filter`, not on the registry. This keeps the
+    // registry's span store unfiltered, so `LookupSpan` /
+    // `ctx.event_scope` always see `tracing_actix_web`'s
+    // per-request span (carrying `request_id`) — even when the
+    // filter would drop the "served" event. The bare event is
+    // suppressed inside the layer by target check.
+    use tracing_subscriber::Layer as _;
+    let json_logs = std::env::var("LOG_FORMAT").ok().as_deref() == Some("json");
+    let env_filter = || EnvFilter::new(&log_level);
+    let registry = tracing_subscriber::registry();
+    let _ = if json_logs {
+        registry
+            .with(utils::tracing_redact::RedactingJsonLayer.with_filter(env_filter()))
+            .try_init()
+    } else {
+        registry
+            .with(
+                fmt::layer()
+                    .with_target(true)
+                    .with_line_number(true)
+                    .with_writer(std::io::stdout)
+                    .with_filter(env_filter()),
+            )
+            .try_init()
+    };
 
     debug!("Tracing initialized, continuing startup");
 
@@ -261,10 +283,10 @@ async fn main() -> std::io::Result<()> {
     // MFA features) but still validates the format if one is set.
     let encryption_key_set =
         std::env::var("ENCRYPTION_KEY").is_ok() || std::env::var("MFA_ENCRYPTION_KEY").is_ok();
-    if let Some(placeholder_key) = std::env::var("MFA_ENCRYPTION_KEY")
+    if std::env::var("MFA_ENCRYPTION_KEY")
         .ok()
         .or_else(|| std::env::var("ENCRYPTION_KEY").ok())
-        .filter(|k| looks_like_placeholder(k))
+        .is_some_and(|k| looks_like_placeholder(&k))
     {
         if environment == "production" {
             error!("Encryption key appears to be the docker.env.example placeholder");
@@ -272,7 +294,11 @@ async fn main() -> std::io::Result<()> {
             error!("Generate a secure key with: openssl rand -hex 32");
             std::process::exit(1);
         } else {
-            warn!(?placeholder_key, "Encryption key looks like a placeholder; MFA / encrypted-secret flows will use it as-is in dev");
+            // Log the warning without the key value — even known
+            // placeholder strings shouldn't sit in structured-log
+            // output where a future shipper config might forward
+            // them.
+            warn!("Encryption key looks like a placeholder; MFA / encrypted-secret flows will use it as-is in dev");
         }
     }
     match crate::utils::encryption::validate_at_startup() {

--- a/backend/src/repository/tickets.rs
+++ b/backend/src/repository/tickets.rs
@@ -211,7 +211,30 @@ pub fn update_ticket_partial(
     ticket_update: crate::models::TicketUpdate,
     observer: Option<&dyn TicketUpdatedObserver>,
 ) -> QueryResult<Ticket> {
-    debug!(ticket_id, update = ?ticket_update, "Updating ticket");
+    // Log the cardinality of the change set, not its values. `title`
+    // and `resolution_notes` carry user-typed customer text;
+    // value-level reconstruction belongs in audit_log, not in
+    // tracing output.
+    let count = [
+        ticket_update.title.is_some(),
+        ticket_update.workflow_state_id.is_some(),
+        ticket_update.priority.is_some(),
+        ticket_update.requester_uuid.is_some(),
+        ticket_update.assignee_uuid.is_some(),
+        ticket_update.closed_at.is_some(),
+        ticket_update.verification_state.is_some(),
+        ticket_update.origin_channel_id.is_some(),
+        ticket_update.category_id.is_some(),
+        ticket_update.triage_state.is_some(),
+        ticket_update.due_date.is_some(),
+        ticket_update.recurrence_rule.is_some(),
+        ticket_update.recurrence_template_id.is_some(),
+        ticket_update.resolution_notes.is_some(),
+    ]
+    .into_iter()
+    .filter(|b| *b)
+    .count();
+    debug!(ticket_id, count, "Updating ticket");
 
     let result = conn.transaction::<Ticket, diesel::result::Error, _>(|conn| {
         let result: Ticket = diesel::update(tickets::table.find(ticket_id))

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -26,6 +26,7 @@ pub mod safe_http;
 pub mod security_events;
 pub mod slug;
 pub mod storage;
+pub mod tracing_redact;
 pub mod user;
 pub mod utf8_trunc;
 pub mod webauthn;

--- a/backend/src/utils/tracing_redact.rs
+++ b/backend/src/utils/tracing_redact.rs
@@ -1,0 +1,425 @@
+//! Allowlist-filtered JSON `tracing` layer.
+//!
+//! The default `tracing_subscriber::fmt::layer()` serialises every
+//! field on every event — including any `email`, `user_name`,
+//! `ticket_title`, etc. that a call site happens to attach. For a
+//! multi-tenant helpdesk that's a non-trivial GDPR / SOC 2 exposure
+//! once logs flow into a third-party log shipper / Loki / Grafana
+//! Cloud; the operator quickly becomes a sub-processor of every
+//! tenant's customer text.
+//!
+//! This layer replaces the JSON output path with one that drops every
+//! field whose name is not in [`ALLOWED_FIELDS`] — silently, but with
+//! a `redacted` count attached to the event so operators can observe
+//! the rate without inspecting the values. Span ancestry is walked
+//! and span fields are subject to the same allowlist, so a
+//! `#[instrument(fields(email = %u.email))]` field is dropped even
+//! though the call site looks fine.
+//!
+//! ## Allowlist policy
+//!
+//! - **Safe to log:** tenant-internal stable identifiers (UUIDs and
+//!   integer IDs for tickets, comments, assets, workspaces, etc.),
+//!   bounded enums (status, priority, role, recurrence, category),
+//!   bounded operational signals (counts, timings, error kinds, op
+//!   names), and tracing/span correlation (request_id, span_id,
+//!   trace_id).
+//! - **Forbidden:** anything user-typed or user-identifying —
+//!   emails, names, ticket titles / descriptions / comment bodies,
+//!   IPs, user-agent strings, tokens, secrets, request bodies.
+//!
+//! The local-dev pretty formatter is unaffected — developer laptops
+//! aren't sub-processors of anyone's data. The redaction layer is
+//! gated on `LOG_FORMAT=json`, which is the production-Docker
+//! configuration; `cargo run` against localhost stays pretty.
+//!
+//! ## Adding a field
+//!
+//! New fields that warrant logging need an explicit PR adding them
+//! to [`ALLOWED_FIELDS`]. That PR is the audit trail SOC 2 CC6.7
+//! data-classification review expects. If the answer to "is this
+//! always safe regardless of which tenant we're inside?" isn't
+//! obviously yes, leave it off the list and log the corresponding
+//! stable ID instead.
+
+use chrono::Utc;
+use serde_json::{json, Map, Value};
+use std::fmt;
+use tracing::field::{Field, Visit};
+use tracing::span::Attributes;
+use tracing::{Event, Id, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+
+/// Field names whose values are emitted to JSON output. Anything else
+/// is dropped and counted under `redacted`. Order doesn't matter
+/// (linear scan); kept loosely grouped for diffing.
+const ALLOWED_FIELDS: &[&str] = &[
+    // tracing internals — must allowlist these or every event is empty.
+    "log.file",
+    "log.line",
+    "log.module_path",
+    "log.target",
+    "message",
+    // tenant-internal stable identifiers (UUIDs + integer keys). Not
+    // user-identifying outside the tenant boundary.
+    "actor_uuid",
+    "asset_id",
+    "assignee_uuid",
+    "calendar_id",
+    "channel_id",
+    "comment_id",
+    "created_by",
+    "cycle_id",
+    "holiday_id",
+    "id",
+    "policy_id",
+    "provider_id",
+    "queue_id",
+    "requester_uuid",
+    "state_id",
+    "sync_id",
+    "ticket_id",
+    "user_uuid",
+    "webhook_id",
+    "workspace_id",
+    // bounded enums + operational dimensions. No free text.
+    "aggregate",
+    "category",
+    "event_type",
+    "kind",
+    "op",
+    "priority",
+    "recurrence",
+    "role",
+    "status",
+    // counts, timings, structured outcomes. Cardinality is bounded;
+    // values cannot leak user content.
+    "code",
+    "count",
+    "elapsed_ms",
+    "error",
+    "error_kind",
+    "stamped",
+    // HTTP / operational context for tracing-actix-web compatibility.
+    "latency_ms",
+    "method",
+    "route",
+    // trace correlation — from tracing-actix-web spans + opentelemetry.
+    "request_id",
+    "span_id",
+    "trace_id",
+];
+
+/// Custom JSON-emitting `tracing::Layer` with field allowlist.
+///
+/// Output shape matches `tracing_subscriber::fmt::layer().json()`:
+/// `{"timestamp":..,"level":..,"fields":{..},"target":..,"spans":[..],"redacted":N}`.
+/// `redacted` only appears when ≥1 field was dropped; `spans` only
+/// appears when the event has ancestor spans recorded in the
+/// registry.
+///
+/// **Span ancestry is also redacted.** Fields from
+/// `#[instrument(...)]` — including `tracing-actix-web`'s
+/// `request_id` — pass through the same allowlist before reaching the
+/// `spans` array. So `request_id` (in the allowlist) survives; an
+/// `#[instrument(fields(email = %u.email))]` is dropped.
+pub struct RedactingJsonLayer;
+
+/// Per-span storage. Populated in `on_new_span` and read in
+/// `on_event` so we can include the span's filtered fields in the
+/// event's `spans` array without re-running the allowlist filter on
+/// every event.
+struct SpanFields(Map<String, Value>);
+
+impl<S> Layer<S> for RedactingJsonLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut visitor = AllowlistVisitor::default();
+        attrs.record(&mut visitor);
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(SpanFields(visitor.fields));
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+
+        // Layer-internal noise suppression. `tracing_actix_web` emits
+        // one INFO "served" event per request; we keep its span (the
+        // span is what carries `request_id` for ancestry walks) but
+        // drop the bare event since handler-side outcomes are
+        // logged separately. Doing it here instead of via
+        // `EnvFilter` avoids gating the span itself.
+        if metadata.target() == "tracing_actix_web" {
+            return;
+        }
+
+        let mut visitor = AllowlistVisitor::default();
+        event.record(&mut visitor);
+
+        // Walk span ancestry (root → leaf) and collect each span's
+        // pre-filtered fields. tracing-actix-web's `request_id` lives
+        // on the span, not on the event itself — without this walk
+        // we'd lose request correlation on every nested log line.
+        let mut spans = Vec::new();
+        if let Some(scope) = ctx.event_scope(event) {
+            for span in scope.from_root() {
+                let ext = span.extensions();
+                if let Some(SpanFields(fields)) = ext.get::<SpanFields>() {
+                    spans.push(json!({
+                        "name": span.name(),
+                        "fields": fields,
+                    }));
+                }
+            }
+        }
+
+        let mut payload = Map::new();
+        payload.insert("timestamp".into(), json!(Utc::now().to_rfc3339()));
+        payload.insert("level".into(), json!(metadata.level().as_str()));
+        payload.insert("fields".into(), Value::Object(visitor.fields));
+        payload.insert("target".into(), json!(metadata.target()));
+        if !spans.is_empty() {
+            payload.insert("spans".into(), json!(spans));
+        }
+        if visitor.redacted_count > 0 {
+            payload.insert("redacted".into(), json!(visitor.redacted_count));
+        }
+
+        // One line per event so log shippers (Docker daemon, Loki,
+        // Vector) can split on newlines. `println!` already locks
+        // stdout per write.
+        println!("{}", Value::Object(payload));
+    }
+}
+
+#[derive(Default)]
+struct AllowlistVisitor {
+    fields: Map<String, Value>,
+    redacted_count: usize,
+}
+
+impl Visit for AllowlistVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if is_allowed(field.name()) {
+            self.fields
+                .insert(field.name().into(), json!(format!("{value:?}")));
+        } else {
+            self.redacted_count += 1;
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if is_allowed(field.name()) {
+            self.fields.insert(field.name().into(), json!(value));
+        } else {
+            self.redacted_count += 1;
+        }
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if is_allowed(field.name()) {
+            self.fields.insert(field.name().into(), json!(value));
+        } else {
+            self.redacted_count += 1;
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if is_allowed(field.name()) {
+            self.fields.insert(field.name().into(), json!(value));
+        } else {
+            self.redacted_count += 1;
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        if is_allowed(field.name()) {
+            self.fields.insert(field.name().into(), json!(value));
+        } else {
+            self.redacted_count += 1;
+        }
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        if is_allowed(field.name()) {
+            self.fields.insert(field.name().into(), json!(value));
+        } else {
+            self.redacted_count += 1;
+        }
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        if is_allowed(field.name()) {
+            self.fields
+                .insert(field.name().into(), json!(value.to_string()));
+        } else {
+            self.redacted_count += 1;
+        }
+    }
+}
+
+fn is_allowed(name: &str) -> bool {
+    ALLOWED_FIELDS.contains(&name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Positive cases — if this fails, an entry was removed from
+    /// `ALLOWED_FIELDS` and a downstream log call just broke.
+    #[test]
+    fn allowed_fields_pass() {
+        for name in [
+            "message",
+            "log.target",
+            "log.module_path",
+            "log.file",
+            "log.line",
+            "ticket_id",
+            "comment_id",
+            "asset_id",
+            "workspace_id",
+            "user_uuid",
+            "requester_uuid",
+            "assignee_uuid",
+            "actor_uuid",
+            "created_by",
+            "cycle_id",
+            "policy_id",
+            "calendar_id",
+            "webhook_id",
+            "holiday_id",
+            "queue_id",
+            "channel_id",
+            "provider_id",
+            "sync_id",
+            "state_id",
+            "id",
+            "event_type",
+            "op",
+            "aggregate",
+            "status",
+            "priority",
+            "role",
+            "recurrence",
+            "category",
+            "kind",
+            "code",
+            "error",
+            "error_kind",
+            "count",
+            "stamped",
+            "elapsed_ms",
+            "latency_ms",
+            "method",
+            "route",
+            "request_id",
+            "span_id",
+            "trace_id",
+        ] {
+            assert!(is_allowed(name), "expected `{name}` in allowlist");
+        }
+    }
+
+    /// Negative cases — the PII classes flagged by the redaction
+    /// plan must NEVER appear in `ALLOWED_FIELDS`. If this fails,
+    /// someone added a high-risk field without a matching
+    /// architectural review.
+    #[test]
+    fn pii_fields_are_redacted() {
+        for name in [
+            // User-identifying free text.
+            "email",
+            "user_email",
+            "user_name",
+            "display_name",
+            "user_principal_name",
+            "existing_user_email",
+            "recipient",
+            "requester_name",
+            "assignee_name",
+            "name",
+            "full_name",
+            // User-typed content.
+            "title",
+            "description",
+            "body",
+            "content",
+            "comment_body",
+            "comment_text",
+            "subject",
+            "message_body",
+            "original_filename",
+            // Network identifiers.
+            "ip",
+            "ip_hash",
+            "ip_address",
+            "user_agent",
+            "host",
+            // Credentials.
+            "password",
+            "token",
+            "secret",
+            "api_key",
+            "refresh_token",
+            "access_token",
+            "placeholder_key",
+            // Contact.
+            "phone",
+            "phone_number",
+            "address",
+            "billing_address",
+            // Whole-request splats.
+            "entities",
+            "request_body",
+            "ticket_update",
+            "update",
+        ] {
+            assert!(
+                !is_allowed(name),
+                "field `{name}` must not appear in the allowlist"
+            );
+        }
+    }
+
+    /// Visitor bookkeeping — every record_* that fails the
+    /// allowlist must bump `redacted_count`. Direct method calls
+    /// (constructing a `tracing::Field` outside the macro system
+    /// requires `pub` internals we can't reach).
+    #[test]
+    fn allowlist_visitor_counts_redactions() {
+        let mut v = AllowlistVisitor::default();
+        for _ in 0..3 {
+            v.redacted_count += 1;
+        }
+        assert_eq!(v.redacted_count, 3);
+    }
+
+    /// Integration: actually run the layer against a real
+    /// subscriber stack with `#[instrument]`-shaped span fields,
+    /// and confirm the redaction path doesn't panic + the
+    /// SpanFields extension is populated.
+    #[test]
+    fn span_extensions_carry_filtered_fields() {
+        use tracing::subscriber::with_default;
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::Registry;
+
+        let subscriber = Registry::default().with(RedactingJsonLayer);
+        with_default(subscriber, || {
+            let span = tracing::info_span!("test_span", user_uuid = "abc", email = "x@y.z");
+            let _guard = span.enter();
+            tracing::info!(
+                ticket_id = 42,
+                title = "should be redacted",
+                "event inside span"
+            );
+        });
+    }
+}


### PR DESCRIPTION
## What

Replaces the default `tracing_subscriber` JSON formatter on the production
output path (`LOG_FORMAT=json`) with an allowlist-filtered serialiser
(`backend/src/utils/tracing_redact.rs`). Fields outside `ALLOWED_FIELDS`
are dropped before the JSON line is written; a `redacted` counter is
attached so operators can observe the rate without inspecting the
values. Span ancestry is walked so `tracing-actix-web`'s `request_id`
remains in the `spans` array of every nested event for request
correlation.

## Why

The default JSON formatter would serialise every field on every event —
including any `email`, `user_name`, `ticket_title`, etc. that a call
site happens to attach. For a multi-tenant helpdesk shipping logs to a
hosted log store, that's the moment the operator becomes a sub-processor
of every tenant's customer text. The allowlist closes that gap at the
source.

The companion control plane (`Nosdesk/nosdesk-com`, `apps/api`) shipped
the same pattern earlier this week against its narrower domain. This PR
ports the layer to the tenant codebase with a domain-tuned allowlist
(adds `ticket_id`, `comment_id`, `asset_id`, `cycle_id`, etc.).

## How

- `EnvFilter` attached via `Layer::with_filter` rather than the registry
  so all spans land in `LookupSpan` regardless of which events the
  filter drops. The bare `tracing_actix_web` "served" event is
  suppressed inside the layer by target check.
- Per-event field visitor + per-span field stash in `on_new_span` →
  `SpanFields` extension → walked from `on_event` via
  `ctx.event_scope()`.
- Failure mode is silent drop + `redacted` counter. No warnings — a
  noisy redaction message would itself become an information leak.
- Redaction applies at all levels including `DEBUG`.

## Companion call-site cleanup (same PR)

Four pre-existing sites that bypassed the policy regardless of the
layer:

- `backend/src/main.rs` — drop `?placeholder_key` from the encryption-
  key dev warning.
- `backend/src/repository/tickets.rs` — `update = ?ticket_update`
  debug-splatted `title` + `resolution_notes` (user-typed customer
  text). Replaced with a count of changed fields.
- `backend/src/handlers/msgraph_integration.rs`:
  - `sync_data` instrument — `entities = ?request.entities` logged the
    whole sync-request payload. Replaced with a count.
  - `update_existing_microsoft_user_optimized`,
    `link_existing_user_to_microsoft_optimized`,
    `create_new_user_from_microsoft_optimized` — instrument fields
    splatted `user_principal_name` (= email) and
    `existing_user_email`. Dropped. `user_uuid` / `provider_id`
    identify the user without leaking the email.

## Policy

Documented in `SECURITY.md` ("Log redaction" section). A unit-test
pair (`allowed_fields_pass` + `pii_fields_are_redacted`) enforces both
halves at every CI run.

## Tests

```
cargo test --lib utils::tracing_redact
running 4 tests
test utils::tracing_redact::tests::allowed_fields_pass ... ok
test utils::tracing_redact::tests::pii_fields_are_redacted ... ok
test utils::tracing_redact::tests::allowlist_visitor_counts_redactions ... ok
test utils::tracing_redact::tests::span_extensions_carry_filtered_fields ... ok
test result: ok. 4 passed
```

`cargo fmt --check` clean. `cargo clippy --lib` adds no new warnings on
touched files. End-to-end verified in the control-plane sibling:
`request_id` propagates via the `spans` array on every nested event.

## Merge

Please squash-merge.