### PR TITLE
feat: ticket merge with first-class history, opt-in customer notify, and bulk action

### DIFF
--- a/backend/migrations/2026-06-05-010000_ticket_merge_workflow_state_value/down.sql
+++ b/backend/migrations/2026-06-05-010000_ticket_merge_workflow_state_value/down.sql
@@ -1,0 +1,6 @@
+-- Intentionally irreversible. Postgres has no DROP VALUE for enum
+-- labels; removing `merged` would mean dropping and recreating the
+-- whole workflow_state_category type along with every column that
+-- references it. An unused label is inert, so a rollback leaves it in
+-- place. The dependent workflow_states row is removed by the down
+-- migration of 2026-06-05-020000_ticket_merge_workflow_state_row.

--- a/backend/migrations/2026-06-05-010000_ticket_merge_workflow_state_value/up.sql
+++ b/backend/migrations/2026-06-05-010000_ticket_merge_workflow_state_value/up.sql
@@ -1,0 +1,11 @@
+-- Adds the `merged` value to the workflow_state_category enum so a
+-- ticket consumed by a merge can sit in a dedicated terminal state,
+-- distinct from `done` (resolved) and `cancelled`. The enum value and
+-- the workflow_states row that uses it are split across two migrations
+-- on purpose: Postgres forbids using a newly added enum label in the
+-- same transaction that adds it, and Diesel wraps each migration in its
+-- own transaction.
+--
+-- IF NOT EXISTS keeps `diesel migration redo` idempotent, since the
+-- down migration cannot remove an enum label (see down.sql).
+ALTER TYPE workflow_state_category ADD VALUE IF NOT EXISTS 'merged';

--- a/backend/migrations/2026-06-05-020000_ticket_merge_workflow_state_row/down.sql
+++ b/backend/migrations/2026-06-05-020000_ticket_merge_workflow_state_row/down.sql
@@ -1,0 +1,7 @@
+-- Remove the seeded Merged state. Suppress the audit trigger for the
+-- same reason the up migration does.
+SET LOCAL session_replication_role = 'replica';
+
+DELETE FROM workflow_states WHERE category = 'merged' AND name = 'Merged';
+
+SET LOCAL session_replication_role = 'origin';

--- a/backend/migrations/2026-06-05-020000_ticket_merge_workflow_state_row/up.sql
+++ b/backend/migrations/2026-06-05-020000_ticket_merge_workflow_state_row/up.sql
@@ -1,0 +1,21 @@
+-- Seeds the built-in `Merged` workflow state, one row per workspace
+-- (workflow_states is workspace-scoped: workspace_id is NOT NULL and the
+-- default / category-position unique indexes are per workspace). Source
+-- tickets in a merge transition here. `pauses_sla` defaults TRUE, so the
+-- SLA engine freezes a merged ticket's clock the same way it does for
+-- `done` with no policy change needed. `is_default` stays FALSE: the
+-- per-workspace partial unique index allows only one default state per
+-- workspace (currently Backlog), and the merge handler selects this row
+-- by category, not by the default flag. The `subtle` colour reuses the
+-- neutral badge palette, visually distinct from `done` (green).
+--
+-- Suppress the audit trigger for this schema-time seed: workflow_states
+-- is audited, and a migration has no actor or workspace to attribute the
+-- rows to (the same idiom as the pauses_sla backfill).
+SET LOCAL session_replication_role = 'replica';
+
+INSERT INTO workflow_states (name, category, color, position, is_default, workspace_id)
+SELECT 'Merged', 'merged', 'subtle', 0, FALSE, w.id
+FROM workspaces w;
+
+SET LOCAL session_replication_role = 'origin';

--- a/backend/migrations/2026-06-05-030000_ticket_merge_columns/down.sql
+++ b/backend/migrations/2026-06-05-030000_ticket_merge_columns/down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE tickets DROP CONSTRAINT IF EXISTS tickets_merge_complete;
+
+DROP INDEX IF EXISTS tickets_merged_into_idx;
+
+ALTER TABLE tickets
+    DROP COLUMN IF EXISTS merged_into_ticket_id,
+    DROP COLUMN IF EXISTS merged_at,
+    DROP COLUMN IF EXISTS merged_by_user_uuid,
+    DROP COLUMN IF EXISTS merge_reason;

--- a/backend/migrations/2026-06-05-030000_ticket_merge_columns/up.sql
+++ b/backend/migrations/2026-06-05-030000_ticket_merge_columns/up.sql
@@ -1,0 +1,30 @@
+-- Merge bookkeeping on the source ticket. A merged source points at its
+-- canonical destination via merged_into_ticket_id and records who
+-- merged it and when. merge_reason is the optional free-text note from
+-- the merge dialog.
+ALTER TABLE tickets
+    ADD COLUMN merged_into_ticket_id INT4 NULL
+        REFERENCES tickets(id) ON DELETE SET NULL,
+    ADD COLUMN merged_at TIMESTAMPTZ NULL,
+    ADD COLUMN merged_by_user_uuid UUID NULL
+        REFERENCES users(uuid) ON DELETE SET NULL,
+    ADD COLUMN merge_reason TEXT NULL;
+
+-- Partial index: only merged sources carry a destination, so the index
+-- stays small and serves the "what was merged into ticket N" lookup.
+CREATE INDEX tickets_merged_into_idx ON tickets (merged_into_ticket_id)
+    WHERE merged_into_ticket_id IS NOT NULL;
+
+-- Invariant: a row is either fully unmerged or fully merged. The three
+-- bookkeeping columns move together. merge_reason is optional and not
+-- part of the invariant.
+ALTER TABLE tickets ADD CONSTRAINT tickets_merge_complete CHECK (
+    (merged_into_ticket_id IS NULL AND merged_at IS NULL AND merged_by_user_uuid IS NULL)
+    OR
+    (merged_into_ticket_id IS NOT NULL AND merged_at IS NOT NULL AND merged_by_user_uuid IS NOT NULL)
+);
+
+-- Chain prevention (merging a ticket into an already-merged target) is
+-- enforced in the merge handler's pre-flight, not here: Postgres CHECK
+-- constraints cannot contain subqueries. See docs/ticket-merge-plan.md
+-- section 4.2 and the handler integration test.

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -55,6 +55,7 @@ pub mod sse;
 pub mod sync;
 pub mod system;
 pub mod tags;
+pub mod ticket_merge;
 pub mod ticket_watchers;
 pub mod tickets;
 pub mod users;

--- a/backend/src/handlers/sse.rs
+++ b/backend/src/handlers/sse.rs
@@ -36,6 +36,16 @@ pub enum SseEvent {
         ticket_id: i32,
         timestamp: chrono::DateTime<chrono::Utc>,
     },
+    /// A merge committed. Open viewers of a source ticket show the
+    /// "merged into #N" banner; the destination's viewers refetch to
+    /// pick up the marker comment and the merged-in sidebar.
+    TicketMerged {
+        target_ticket_id: i32,
+        source_ticket_ids: Vec<i32>,
+        actor_uuid: String,
+        merge_event_id: i64,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    },
     CommentAdded {
         ticket_id: i32,
         comment: serde_json::Value,
@@ -285,6 +295,7 @@ fn event_type_str(event: &SseEvent) -> &'static str {
         SseEvent::TicketUpdated { .. } => "ticket-updated",
         SseEvent::TicketCreated { .. } => "ticket-created",
         SseEvent::TicketDeleted { .. } => "ticket-deleted",
+        SseEvent::TicketMerged { .. } => "ticket-merged",
         SseEvent::CommentAdded { .. } => "comment-added",
         SseEvent::CommentDeleted { .. } => "comment-deleted",
         SseEvent::AttachmentAdded { .. } => "attachment-added",

--- a/backend/src/handlers/ticket_merge.rs
+++ b/backend/src/handlers/ticket_merge.rs
@@ -32,6 +32,9 @@ pub struct MergeRequest {
     pub notify_customer: bool,
     #[serde(default)]
     pub expected_state: Vec<ExpectedStateDto>,
+    /// Agent-edited merge-marker comment body from the dialog.
+    #[serde(default)]
+    pub marker_body: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -82,6 +85,7 @@ pub async fn merge_tickets(
                 workflow_state_id: e.workflow_state_id,
             })
             .collect(),
+        marker_body: body.marker_body,
     };
 
     let outcome = match ticket_merge::execute_merge(&mut conn, input, &actor) {

--- a/backend/src/handlers/ticket_merge.rs
+++ b/backend/src/handlers/ticket_merge.rs
@@ -6,14 +6,18 @@
 //! `{ error, code }` envelope. The repository owns the transaction and
 //! the lifecycle order.
 
+use std::sync::Arc;
+
 use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Responder};
 use serde::Deserialize;
 
 use crate::db::Pool;
 use crate::handlers::errors;
+use crate::handlers::sse::{SseEvent, SseState};
 use crate::middleware::request_context::RequestContext;
 use crate::models::WorkspaceRole;
 use crate::repository::ticket_merge::{self, ExpectedState, MergeError, MergeInput};
+use crate::services::search::{indexing_tasks, SearchService};
 use crate::utils::rbac::require_workspace_role;
 
 /// `POST /api/tickets/merge` request body. Mirrors
@@ -48,6 +52,8 @@ pub async fn merge_tickets(
     req: HttpRequest,
     body: web::Json<MergeRequest>,
     pool: web::Data<Pool>,
+    sse_state: web::Data<SseState>,
+    search_service: web::Data<Arc<SearchService>>,
 ) -> impl Responder {
     if let Err(e) = require_workspace_role(&req, WorkspaceRole::Agent) {
         return e;
@@ -77,18 +83,59 @@ pub async fn merge_tickets(
             .collect(),
     };
 
-    match ticket_merge::execute_merge(&mut conn, input, &actor) {
-        Ok(outcome) => HttpResponse::Ok().json(serde_json::json!({
-            "merge_event_id": outcome.merge_event_id,
-            "destination_ticket": outcome.destination,
-            "merged_sources": outcome.merged_sources,
-            "comments_moved": outcome.comments_moved,
-            "channel_messages_rerouted": outcome.channel_messages_rerouted,
-            "watchers_added_to_destination": outcome.watchers_added_to_destination,
-            "merge_marker_comment_id": outcome.merge_marker_comment_id,
-        })),
-        Err(e) => map_merge_error(e),
+    let outcome = match ticket_merge::execute_merge(&mut conn, input, &actor) {
+        Ok(o) => o,
+        Err(e) => return map_merge_error(e),
+    };
+
+    // Post-commit, best-effort. None of this rolls back the merge.
+    // Reindex the now-merged sources so their search snippet reflects
+    // the terminal state. The destination's ticket fields are unchanged,
+    // so it doesn't need reindexing (and reindexing it with no article
+    // body would drop its article from the index).
+    for source in &outcome.merged_sources {
+        indexing_tasks::spawn_index_ticket(
+            search_service.get_ref().clone(),
+            source.clone(),
+            None,
+        );
     }
+
+    // Broadcast so open viewers react without a reload: the destination
+    // refetches, each source shows the merged-into banner.
+    let actor_uuid = actor.uuid.map(|u| u.to_string()).unwrap_or_default();
+    let now = chrono::Utc::now();
+    let source_ids: Vec<i32> = outcome.merged_sources.iter().map(|t| t.id).collect();
+    sse_state
+        .broadcast_event(SseEvent::TicketMerged {
+            target_ticket_id: outcome.destination.id,
+            source_ticket_ids: source_ids,
+            actor_uuid: actor_uuid.clone(),
+            merge_event_id: outcome.merge_event_id,
+            timestamp: now,
+        })
+        .await;
+    for source in &outcome.merged_sources {
+        sse_state
+            .broadcast_event(SseEvent::TicketUpdated {
+                ticket_id: source.id,
+                field: "workflow_state_id".to_string(),
+                value: serde_json::json!(source.workflow_state_id),
+                updated_by: actor_uuid.clone(),
+                timestamp: now,
+            })
+            .await;
+    }
+
+    HttpResponse::Ok().json(serde_json::json!({
+        "merge_event_id": outcome.merge_event_id,
+        "destination_ticket": outcome.destination,
+        "merged_sources": outcome.merged_sources,
+        "comments_moved": outcome.comments_moved,
+        "channel_messages_rerouted": outcome.channel_messages_rerouted,
+        "watchers_added_to_destination": outcome.watchers_added_to_destination,
+        "merge_marker_comment_id": outcome.merge_marker_comment_id,
+    }))
 }
 
 /// `GET /api/tickets/{id}/merge-history`. Agent role or higher.

--- a/backend/src/handlers/ticket_merge.rs
+++ b/backend/src/handlers/ticket_merge.rs
@@ -1,0 +1,137 @@
+//! HTTP handlers for ticket merge.
+//!
+//! Thin wrappers over `repository::ticket_merge`: resolve the actor +
+//! workspace from the request, gate on the workspace Agent role, call
+//! the repository, and map `MergeError` onto the structured
+//! `{ error, code }` envelope. The repository owns the transaction and
+//! the lifecycle order.
+
+use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Responder};
+use serde::Deserialize;
+
+use crate::db::Pool;
+use crate::handlers::errors;
+use crate::middleware::request_context::RequestContext;
+use crate::models::WorkspaceRole;
+use crate::repository::ticket_merge::{self, ExpectedState, MergeError, MergeInput};
+use crate::utils::rbac::require_workspace_role;
+
+/// `POST /api/tickets/merge` request body. Mirrors
+/// `docs/ticket-merge-plan.md` section 7.1.
+#[derive(Debug, Deserialize)]
+pub struct MergeRequest {
+    pub destination_ticket_id: i32,
+    pub source_ticket_ids: Vec<i32>,
+    #[serde(default)]
+    pub reason: Option<String>,
+    #[serde(default)]
+    pub notify_customer: bool,
+    #[serde(default)]
+    pub expected_state: Vec<ExpectedStateDto>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExpectedStateDto {
+    pub ticket_id: i32,
+    pub workflow_state_id: i32,
+}
+
+/// Resolve the workspace-pinned actor the auth middleware attached.
+fn actor_from(req: &HttpRequest) -> Option<crate::sync::actor::ActorContext> {
+    req.extensions()
+        .get::<RequestContext>()
+        .map(|c| c.actor.clone())
+}
+
+/// `POST /api/tickets/merge`. Agent role or higher.
+pub async fn merge_tickets(
+    req: HttpRequest,
+    body: web::Json<MergeRequest>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Agent) {
+        return e;
+    }
+    let actor = match actor_from(&req) {
+        Some(a) => a,
+        None => return errors::unauthorized("Authentication required"),
+    };
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+
+    let body = body.into_inner();
+    let input = MergeInput {
+        destination_ticket_id: body.destination_ticket_id,
+        source_ticket_ids: body.source_ticket_ids,
+        reason: body.reason,
+        notify_customer: body.notify_customer,
+        expected_state: body
+            .expected_state
+            .into_iter()
+            .map(|e| ExpectedState {
+                ticket_id: e.ticket_id,
+                workflow_state_id: e.workflow_state_id,
+            })
+            .collect(),
+    };
+
+    match ticket_merge::execute_merge(&mut conn, input, &actor) {
+        Ok(outcome) => HttpResponse::Ok().json(serde_json::json!({
+            "merge_event_id": outcome.merge_event_id,
+            "destination_ticket": outcome.destination,
+            "merged_sources": outcome.merged_sources,
+            "comments_moved": outcome.comments_moved,
+            "channel_messages_rerouted": outcome.channel_messages_rerouted,
+            "watchers_added_to_destination": outcome.watchers_added_to_destination,
+            "merge_marker_comment_id": outcome.merge_marker_comment_id,
+        })),
+        Err(e) => map_merge_error(e),
+    }
+}
+
+/// `GET /api/tickets/{id}/merge-history`. Agent role or higher.
+pub async fn get_merge_history(
+    req: HttpRequest,
+    path: web::Path<i32>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Agent) {
+        return e;
+    }
+    let actor = match actor_from(&req) {
+        Some(a) => a,
+        None => return errors::unauthorized("Authentication required"),
+    };
+    let ticket_id = path.into_inner();
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+
+    // Read under the actor context so RLS scopes the query to the
+    // caller's workspace.
+    let result = crate::sync::session::with_actor_context(&mut conn, &actor, |c| {
+        ticket_merge::merge_history_for_ticket(c, ticket_id)
+    });
+    match result {
+        Ok(history) => HttpResponse::Ok().json(history),
+        Err(e) => errors::db_error(&e),
+    }
+}
+
+/// Map a `MergeError` to the structured `{ error, code }` response.
+fn map_merge_error(err: MergeError) -> HttpResponse {
+    let message = err.to_string();
+    match err {
+        MergeError::Db(e) => errors::db_error(&e),
+        MergeError::NotFound(_) => errors::not_found_msg(message),
+        MergeError::StateConflict(_) => {
+            errors::conflict_with_code(message, "MERGE_STATE_CONFLICT")
+        }
+        MergeError::MissingWorkspace | MergeError::MergedStateMissing => errors::internal(message),
+        // Every remaining variant is a pre-flight validation failure.
+        _ => errors::bad_request_with_code(message, "MERGE_VALIDATION"),
+    }
+}

--- a/backend/src/handlers/ticket_merge.rs
+++ b/backend/src/handlers/ticket_merge.rs
@@ -68,6 +68,7 @@ pub async fn merge_tickets(
     };
 
     let body = body.into_inner();
+    let notify_customer = body.notify_customer;
     let input = MergeInput {
         destination_ticket_id: body.destination_ticket_id,
         source_ticket_ids: body.source_ticket_ids,
@@ -125,6 +126,21 @@ pub async fn merge_tickets(
                 timestamp: now,
             })
             .await;
+    }
+
+    // Step 15: customer notification, opt-in and best-effort. Runs in
+    // its own transaction so a send-queue hiccup never unwinds the
+    // committed merge.
+    if notify_customer {
+        if let Err(e) = crate::sync::session::with_actor_context(&mut conn, &actor, |c| {
+            ticket_merge::enqueue_merge_notifications(
+                c,
+                &outcome.destination,
+                &outcome.merged_sources,
+            )
+        }) {
+            tracing::warn!(error = %e, "merge customer notification enqueue failed");
+        }
     }
 
     HttpResponse::Ok().json(serde_json::json!({

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1760,6 +1760,10 @@ async fn main() -> std::io::Result<()> {
                     .route("/tickets", web::post().to(handlers::create_ticket))
                     .route("/tickets/empty", web::post().to(handlers::create_empty_ticket))
                     .route("/tickets/bulk", web::post().to(handlers::bulk_tickets))
+                    // Literal /tickets/merge before /tickets/{id}; there is no
+                    // /tickets/{id} POST, so no wildcard can absorb it.
+                    .route("/tickets/merge", web::post().to(handlers::ticket_merge::merge_tickets))
+                    .route("/tickets/{id}/merge-history", web::get().to(handlers::ticket_merge::get_merge_history))
                     .route("/tickets/{id}", web::get().to(handlers::get_ticket))
                     .route("/tickets/{id}", web::put().to(handlers::update_ticket))
                     .route("/tickets/{id}", web::patch().to(handlers::update_ticket_partial))

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -50,6 +50,13 @@ pub enum WorkflowStateCategory {
     Done,
     #[serde(rename = "cancelled")]
     Cancelled,
+    /// Terminal state for a ticket consumed by a merge. Distinct from
+    /// `done` (resolved) and `cancelled` so list filters and the
+    /// activity feed can tell "closed because merged" apart from
+    /// "closed because finished". Pauses SLA via the per-row
+    /// `pauses_sla` flag, the same as the other terminal categories.
+    #[serde(rename = "merged")]
+    Merged,
 }
 
 impl WorkflowStateCategory {
@@ -61,6 +68,7 @@ impl WorkflowStateCategory {
             WorkflowStateCategory::InReview => "in_review",
             WorkflowStateCategory::Done => "done",
             WorkflowStateCategory::Cancelled => "cancelled",
+            WorkflowStateCategory::Merged => "merged",
         }
     }
 
@@ -68,7 +76,7 @@ impl WorkflowStateCategory {
     /// SLA, rollup, and metric code that needs a "is this work finished?"
     /// answer without enumerating every named state.
     pub fn is_terminal(&self) -> bool {
-        matches!(self, Self::Done | Self::Cancelled)
+        matches!(self, Self::Done | Self::Cancelled | Self::Merged)
     }
 
     /// Folds the new six-category model down to the legacy three-bucket
@@ -80,7 +88,7 @@ impl WorkflowStateCategory {
         match self {
             Self::Triage | Self::Backlog => "open",
             Self::Active | Self::InReview => "in-progress",
-            Self::Done | Self::Cancelled => "closed",
+            Self::Done | Self::Cancelled | Self::Merged => "closed",
         }
     }
 }
@@ -101,6 +109,7 @@ impl FromSql<crate::schema::sql_types::WorkflowStateCategory, Pg> for WorkflowSt
             b"in_review" => Ok(Self::InReview),
             b"done" => Ok(Self::Done),
             b"cancelled" => Ok(Self::Cancelled),
+            b"merged" => Ok(Self::Merged),
             other => Err(format!(
                 "unknown workflow_state_category: {}",
                 String::from_utf8_lossy(other)
@@ -901,6 +910,20 @@ pub struct Ticket {
     pub sla_resolution_target_at: Option<NaiveDateTime>,
     /// Idempotency stamp for the resolution breach.
     pub sla_resolution_breached_at: Option<NaiveDateTime>,
+    /// Canonical destination this ticket was merged into, or NULL when
+    /// the ticket is not a merge source. Set together with `merged_at`
+    /// and `merged_by_user_uuid` (DB invariant `tickets_merge_complete`).
+    /// A non-NULL value marks the ticket terminal: its UI is read-only
+    /// and future channel replies reroute to the destination.
+    pub merged_into_ticket_id: Option<i32>,
+    /// Wall-clock moment the merge committed. NULL on unmerged tickets.
+    pub merged_at: Option<NaiveDateTime>,
+    /// The actor who performed the merge. NULL on unmerged tickets.
+    #[serde(serialize_with = "serialize_optional_uuid_as_string")]
+    pub merged_by_user_uuid: Option<Uuid>,
+    /// Optional free-text note captured in the merge dialog. NULL when
+    /// the merging agent left the reason field empty.
+    pub merge_reason: Option<String>,
 }
 
 // Ticket implementation removed - serialization now handled by serde attributes
@@ -2310,6 +2333,15 @@ pub struct LinkedTicket {
 pub struct NewLinkedTicket {
     pub ticket_id: i32,
     pub linked_ticket_id: i32,
+    /// One of `blocks` / `blocked_by` / `related` / `duplicate_of`,
+    /// locked by `linked_tickets_relation_type_check`. The DB default
+    /// is `related`; the column is spelled out here so the merge path
+    /// can write `duplicate_of` edges directly.
+    pub relation_type: String,
+    /// Optional context for the relationship (e.g. the merge reason).
+    pub description: Option<String>,
+    /// Actor who created the edge. NULL for system-created links.
+    pub created_by: Option<Uuid>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/backend/src/repository/linked_tickets.rs
+++ b/backend/src/repository/linked_tickets.rs
@@ -94,15 +94,23 @@ pub fn link_tickets(conn: &mut DbConnection, ticket1_id: i32, ticket2_id: i32) -
         "Existing links"
     );
 
-    // Create bidirectional links
+    // Create bidirectional links. relation_type defaults to the
+    // generic "related"; the directional merge edge uses
+    // `link_tickets_directional` instead.
     let new_link1 = NewLinkedTicket {
         ticket_id: ticket1.id,
         linked_ticket_id: ticket2.id,
+        relation_type: "related".to_string(),
+        description: None,
+        created_by: None,
     };
 
     let new_link2 = NewLinkedTicket {
         ticket_id: ticket2.id,
         linked_ticket_id: ticket1.id,
+        relation_type: "related".to_string(),
+        description: None,
+        created_by: None,
     };
 
     // Insert both links in a transaction
@@ -132,6 +140,37 @@ pub fn link_tickets(conn: &mut DbConnection, ticket1_id: i32, ticket2_id: i32) -
 
         Ok(())
     })
+}
+
+// sync-pending-wire: merge service emits ticket.merged with the edge in its data blob
+/// Insert a single directed `linked_tickets` edge `ticket_id ->
+/// linked_ticket_id` with an explicit relation_type. Unlike
+/// `link_tickets`, this does NOT mirror the reverse direction:
+/// `duplicate_of` is asymmetric (the source is a duplicate of the
+/// target, not the other way round). Idempotent via
+/// `on_conflict_do_nothing`. The merge service is the first caller.
+pub fn link_tickets_directional(
+    conn: &mut DbConnection,
+    ticket_id: i32,
+    linked_ticket_id: i32,
+    relation_type: &str,
+    description: Option<String>,
+    created_by: Option<uuid::Uuid>,
+) -> QueryResult<usize> {
+    use crate::schema::linked_tickets;
+
+    let row = NewLinkedTicket {
+        ticket_id,
+        linked_ticket_id,
+        relation_type: relation_type.to_string(),
+        description,
+        created_by,
+    };
+
+    diesel::insert_into(linked_tickets::table)
+        .values(&row)
+        .on_conflict_do_nothing()
+        .execute(conn)
 }
 
 // sync-pending-wire: needs sync aggregate wiring
@@ -252,6 +291,56 @@ mod tests {
 
         assert!(get_linked_tickets(&mut conn, t1.id).unwrap().is_empty());
         assert!(get_linked_tickets(&mut conn, t2.id).unwrap().is_empty());
+    }
+
+    #[test]
+    fn directional_link_writes_relation_type_one_way() {
+        use crate::schema::linked_tickets;
+
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "directional", UserRole::User);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+        let dst = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+
+        let inserted = link_tickets_directional(
+            &mut conn,
+            src.id,
+            dst.id,
+            "duplicate_of",
+            Some("same outage".to_string()),
+            Some(user.uuid),
+        )
+        .unwrap();
+        assert_eq!(inserted, 1);
+
+        // Forward edge carries the relation_type, description, and author.
+        let forward: (String, Option<String>, Option<uuid::Uuid>) = linked_tickets::table
+            .filter(linked_tickets::ticket_id.eq(src.id))
+            .filter(linked_tickets::linked_ticket_id.eq(dst.id))
+            .select((
+                linked_tickets::relation_type,
+                linked_tickets::description,
+                linked_tickets::created_by,
+            ))
+            .first(&mut conn)
+            .unwrap();
+        assert_eq!(forward.0, "duplicate_of");
+        assert_eq!(forward.1.as_deref(), Some("same outage"));
+        assert_eq!(forward.2, Some(user.uuid));
+
+        // No reverse edge: duplicate_of is asymmetric.
+        let reverse: i64 = linked_tickets::table
+            .filter(linked_tickets::ticket_id.eq(dst.id))
+            .filter(linked_tickets::linked_ticket_id.eq(src.id))
+            .count()
+            .get_result(&mut conn)
+            .unwrap();
+        assert_eq!(reverse, 0);
+
+        // Idempotent: a second call conflicts and inserts nothing.
+        let again =
+            link_tickets_directional(&mut conn, src.id, dst.id, "duplicate_of", None, None).unwrap();
+        assert_eq!(again, 0);
     }
 
     #[test]

--- a/backend/src/repository/mod.rs
+++ b/backend/src/repository/mod.rs
@@ -34,6 +34,7 @@ pub mod sla;
 pub mod sla_admin;
 pub mod sync_history;
 pub mod tags;
+pub mod ticket_merge;
 pub mod ticket_query;
 pub mod ticket_visibility;
 pub mod ticket_watchers;

--- a/backend/src/repository/ticket_merge.rs
+++ b/backend/src/repository/ticket_merge.rs
@@ -576,6 +576,122 @@ fn build_marker(
     }
 }
 
+/// Where this ticket was merged to (populated only when the ticket is
+/// itself a merge source).
+#[derive(Debug, serde::Serialize)]
+pub struct MergedIntoInfo {
+    pub destination_id: i32,
+    pub merged_at: Option<chrono::NaiveDateTime>,
+    pub merged_by: Option<Uuid>,
+    pub reason: Option<String>,
+}
+
+/// One merge that consumed sources into this ticket, reconstructed from
+/// the `ticket.merged` sync event.
+#[derive(Debug, serde::Serialize)]
+pub struct MergeEvent {
+    pub event_id: i64,
+    pub merged_at: chrono::DateTime<chrono::Utc>,
+    pub merged_by_user_uuid: Option<Uuid>,
+    pub merged_by_name: Option<String>,
+    pub source_ticket_ids: Vec<i32>,
+    pub reason: Option<String>,
+    pub comments_moved: i64,
+    pub merge_marker_comment_id: Option<i32>,
+}
+
+/// Merge history for a ticket, from both directions.
+#[derive(Debug, serde::Serialize)]
+pub struct MergeHistory {
+    pub merged_into: Option<MergedIntoInfo>,
+    pub merge_events: Vec<MergeEvent>,
+}
+
+/// Build the merge history for `ticket_id`: where it was merged to (if
+/// it's a source) and the merges that consumed other tickets into it.
+/// Reads through RLS, so it only sees the caller's workspace.
+pub fn merge_history_for_ticket(
+    conn: &mut DbConnection,
+    ticket_id: i32,
+) -> QueryResult<MergeHistory> {
+    use crate::schema::tickets;
+    use diesel::sql_types::{BigInt, Integer, Jsonb, Nullable, Text, Timestamptz, Uuid as SqlUuid};
+
+    // Direction 1: this ticket as a source.
+    let row: Option<(Option<i32>, Option<chrono::NaiveDateTime>, Option<Uuid>, Option<String>)> =
+        tickets::table
+            .find(ticket_id)
+            .select((
+                tickets::merged_into_ticket_id,
+                tickets::merged_at,
+                tickets::merged_by_user_uuid,
+                tickets::merge_reason,
+            ))
+            .first(conn)
+            .optional()?;
+
+    let merged_into = row.and_then(|(into, at, by, reason)| {
+        into.map(|destination_id| MergedIntoInfo {
+            destination_id,
+            merged_at: at,
+            merged_by: by,
+            reason,
+        })
+    });
+
+    // Direction 2: merges that consumed sources into this ticket.
+    #[derive(diesel::QueryableByName)]
+    struct EventRow {
+        #[diesel(sql_type = BigInt)]
+        sync_id: i64,
+        #[diesel(sql_type = Timestamptz)]
+        occurred_at: chrono::DateTime<chrono::Utc>,
+        #[diesel(sql_type = Jsonb)]
+        data: serde_json::Value,
+        #[diesel(sql_type = Nullable<SqlUuid>)]
+        actor_uuid: Option<Uuid>,
+        #[diesel(sql_type = Nullable<Text>)]
+        actor_name: Option<String>,
+    }
+
+    let rows: Vec<EventRow> = diesel::sql_query(
+        "SELECT s.sync_id, s.occurred_at, s.data, s.actor_uuid, u.name AS actor_name \
+         FROM sync_actions s \
+         LEFT JOIN users u ON u.uuid = s.actor_uuid \
+         WHERE s.event_type = 'ticket.merged' AND s.aggregate_id = $1::text \
+         ORDER BY s.sync_id DESC LIMIT 50",
+    )
+    .bind::<Integer, _>(ticket_id)
+    .load(conn)?;
+
+    let merge_events = rows
+        .into_iter()
+        .map(|r| {
+            let source_ticket_ids = r.data["source_ticket_ids"]
+                .as_array()
+                .map(|a| a.iter().filter_map(|v| v.as_i64().map(|n| n as i32)).collect())
+                .unwrap_or_default();
+            MergeEvent {
+                event_id: r.sync_id,
+                merged_at: r.occurred_at,
+                merged_by_user_uuid: r.actor_uuid,
+                merged_by_name: r.actor_name,
+                source_ticket_ids,
+                reason: r.data["reason"].as_str().map(str::to_string),
+                comments_moved: r.data["comments_moved"].as_i64().unwrap_or(0),
+                merge_marker_comment_id: r.data["merge_marker_comment_id"]
+                    .as_i64()
+                    .map(|n| n as i32),
+            }
+        })
+        .collect();
+
+    Ok(MergeHistory {
+        merged_into,
+        merge_events,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/src/repository/ticket_merge.rs
+++ b/backend/src/repository/ticket_merge.rs
@@ -1,0 +1,978 @@
+//! Ticket merge lifecycle.
+//!
+//! `execute_merge` folds one or more source tickets into a destination
+//! ticket inside a single transaction: it moves comments and channel
+//! messages, unions watchers / project / cycle / asset / tag / doc
+//! links, rewrites the sources' other ticket links onto the
+//! destination, records a `duplicate_of` edge per source, writes a
+//! structured merge-marker comment on the destination, and emits the
+//! `ticket.merged` / `ticket.merged_into` sync events. The whole thing
+//! runs under `with_actor_context` so every audited write and every
+//! sync row shares the actor's `correlation_id`.
+//!
+//! Lifecycle order mirrors `docs/ticket-merge-plan.md` section 5. The
+//! handler stays thin: parse, authorise, call `execute_merge`, format
+//! the response.
+
+use diesel::prelude::*;
+use diesel::sql_types::{Array, BigInt, Integer};
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::db::DbConnection;
+use crate::models::{
+    Comment, ContentFormat, NewComment, SyncAggregate, SyncOp, Ticket, WorkflowStateCategory,
+};
+use crate::sync::actor::ActorContext;
+use crate::sync::emit::{self, SyncEmit};
+use crate::sync::session::with_actor_context;
+use crate::sync::groups;
+
+/// The optimistic-lock token for one ticket: the workflow_state_id the
+/// client last saw. The merge aborts if any ticket's state has moved
+/// since the dialog opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExpectedState {
+    pub ticket_id: i32,
+    pub workflow_state_id: i32,
+}
+
+/// Parsed merge request plus the resolved actor's workspace. The
+/// handler builds this from the request body.
+#[derive(Debug, Clone)]
+pub struct MergeInput {
+    pub destination_ticket_id: i32,
+    pub source_ticket_ids: Vec<i32>,
+    pub reason: Option<String>,
+    /// Carried through to the post-commit notification step (Commit 5);
+    /// the lifecycle records it in the `ticket.merged` event so the
+    /// audit trail shows whether the customer was told.
+    pub notify_customer: bool,
+    /// Optional optimistic-lock tokens. Empty means "skip the check".
+    pub expected_state: Vec<ExpectedState>,
+}
+
+/// Counts and identifiers the API echoes back after a successful merge.
+#[derive(Debug, Clone)]
+pub struct MergeOutcome {
+    pub merge_event_id: i64,
+    pub destination: Ticket,
+    pub merged_sources: Vec<Ticket>,
+    pub comments_moved: usize,
+    pub channel_messages_rerouted: usize,
+    pub watchers_added_to_destination: usize,
+    pub merge_marker_comment_id: i32,
+    pub correlation_id: Option<Uuid>,
+}
+
+/// Pre-flight and execution failures. The handler maps each variant to
+/// an HTTP status + machine-readable code.
+#[derive(Debug)]
+pub enum MergeError {
+    /// No source ids supplied.
+    EmptySources,
+    /// A source id equals the destination id.
+    SelfMerge(i32),
+    /// A source or the destination is already a merge source.
+    AlreadyMerged(i32),
+    /// The destination sits in the terminal `merged` category.
+    DestinationIsMerged,
+    /// A ticket id resolved to a different workspace than the actor's.
+    CrossWorkspace(i32),
+    /// The destination is a recurrence series parent and must not
+    /// absorb other tickets.
+    RecurrenceParentDestination,
+    /// A source or the destination id does not resolve in this
+    /// workspace.
+    NotFound(i32),
+    /// One or more tickets' workflow state moved since the client
+    /// snapshot. Carries the actual current states for the diverged
+    /// tickets so the handler can tell the user which ones changed.
+    StateConflict(Vec<ExpectedState>),
+    /// The workspace has no seeded `merged` workflow state (should
+    /// never happen; the migration seeds one per workspace).
+    MergedStateMissing,
+    /// The actor context carried no workspace id.
+    MissingWorkspace,
+    /// Any other database error.
+    Db(diesel::result::Error),
+}
+
+impl From<diesel::result::Error> for MergeError {
+    fn from(e: diesel::result::Error) -> Self {
+        MergeError::Db(e)
+    }
+}
+
+impl std::fmt::Display for MergeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MergeError::EmptySources => write!(f, "no source tickets supplied"),
+            MergeError::SelfMerge(id) => write!(f, "ticket {id} is both a source and the destination"),
+            MergeError::AlreadyMerged(id) => write!(f, "ticket {id} is already merged"),
+            MergeError::DestinationIsMerged => write!(f, "destination ticket is itself merged"),
+            MergeError::CrossWorkspace(id) => write!(f, "ticket {id} is in a different workspace"),
+            MergeError::RecurrenceParentDestination => {
+                write!(f, "destination is a recurrence parent and cannot absorb tickets")
+            }
+            MergeError::NotFound(id) => write!(f, "ticket {id} not found"),
+            MergeError::StateConflict(_) => write!(f, "tickets changed since the merge was opened"),
+            MergeError::MergedStateMissing => write!(f, "workspace has no merged workflow state"),
+            MergeError::MissingWorkspace => write!(f, "actor has no workspace context"),
+            MergeError::Db(e) => write!(f, "database error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for MergeError {}
+
+/// Encode `(workspace_id, ticket_id)` into one int64 advisory-lock key
+/// so locks never collide across workspaces.
+fn advisory_key(workspace_id: i32, ticket_id: i32) -> i64 {
+    ((workspace_id as i64) << 32) | (ticket_id as i64 & 0xffff_ffff)
+}
+
+// sync-pending-wire: emits ticket.merged / ticket.merged_into via sync::emit::record inside the txn
+/// Merge `input.source_ticket_ids` into `input.destination_ticket_id`.
+///
+/// Runs every step in one `with_actor_context` transaction; any
+/// pre-flight failure or DB error rolls the whole thing back. Post-
+/// commit concerns (search reindex, SSE, customer notification) are the
+/// caller's job and live in later commits.
+pub fn execute_merge(
+    conn: &mut DbConnection,
+    input: MergeInput,
+    actor: &ActorContext,
+) -> Result<MergeOutcome, MergeError> {
+    use crate::schema::{tickets, workflow_states};
+
+    let workspace_id = actor.workspace_id.ok_or(MergeError::MissingWorkspace)?;
+    let target_id = input.destination_ticket_id;
+
+    if input.source_ticket_ids.is_empty() {
+        return Err(MergeError::EmptySources);
+    }
+
+    // Dedup sources and reject a source that equals the destination.
+    let mut source_ids: Vec<i32> = input.source_ticket_ids.clone();
+    source_ids.sort_unstable();
+    source_ids.dedup();
+    if let Some(&dup) = source_ids.iter().find(|&&id| id == target_id) {
+        return Err(MergeError::SelfMerge(dup));
+    }
+
+    let reason = input
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    with_actor_context(conn, actor, |conn| {
+        // Step 2: advisory-lock every involved ticket, sorted so two
+        // overlapping merges acquire in the same order and can't
+        // deadlock. The second caller blocks until the first commits,
+        // then sees the new merged state and fails pre-flight cleanly.
+        let mut lock_ids: Vec<i32> = source_ids.clone();
+        lock_ids.push(target_id);
+        lock_ids.sort_unstable();
+        lock_ids.dedup();
+        for id in &lock_ids {
+            diesel::sql_query("SELECT pg_advisory_xact_lock($1)")
+                .bind::<BigInt, _>(advisory_key(workspace_id, *id))
+                .execute(conn)?;
+        }
+
+        // Resolve the workspace's merged workflow state up front.
+        let merged_state_id: i32 = workflow_states::table
+            .filter(workflow_states::category.eq(WorkflowStateCategory::Merged))
+            .filter(workflow_states::workspace_id.eq(workspace_id))
+            .select(workflow_states::id)
+            .first(conn)
+            .optional()?
+            .ok_or(MergeError::MergedStateMissing)?;
+
+        // Step 3: re-read destination + sources under the lock.
+        let destination = load_ticket(conn, target_id)?;
+        if destination.workspace_id != workspace_id {
+            return Err(MergeError::CrossWorkspace(target_id));
+        }
+        if destination.merged_into_ticket_id.is_some() {
+            return Err(MergeError::AlreadyMerged(target_id));
+        }
+        if state_category(conn, destination.workflow_state_id)? == WorkflowStateCategory::Merged {
+            return Err(MergeError::DestinationIsMerged);
+        }
+        // A recurrence series parent (carries an RRULE) must not absorb
+        // tickets: the next occurrence would inherit polluted state.
+        if destination.recurrence_rule.is_some() {
+            return Err(MergeError::RecurrenceParentDestination);
+        }
+
+        let mut sources: Vec<Ticket> = Vec::with_capacity(source_ids.len());
+        for &sid in &source_ids {
+            let s = load_ticket(conn, sid)?;
+            if s.workspace_id != workspace_id {
+                return Err(MergeError::CrossWorkspace(sid));
+            }
+            if s.merged_into_ticket_id.is_some() {
+                return Err(MergeError::AlreadyMerged(sid));
+            }
+            sources.push(s);
+        }
+
+        // Optimistic lock: every supplied token must still match.
+        if !input.expected_state.is_empty() {
+            let mut diverged = Vec::new();
+            let mut check = |t: &Ticket| {
+                if let Some(exp) = input
+                    .expected_state
+                    .iter()
+                    .find(|e| e.ticket_id == t.id)
+                {
+                    if exp.workflow_state_id != t.workflow_state_id {
+                        diverged.push(ExpectedState {
+                            ticket_id: t.id,
+                            workflow_state_id: t.workflow_state_id,
+                        });
+                    }
+                }
+            };
+            check(&destination);
+            sources.iter().for_each(&mut check);
+            if !diverged.is_empty() {
+                return Err(MergeError::StateConflict(diverged));
+            }
+        }
+
+        let source_array = source_ids.clone();
+
+        // Step 4: mark sources merged and move them to the merged state.
+        diesel::update(tickets::table.filter(tickets::id.eq_any(&source_array)))
+            .set((
+                tickets::merged_into_ticket_id.eq(target_id),
+                tickets::merged_at.eq(diesel::dsl::now),
+                tickets::merged_by_user_uuid.eq(actor.uuid),
+                tickets::merge_reason.eq(reason.clone()),
+                tickets::workflow_state_id.eq(merged_state_id),
+                tickets::updated_at.eq(diesel::dsl::now),
+            ))
+            .execute(conn)?;
+
+        // Step 5: move comments (attachments ride along via comment_id).
+        let comments_moved = diesel::sql_query(
+            "UPDATE comments SET ticket_id = $1 WHERE ticket_id = ANY($2)",
+        )
+        .bind::<Integer, _>(target_id)
+        .bind::<Array<Integer>, _>(&source_array)
+        .execute(conn)?;
+
+        // Step 6: reroute channel messages so future inbound replies
+        // thread onto the destination.
+        let channel_messages_rerouted = diesel::sql_query(
+            "UPDATE channel_messages SET ticket_id = $1 WHERE ticket_id = ANY($2)",
+        )
+        .bind::<Integer, _>(target_id)
+        .bind::<Array<Integer>, _>(&source_array)
+        .execute(conn)?;
+
+        // Step 7: union watchers onto the destination. Source rows stay
+        // put (the source is still a real record). notify_on_internal_
+        // notes ORs so the destination keeps the most permissive flag.
+        let watchers_added_to_destination = diesel::sql_query(
+            "INSERT INTO ticket_watchers \
+                 (ticket_id, user_uuid, auto_added, notify_on_internal_notes, workspace_id) \
+             SELECT $1, sw.user_uuid, TRUE, sw.notify_on_internal_notes, sw.workspace_id \
+             FROM ticket_watchers sw \
+             WHERE sw.ticket_id = ANY($2) \
+             ON CONFLICT (ticket_id, user_uuid) DO UPDATE SET \
+                 notify_on_internal_notes = \
+                     ticket_watchers.notify_on_internal_notes OR EXCLUDED.notify_on_internal_notes",
+        )
+        .bind::<Integer, _>(target_id)
+        .bind::<Array<Integer>, _>(&source_array)
+        .execute(conn)?;
+
+        // Project / cycle / asset memberships union onto the
+        // destination, then drop from the sources (closed records
+        // shouldn't show on boards). Tags and doc links accumulate on
+        // the destination; leaving them on the source is harmless.
+        union_then_clear(conn, "project_tickets", "project_id", target_id, &source_array, true)?;
+        union_then_clear(conn, "cycle_tickets", "cycle_id", target_id, &source_array, true)?;
+        union_then_clear(conn, "ticket_assets", "asset_id", target_id, &source_array, true)?;
+        union_then_clear(conn, "ticket_tags", "tag_id", target_id, &source_array, false)?;
+        union_doc_links(conn, target_id, &source_array)?;
+
+        // Step 8: rewrite the sources' OTHER ticket links onto the
+        // destination (both directions), then drop every source link.
+        // INSERT ... SELECT ON CONFLICT DO NOTHING sidesteps PK
+        // collisions when the destination already shares that edge, and
+        // the WHERE clauses exclude edges that would self-link.
+        diesel::sql_query(
+            "INSERT INTO linked_tickets \
+                 (ticket_id, linked_ticket_id, relation_type, description, created_by, workspace_id) \
+             SELECT $1, lt.linked_ticket_id, lt.relation_type, lt.description, lt.created_by, lt.workspace_id \
+             FROM linked_tickets lt \
+             WHERE lt.ticket_id = ANY($2) \
+               AND lt.linked_ticket_id <> $1 \
+               AND lt.linked_ticket_id <> ALL($2) \
+             ON CONFLICT DO NOTHING",
+        )
+        .bind::<Integer, _>(target_id)
+        .bind::<Array<Integer>, _>(&source_array)
+        .execute(conn)?;
+        diesel::sql_query(
+            "INSERT INTO linked_tickets \
+                 (ticket_id, linked_ticket_id, relation_type, description, created_by, workspace_id) \
+             SELECT lt.ticket_id, $1, lt.relation_type, lt.description, lt.created_by, lt.workspace_id \
+             FROM linked_tickets lt \
+             WHERE lt.linked_ticket_id = ANY($2) \
+               AND lt.ticket_id <> $1 \
+               AND lt.ticket_id <> ALL($2) \
+             ON CONFLICT DO NOTHING",
+        )
+        .bind::<Integer, _>(target_id)
+        .bind::<Array<Integer>, _>(&source_array)
+        .execute(conn)?;
+        diesel::sql_query(
+            "DELETE FROM linked_tickets WHERE ticket_id = ANY($1) OR linked_ticket_id = ANY($1)",
+        )
+        .bind::<Array<Integer>, _>(&source_array)
+        .execute(conn)?;
+
+        // Step 9: record the canonical merge edge, one per source.
+        for &sid in &source_ids {
+            crate::repository::linked_tickets::link_tickets_directional(
+                conn,
+                sid,
+                target_id,
+                "duplicate_of",
+                reason.clone(),
+                actor.uuid,
+            )?;
+        }
+
+        // Step 10: write the structured merge-marker comment on the
+        // destination. Inserted directly (not via create_comment) so it
+        // does NOT stamp the destination's first_response_at: a merge
+        // marker is bookkeeping, not a staff reply to the customer.
+        let marker = build_marker(&destination, &sources, actor, reason.as_deref());
+        let marker_comment: Comment = diesel::insert_into(crate::schema::comments::table)
+            .values(&marker)
+            .get_result(conn)?;
+
+        let groups = groups::for_ticket(conn, &destination)?;
+        emit::record(
+            conn,
+            SyncEmit {
+                aggregate: SyncAggregate::Comment,
+                aggregate_id: marker_comment.id.to_string(),
+                op: SyncOp::Insert,
+                event_type: "comment.created",
+                data: json!({ "ticket_id": target_id, "kind": "merge_marker" }),
+                groups: groups.clone(),
+                causation_id: None,
+            },
+        )?;
+
+        // Step 11: emit the first-class merge events. One aggregate
+        // event on the destination, one on each source. All share the
+        // actor's correlation_id via the session GUC, so the audit log
+        // and these rows stitch together.
+        let merge_event_id = emit::record(
+            conn,
+            SyncEmit {
+                aggregate: SyncAggregate::Ticket,
+                aggregate_id: target_id.to_string(),
+                op: SyncOp::Update,
+                event_type: "ticket.merged",
+                data: json!({
+                    "source_ticket_ids": source_ids,
+                    "actor_uuid": actor.uuid,
+                    "reason": reason,
+                    "comments_moved": comments_moved,
+                    "channel_messages_rerouted": channel_messages_rerouted,
+                    "watchers_added": watchers_added_to_destination,
+                    "customer_notified": input.notify_customer,
+                    "merge_marker_comment_id": marker_comment.id,
+                }),
+                groups,
+                causation_id: None,
+            },
+        )?;
+
+        for source in &sources {
+            let source_groups = groups::for_ticket(conn, source)?;
+            emit::record(
+                conn,
+                SyncEmit {
+                    aggregate: SyncAggregate::Ticket,
+                    aggregate_id: source.id.to_string(),
+                    op: SyncOp::Update,
+                    event_type: "ticket.merged_into",
+                    data: json!({
+                        "merged_into_ticket_id": target_id,
+                        "actor_uuid": actor.uuid,
+                    }),
+                    groups: source_groups,
+                    causation_id: None,
+                },
+            )?;
+        }
+
+        // Re-read the now-merged rows for the response DTO.
+        let destination = load_ticket(conn, target_id)?;
+        let mut merged_sources = Vec::with_capacity(source_ids.len());
+        for &sid in &source_ids {
+            merged_sources.push(load_ticket(conn, sid)?);
+        }
+
+        Ok(MergeOutcome {
+            merge_event_id,
+            destination,
+            merged_sources,
+            comments_moved,
+            channel_messages_rerouted,
+            watchers_added_to_destination,
+            merge_marker_comment_id: marker_comment.id,
+            correlation_id: actor.correlation_id,
+        })
+    })
+}
+
+/// Fetch a ticket by id, mapping "not found" to a clean `MergeError`.
+fn load_ticket(conn: &mut DbConnection, id: i32) -> Result<Ticket, MergeError> {
+    use crate::schema::tickets;
+    tickets::table
+        .find(id)
+        .first::<Ticket>(conn)
+        .optional()?
+        .ok_or(MergeError::NotFound(id))
+}
+
+/// Resolve a workflow state's category.
+fn state_category(
+    conn: &mut DbConnection,
+    state_id: i32,
+) -> Result<WorkflowStateCategory, MergeError> {
+    use crate::schema::workflow_states;
+    Ok(workflow_states::table
+        .find(state_id)
+        .select(workflow_states::category)
+        .first(conn)?)
+}
+
+/// Union a two-column junction table (`<other>_id`, `ticket_id`) onto
+/// the destination via raw SQL, then optionally delete the source rows.
+/// `other_col` is the non-ticket key column. `clear_sources` drops the
+/// sources' rows after copying (project / cycle / asset boards
+/// shouldn't list closed records); false leaves them (tags accumulate).
+fn union_then_clear(
+    conn: &mut DbConnection,
+    table: &str,
+    other_col: &str,
+    target_id: i32,
+    sources: &[i32],
+    clear_sources: bool,
+) -> Result<(), MergeError> {
+    let insert = format!(
+        "INSERT INTO {table} ({other_col}, ticket_id, workspace_id) \
+         SELECT j.{other_col}, $1, j.workspace_id FROM {table} j \
+         WHERE j.ticket_id = ANY($2) ON CONFLICT DO NOTHING"
+    );
+    diesel::sql_query(insert)
+        .bind::<Integer, _>(target_id)
+        .bind::<Array<Integer>, _>(sources)
+        .execute(conn)?;
+
+    if clear_sources {
+        let delete = format!("DELETE FROM {table} WHERE ticket_id = ANY($1)");
+        diesel::sql_query(delete)
+            .bind::<Array<Integer>, _>(sources)
+            .execute(conn)?;
+    }
+    Ok(())
+}
+
+/// Union documentation_page_tickets onto the destination, preserving
+/// each row's link_type.
+fn union_doc_links(
+    conn: &mut DbConnection,
+    target_id: i32,
+    sources: &[i32],
+) -> Result<(), MergeError> {
+    diesel::sql_query(
+        "INSERT INTO documentation_page_tickets \
+             (page_id, ticket_id, link_type, created_by, workspace_id) \
+         SELECT d.page_id, $1, d.link_type, d.created_by, d.workspace_id \
+         FROM documentation_page_tickets d \
+         WHERE d.ticket_id = ANY($2) ON CONFLICT DO NOTHING",
+    )
+    .bind::<Integer, _>(target_id)
+    .bind::<Array<Integer>, _>(sources)
+    .execute(conn)?;
+    Ok(())
+}
+
+/// Build the merge-marker comment. The human-readable body is a
+/// fallback; the structured `channel_metadata.kind = 'merge_marker'`
+/// blob is what the activity-feed card renders.
+fn build_marker(
+    destination: &Ticket,
+    sources: &[Ticket],
+    actor: &ActorContext,
+    reason: Option<&str>,
+) -> NewComment {
+    let source_json: Vec<_> = sources
+        .iter()
+        .map(|s| {
+            json!({
+                "id": s.id,
+                "title": s.title,
+                "requester_uuid": s.requester_uuid,
+                "opened_at": s.created_at,
+            })
+        })
+        .collect();
+
+    let mut lines = vec![format!(
+        "Merged {} ticket(s) into this one:",
+        sources.len()
+    )];
+    for s in sources {
+        lines.push(format!("- #{}: \"{}\"", s.id, s.title));
+    }
+    if let Some(r) = reason {
+        lines.push(format!("Reason: {r}"));
+    }
+    let body_text = lines.join("\n");
+    let body_html = format!(
+        "<p>{}</p>",
+        body_text.replace('&', "&amp;").replace('<', "&lt;").replace('\n', "<br>")
+    );
+
+    let metadata = json!({
+        "kind": "merge_marker",
+        "source_ticket_ids": sources.iter().map(|s| s.id).collect::<Vec<_>>(),
+        "sources": source_json,
+        "merged_into_ticket_id": destination.id,
+        "merged_by_user_uuid": actor.uuid,
+        "reason": reason,
+    });
+
+    NewComment {
+        content: body_text.clone(),
+        ticket_id: destination.id,
+        // Authored by the merging actor (per the resolved open question).
+        // The merge actor always has a uuid; fall back to nil only to
+        // keep the type total.
+        user_uuid: actor.uuid.unwrap_or(Uuid::nil()),
+        channel_metadata: Some(metadata),
+        is_internal: false,
+        content_format: ContentFormat::Html,
+        body_text: Some(body_text),
+        body_html: Some(body_html),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::UserRole;
+    use crate::test_helpers::{setup_test_connection, TestFixtures};
+
+    fn actor_for(user_uuid: Uuid) -> ActorContext {
+        ActorContext::user(user_uuid, Some(Uuid::new_v4())).with_workspace(1)
+    }
+
+    fn input(dest: i32, sources: Vec<i32>) -> MergeInput {
+        MergeInput {
+            destination_ticket_id: dest,
+            source_ticket_ids: sources,
+            reason: Some("same outage".to_string()),
+            notify_customer: false,
+            expected_state: Vec::new(),
+        }
+    }
+
+    fn add_watcher(conn: &mut DbConnection, ticket: i32, user: Uuid, notify: bool) {
+        use crate::schema::ticket_watchers::dsl as w;
+        diesel::insert_into(w::ticket_watchers)
+            .values((
+                w::ticket_id.eq(ticket),
+                w::user_uuid.eq(user),
+                w::auto_added.eq(false),
+                w::notify_on_internal_notes.eq(notify),
+                w::workspace_id.eq(1),
+            ))
+            .execute(conn)
+            .unwrap();
+    }
+
+    fn count_sync(conn: &mut DbConnection, event_type: &str, aggregate_id: i32) -> i64 {
+        use diesel::sql_types::{BigInt, Integer, Text};
+        #[derive(diesel::QueryableByName)]
+        struct C {
+            #[diesel(sql_type = BigInt)]
+            n: i64,
+        }
+        diesel::sql_query(
+            "SELECT COUNT(*) AS n FROM sync_actions WHERE event_type = $1 AND aggregate_id = $2::text",
+        )
+        .bind::<Text, _>(event_type)
+        .bind::<Integer, _>(aggregate_id)
+        .get_result::<C>(conn)
+        .unwrap()
+        .n
+    }
+
+    #[test]
+    fn happy_path_single_source() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "agent", UserRole::User);
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+        TestFixtures::create_comment(&mut conn, src.id, user.uuid, "from source");
+
+        let outcome =
+            execute_merge(&mut conn, input(dest.id, vec![src.id]), &actor_for(user.uuid)).unwrap();
+
+        assert_eq!(outcome.comments_moved, 1);
+        assert_eq!(outcome.merged_sources.len(), 1);
+        let merged = &outcome.merged_sources[0];
+        assert_eq!(merged.merged_into_ticket_id, Some(dest.id));
+        assert!(merged.merged_at.is_some());
+        assert_eq!(merged.merged_by_user_uuid, Some(user.uuid));
+
+        // Source sits in the merged category now.
+        assert_eq!(
+            state_category(&mut conn, merged.workflow_state_id).unwrap(),
+            WorkflowStateCategory::Merged
+        );
+
+        // Marker comment exists on the destination, flagged structured.
+        use crate::schema::comments::dsl as c;
+        let meta: Option<serde_json::Value> = c::comments
+            .filter(c::id.eq(outcome.merge_marker_comment_id))
+            .select(c::channel_metadata)
+            .first(&mut conn)
+            .unwrap();
+        assert_eq!(meta.unwrap()["kind"], "merge_marker");
+
+        // duplicate_of edge recorded source -> dest.
+        use crate::schema::linked_tickets::dsl as l;
+        let rel: String = l::linked_tickets
+            .filter(l::ticket_id.eq(src.id))
+            .filter(l::linked_ticket_id.eq(dest.id))
+            .select(l::relation_type)
+            .first(&mut conn)
+            .unwrap();
+        assert_eq!(rel, "duplicate_of");
+
+        // First-class events emitted.
+        assert_eq!(count_sync(&mut conn, "ticket.merged", dest.id), 1);
+        assert_eq!(count_sync(&mut conn, "ticket.merged_into", src.id), 1);
+    }
+
+    #[test]
+    fn happy_path_three_sources() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "agent3", UserRole::User);
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let s1 = TestFixtures::create_ticket(&mut conn, "S1", Some(user.uuid), None);
+        let s2 = TestFixtures::create_ticket(&mut conn, "S2", Some(user.uuid), None);
+        let s3 = TestFixtures::create_ticket(&mut conn, "S3", Some(user.uuid), None);
+
+        let outcome = execute_merge(
+            &mut conn,
+            input(dest.id, vec![s1.id, s2.id, s3.id]),
+            &actor_for(user.uuid),
+        )
+        .unwrap();
+
+        assert_eq!(outcome.merged_sources.len(), 3);
+        assert!(outcome
+            .merged_sources
+            .iter()
+            .all(|t| t.merged_into_ticket_id == Some(dest.id)));
+        assert_eq!(count_sync(&mut conn, "ticket.merged_into", s2.id), 1);
+    }
+
+    #[test]
+    fn self_merge_rejected() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "self", UserRole::User);
+        let t = TestFixtures::create_ticket(&mut conn, "T", Some(user.uuid), None);
+
+        let err = execute_merge(&mut conn, input(t.id, vec![t.id]), &actor_for(user.uuid))
+            .unwrap_err();
+        assert!(matches!(err, MergeError::SelfMerge(id) if id == t.id));
+    }
+
+    #[test]
+    fn already_merged_source_rejected() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "chain", UserRole::User);
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let other = TestFixtures::create_ticket(&mut conn, "Other", Some(user.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+
+        execute_merge(&mut conn, input(dest.id, vec![src.id]), &actor_for(user.uuid)).unwrap();
+
+        // Second merge of the now-merged source must be refused. This is
+        // the same outcome a serialised concurrent merge produces: the
+        // loser acquires the lock after the winner commits and sees the
+        // merged state.
+        let err = execute_merge(&mut conn, input(other.id, vec![src.id]), &actor_for(user.uuid))
+            .unwrap_err();
+        assert!(matches!(err, MergeError::AlreadyMerged(id) if id == src.id));
+    }
+
+    #[test]
+    fn missing_source_rejected() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "missing", UserRole::User);
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+
+        // A source id that does not resolve in this workspace. Under RLS
+        // a cross-workspace ticket is likewise invisible and lands here.
+        let err = execute_merge(&mut conn, input(dest.id, vec![999_999]), &actor_for(user.uuid))
+            .unwrap_err();
+        assert!(matches!(err, MergeError::NotFound(999_999)));
+    }
+
+    #[test]
+    fn optimistic_lock_conflict() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "optlock", UserRole::User);
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+
+        let mut req = input(dest.id, vec![src.id]);
+        // Stale snapshot: claim the destination was in a state it isn't.
+        req.expected_state = vec![ExpectedState {
+            ticket_id: dest.id,
+            workflow_state_id: dest.workflow_state_id + 9999,
+        }];
+
+        let err = execute_merge(&mut conn, req, &actor_for(user.uuid)).unwrap_err();
+        match err {
+            MergeError::StateConflict(diverged) => {
+                assert_eq!(diverged.len(), 1);
+                assert_eq!(diverged[0].ticket_id, dest.id);
+                assert_eq!(diverged[0].workflow_state_id, dest.workflow_state_id);
+            }
+            other => panic!("expected StateConflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn watchers_union_ors_notify_flag() {
+        let mut conn = setup_test_connection();
+        let owner = TestFixtures::create_user(&mut conn, "owner", UserRole::User);
+        let shared = TestFixtures::create_user(&mut conn, "shared", UserRole::User);
+        let only_src = TestFixtures::create_user(&mut conn, "onlysrc", UserRole::User);
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(owner.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(owner.uuid), None);
+
+        // Shared watcher: notify=false on dest, notify=true on source.
+        add_watcher(&mut conn, dest.id, shared.uuid, false);
+        add_watcher(&mut conn, src.id, shared.uuid, true);
+        // Source-only watcher gets added to dest.
+        add_watcher(&mut conn, src.id, only_src.uuid, false);
+
+        execute_merge(&mut conn, input(dest.id, vec![src.id]), &actor_for(owner.uuid)).unwrap();
+
+        use crate::schema::ticket_watchers::dsl as w;
+        let shared_notify: bool = w::ticket_watchers
+            .filter(w::ticket_id.eq(dest.id))
+            .filter(w::user_uuid.eq(shared.uuid))
+            .select(w::notify_on_internal_notes)
+            .first(&mut conn)
+            .unwrap();
+        assert!(shared_notify, "OR of false|true must be true");
+
+        let only_src_on_dest: i64 = w::ticket_watchers
+            .filter(w::ticket_id.eq(dest.id))
+            .filter(w::user_uuid.eq(only_src.uuid))
+            .count()
+            .get_result(&mut conn)
+            .unwrap();
+        assert_eq!(only_src_on_dest, 1);
+    }
+
+    #[test]
+    fn comments_move_with_attachment() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "att", UserRole::User);
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+        let comment = TestFixtures::create_comment(&mut conn, src.id, user.uuid, "has file");
+        let att = TestFixtures::create_attachment(&mut conn, comment.id, "f.pdf");
+
+        execute_merge(&mut conn, input(dest.id, vec![src.id]), &actor_for(user.uuid)).unwrap();
+
+        use crate::schema::comments::dsl as c;
+        let moved_ticket: i32 = c::comments
+            .filter(c::id.eq(comment.id))
+            .select(c::ticket_id)
+            .first(&mut conn)
+            .unwrap();
+        assert_eq!(moved_ticket, dest.id);
+
+        // Attachment rides along via comment_id (unchanged).
+        use crate::schema::attachments::dsl as a;
+        let still_linked: i32 = a::attachments
+            .filter(a::id.eq(att.id))
+            .select(a::comment_id)
+            .first::<Option<i32>>(&mut conn)
+            .unwrap()
+            .unwrap();
+        assert_eq!(still_linked, comment.id);
+    }
+
+    #[test]
+    fn channel_messages_rerouted() {
+        use crate::models::NewChannelMessage;
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "chan", UserRole::User);
+        let channel = TestFixtures::create_channel(&mut conn, "email");
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+
+        use crate::schema::channel_messages::dsl as cm;
+        let msg_id: i64 = diesel::insert_into(cm::channel_messages)
+            .values(&NewChannelMessage {
+                channel_id: channel.id,
+                external_id: "ext-1".to_string(),
+                direction: "inbound".to_string(),
+                ticket_id: Some(src.id),
+                comment_id: None,
+                in_reply_to: None,
+                from_address: Some("c@example.com".to_string()),
+                author_user_uuid: None,
+                raw_metadata: None,
+            })
+            .returning(cm::id)
+            .get_result(&mut conn)
+            .unwrap();
+
+        let outcome =
+            execute_merge(&mut conn, input(dest.id, vec![src.id]), &actor_for(user.uuid)).unwrap();
+        assert_eq!(outcome.channel_messages_rerouted, 1);
+
+        let now_on: Option<i32> = cm::channel_messages
+            .filter(cm::id.eq(msg_id))
+            .select(cm::ticket_id)
+            .first(&mut conn)
+            .unwrap();
+        assert_eq!(now_on, Some(dest.id));
+    }
+
+    #[test]
+    fn project_membership_moves_to_target() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "proj", UserRole::User);
+        let project = TestFixtures::create_project(&mut conn, "Proj");
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+
+        use crate::schema::project_tickets::dsl as p;
+        diesel::insert_into(p::project_tickets)
+            .values((
+                p::project_id.eq(project.id),
+                p::ticket_id.eq(src.id),
+                p::workspace_id.eq(1),
+            ))
+            .execute(&mut conn)
+            .unwrap();
+
+        execute_merge(&mut conn, input(dest.id, vec![src.id]), &actor_for(user.uuid)).unwrap();
+
+        let on_dest: i64 = p::project_tickets
+            .filter(p::project_id.eq(project.id))
+            .filter(p::ticket_id.eq(dest.id))
+            .count()
+            .get_result(&mut conn)
+            .unwrap();
+        let on_src: i64 = p::project_tickets
+            .filter(p::ticket_id.eq(src.id))
+            .count()
+            .get_result(&mut conn)
+            .unwrap();
+        assert_eq!(on_dest, 1, "moved onto destination");
+        assert_eq!(on_src, 0, "removed from closed source");
+    }
+
+    #[test]
+    fn linked_tickets_rewritten_and_self_link_dropped() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "links", UserRole::User);
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+        let other = TestFixtures::create_ticket(&mut conn, "Other", Some(user.uuid), None);
+
+        // src <-> other (rewrites onto dest) and src <-> dest (would
+        // self-link, must be dropped).
+        crate::repository::linked_tickets::link_tickets(&mut conn, src.id, other.id).unwrap();
+        crate::repository::linked_tickets::link_tickets(&mut conn, src.id, dest.id).unwrap();
+
+        execute_merge(&mut conn, input(dest.id, vec![src.id]), &actor_for(user.uuid)).unwrap();
+
+        use crate::schema::linked_tickets::dsl as l;
+        // No edge references the source any more.
+        let src_edges: i64 = l::linked_tickets
+            .filter(l::ticket_id.eq(src.id).or(l::linked_ticket_id.eq(src.id)))
+            .count()
+            .get_result(&mut conn)
+            .unwrap();
+        // Only the duplicate_of merge edge survives src -> dest.
+        assert_eq!(src_edges, 1);
+
+        // dest <-> other now exists (rewritten from src), no self-link.
+        let dest_other: i64 = l::linked_tickets
+            .filter(l::ticket_id.eq(dest.id))
+            .filter(l::linked_ticket_id.eq(other.id))
+            .count()
+            .get_result(&mut conn)
+            .unwrap();
+        assert_eq!(dest_other, 1);
+    }
+
+    #[test]
+    fn audit_and_sync_share_correlation_id() {
+        use diesel::sql_types::{BigInt, Text};
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "corr", UserRole::User);
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+
+        let outcome =
+            execute_merge(&mut conn, input(dest.id, vec![src.id]), &actor_for(user.uuid)).unwrap();
+        let corr = outcome.correlation_id.expect("actor carried a correlation id");
+
+        #[derive(diesel::QueryableByName)]
+        struct C {
+            #[diesel(sql_type = BigInt)]
+            n: i64,
+        }
+        let sync_rows: i64 = diesel::sql_query(
+            "SELECT COUNT(*) AS n FROM sync_actions WHERE correlation_id = $1::uuid",
+        )
+        .bind::<Text, _>(corr.to_string())
+        .get_result::<C>(&mut conn)
+        .unwrap()
+        .n;
+        let audit_rows: i64 = diesel::sql_query(
+            "SELECT COUNT(*) AS n FROM audit_log WHERE correlation_id = $1::uuid",
+        )
+        .bind::<Text, _>(corr.to_string())
+        .get_result::<C>(&mut conn)
+        .unwrap()
+        .n;
+
+        assert!(sync_rows > 0, "sync_actions rows share the correlation id");
+        assert!(audit_rows > 0, "audit_log rows share the correlation id");
+    }
+}

--- a/backend/src/repository/ticket_merge.rs
+++ b/backend/src/repository/ticket_merge.rs
@@ -51,6 +51,11 @@ pub struct MergeInput {
     pub notify_customer: bool,
     /// Optional optimistic-lock tokens. Empty means "skip the check".
     pub expected_state: Vec<ExpectedState>,
+    /// Agent-edited body for the merge-marker comment (the merge
+    /// dialog's description area). `None` falls back to the generated
+    /// summary. The structured channel_metadata is always attached so
+    /// the activity card renders regardless.
+    pub marker_body: Option<String>,
 }
 
 /// Counts and identifiers the API echoes back after a successful merge.
@@ -357,7 +362,13 @@ pub fn execute_merge(
         // destination. Inserted directly (not via create_comment) so it
         // does NOT stamp the destination's first_response_at: a merge
         // marker is bookkeeping, not a staff reply to the customer.
-        let marker = build_marker(&destination, &sources, actor, reason.as_deref());
+        let marker = build_marker(
+            &destination,
+            &sources,
+            actor,
+            reason.as_deref(),
+            input.marker_body.as_deref(),
+        );
         let marker_comment: Comment = diesel::insert_into(crate::schema::comments::table)
             .values(&marker)
             .get_result(conn)?;
@@ -523,6 +534,7 @@ fn build_marker(
     sources: &[Ticket],
     actor: &ActorContext,
     reason: Option<&str>,
+    marker_body: Option<&str>,
 ) -> NewComment {
     let source_json: Vec<_> = sources
         .iter()
@@ -546,10 +558,20 @@ fn build_marker(
     if let Some(r) = reason {
         lines.push(format!("Reason: {r}"));
     }
-    let body_text = lines.join("\n");
+    // Agent-edited body wins; otherwise fall back to the generated
+    // summary. Either way the structured metadata below drives the card.
+    let generated = lines.join("\n");
+    let body_text = marker_body
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or(generated);
     let body_html = format!(
         "<p>{}</p>",
-        body_text.replace('&', "&amp;").replace('<', "&lt;").replace('\n', "<br>")
+        body_text
+            .replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('\n', "<br>")
     );
 
     let metadata = json!({
@@ -786,6 +808,7 @@ mod tests {
             reason: Some("same outage".to_string()),
             notify_customer: false,
             expected_state: Vec::new(),
+            marker_body: None,
         }
     }
 

--- a/backend/src/repository/ticket_merge.rs
+++ b/backend/src/repository/ticket_merge.rs
@@ -21,7 +21,8 @@ use uuid::Uuid;
 
 use crate::db::DbConnection;
 use crate::models::{
-    Comment, ContentFormat, NewComment, SyncAggregate, SyncOp, Ticket, WorkflowStateCategory,
+    Comment, ContentFormat, NewComment, NewOutboundEmail, SyncAggregate, SyncOp, Ticket,
+    WorkflowStateCategory,
 };
 use crate::sync::actor::ActorContext;
 use crate::sync::emit::{self, SyncEmit};
@@ -607,6 +608,7 @@ pub struct MergeHistory {
     pub merge_events: Vec<MergeEvent>,
 }
 
+// sync-audit-only: read-only history query, emits nothing
 /// Build the merge history for `ticket_id`: where it was merged to (if
 /// it's a source) and the merges that consumed other tickets into it.
 /// Reads through RLS, so it only sees the caller's workspace.
@@ -690,6 +692,81 @@ pub fn merge_history_for_ticket(
         merged_into,
         merge_events,
     })
+}
+
+/// Enqueue a templated "your request was merged" reply to each source
+/// ticket's customer, on the source's origin email channel. Best-effort
+/// and post-commit; the handler calls this only when the merge dialog's
+/// notify-customer box was ticked. Each outbound binds to the
+/// destination ticket, so a customer reply threads onto the merged
+/// target rather than reopening the source. Sources without an email
+/// channel or a requester email are skipped. Returns the number
+/// enqueued.
+pub fn enqueue_merge_notifications(
+    conn: &mut DbConnection,
+    destination: &Ticket,
+    sources: &[Ticket],
+) -> QueryResult<usize> {
+    use crate::repository::{
+        channels as channels_repo, outbound_emails, site_settings as site_settings_repo,
+        user_helpers,
+    };
+    use crate::services::channels::email_imap::ImapChannelConfig;
+    use crate::services::channels::threading::{format_outbound_message_id, format_outbound_subject};
+
+    let settings = site_settings_repo::get_site_settings(conn)?;
+    let locale = crate::utils::locale::effective_locale(None, &settings.default_locale);
+    let body = crate::utils::i18n::tr(&locale, "merge-notification-customer-template");
+
+    let mut enqueued = 0usize;
+    for source in sources {
+        let (Some(channel_id), Some(requester_uuid)) =
+            (source.origin_channel_id, source.requester_uuid)
+        else {
+            continue;
+        };
+
+        // Email is the only channel that delivers a reply today.
+        let channel = match channels_repo::find(conn, channel_id) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if channel.provider != "email_imap" {
+            continue;
+        }
+        let reply_domain = match serde_json::from_value::<ImapChannelConfig>(channel.config.clone())
+        {
+            Ok(cfg) => cfg.reply_domain,
+            Err(_) => continue,
+        };
+        let Some(recipient) = user_helpers::get_primary_email(&requester_uuid, conn) else {
+            continue;
+        };
+
+        let message_id = format_outbound_message_id(destination.id, source.id, &reply_domain);
+        let subject = format_outbound_subject(destination.id, &destination.title);
+
+        outbound_emails::enqueue(
+            conn,
+            NewOutboundEmail {
+                channel_id: Some(channel_id),
+                ticket_id: Some(destination.id),
+                comment_id: None,
+                recipient,
+                subject,
+                body_text: body.clone(),
+                body_html: None,
+                message_id,
+                in_reply_to: None,
+                references_list: Vec::new(),
+                headers_json: serde_json::json!({}),
+                correlation_id: None,
+                idempotency_key: None,
+            },
+        )?;
+        enqueued += 1;
+    }
+    Ok(enqueued)
 }
 
 #[cfg(test)]
@@ -1090,5 +1167,56 @@ mod tests {
 
         assert!(sync_rows > 0, "sync_actions rows share the correlation id");
         assert!(audit_rows > 0, "audit_log rows share the correlation id");
+    }
+
+    #[test]
+    fn merge_notifications_enqueue_for_email_sources() {
+        use crate::schema::{channels, outbound_emails, tickets};
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "customer", UserRole::User);
+        TestFixtures::create_user_email(&mut conn, user.uuid, "customer@example.com", true);
+
+        let channel: crate::models::Channel = diesel::insert_into(channels::table)
+            .values(&crate::models::NewChannel {
+                provider: "email_imap".to_string(),
+                name: "mail".to_string(),
+                enabled: true,
+                config: serde_json::json!({
+                    "host": "mail.example.com",
+                    "username": "support@example.com",
+                    "reply_domain": "example.com",
+                }),
+            })
+            .get_result(&mut conn)
+            .unwrap();
+
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+        diesel::update(tickets::table.find(src.id))
+            .set(tickets::origin_channel_id.eq(channel.id))
+            .execute(&mut conn)
+            .unwrap();
+        let src: Ticket = tickets::table.find(src.id).first(&mut conn).unwrap();
+
+        let n = enqueue_merge_notifications(&mut conn, &dest, &[src]).unwrap();
+        assert_eq!(n, 1);
+
+        let queued: i64 = outbound_emails::table
+            .filter(outbound_emails::ticket_id.eq(dest.id))
+            .count()
+            .get_result(&mut conn)
+            .unwrap();
+        assert_eq!(queued, 1);
+    }
+
+    #[test]
+    fn merge_notifications_skip_sources_without_channel() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "nochan", UserRole::User);
+        let dest = TestFixtures::create_ticket(&mut conn, "Dest", Some(user.uuid), None);
+        let src = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+
+        let n = enqueue_merge_notifications(&mut conn, &dest, &[src]).unwrap();
+        assert_eq!(n, 0);
     }
 }

--- a/backend/src/repository/tickets.rs
+++ b/backend/src/repository/tickets.rs
@@ -891,6 +891,77 @@ mod tests {
     use crate::models::UserRole;
     use crate::test_helpers::{setup_test_connection, TestFixtures};
 
+    #[test]
+    fn merged_workflow_state_is_seeded() {
+        use crate::models::WorkflowStateCategory;
+        use crate::schema::workflow_states;
+
+        let mut conn = setup_test_connection();
+        let (name, is_default, pauses_sla): (String, bool, bool) = workflow_states::table
+            .filter(workflow_states::category.eq(WorkflowStateCategory::Merged))
+            .filter(workflow_states::workspace_id.eq(1))
+            .select((
+                workflow_states::name,
+                workflow_states::is_default,
+                workflow_states::pauses_sla,
+            ))
+            .first(&mut conn)
+            .expect("Merged workflow state must be seeded for workspace 1");
+
+        assert_eq!(name, "Merged");
+        // Not the workspace default (only one default allowed per workspace).
+        assert!(!is_default);
+        // Pauses SLA the same way other terminal states do.
+        assert!(pauses_sla);
+    }
+
+    #[test]
+    fn ticket_can_be_marked_merged() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "merger", UserRole::User);
+        let source = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+        let target = TestFixtures::create_ticket(&mut conn, "Target", Some(user.uuid), None);
+
+        let now = chrono::Utc::now().naive_utc();
+        let updated = diesel::update(tickets::table.find(source.id))
+            .set((
+                tickets::merged_into_ticket_id.eq(Some(target.id)),
+                tickets::merged_at.eq(Some(now)),
+                tickets::merged_by_user_uuid.eq(Some(user.uuid)),
+                tickets::merge_reason.eq(Some("same outage".to_string())),
+            ))
+            .execute(&mut conn)
+            .expect("setting all merge columns together satisfies the invariant");
+        assert_eq!(updated, 1);
+
+        let reloaded: Ticket = tickets::table.find(source.id).first(&mut conn).unwrap();
+        assert_eq!(reloaded.merged_into_ticket_id, Some(target.id));
+        assert_eq!(reloaded.merged_by_user_uuid, Some(user.uuid));
+        assert_eq!(reloaded.merge_reason.as_deref(), Some("same outage"));
+    }
+
+    #[test]
+    fn partial_merge_state_violates_invariant() {
+        let mut conn = setup_test_connection();
+        let user = TestFixtures::create_user(&mut conn, "partial", UserRole::User);
+        let source = TestFixtures::create_ticket(&mut conn, "Source", Some(user.uuid), None);
+        let target = TestFixtures::create_ticket(&mut conn, "Target", Some(user.uuid), None);
+
+        // Setting merged_into_ticket_id without merged_at / merged_by_user_uuid
+        // must be rejected by tickets_merge_complete.
+        let result = diesel::update(tickets::table.find(source.id))
+            .set(tickets::merged_into_ticket_id.eq(Some(target.id)))
+            .execute(&mut conn);
+
+        match result {
+            Err(diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::CheckViolation,
+                _,
+            )) => {}
+            other => panic!("expected CheckViolation, got {other:?}"),
+        }
+    }
+
     /// Insert a ticket with an explicit verification state. The shared
     /// fixture helper always passes `None`, which is the wrong shape for
     /// testing the pending-release path.

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1420,6 +1420,10 @@ diesel::table! {
         sla_response_breached_at -> Nullable<Timestamptz>,
         sla_resolution_target_at -> Nullable<Timestamptz>,
         sla_resolution_breached_at -> Nullable<Timestamptz>,
+        merged_into_ticket_id -> Nullable<Int4>,
+        merged_at -> Nullable<Timestamptz>,
+        merged_by_user_uuid -> Nullable<Uuid>,
+        merge_reason -> Nullable<Text>,
     }
 }
 

--- a/backend/src/services/assignment.rs
+++ b/backend/src/services/assignment.rs
@@ -385,6 +385,10 @@ mod tests {
             sla_response_breached_at: None,
             sla_resolution_target_at: None,
             sla_resolution_breached_at: None,
+            merged_into_ticket_id: None,
+            merged_at: None,
+            merged_by_user_uuid: None,
+            merge_reason: None,
         };
         overrides(&mut ticket);
         ticket

--- a/backend/src/services/channels/auto_ack.rs
+++ b/backend/src/services/channels/auto_ack.rs
@@ -316,6 +316,10 @@ mod tests {
             sla_response_breached_at: None,
             sla_resolution_target_at: None,
             sla_resolution_breached_at: None,
+            merged_into_ticket_id: None,
+            merged_at: None,
+            merged_by_user_uuid: None,
+            merge_reason: None,
         }
     }
 

--- a/backend/src/services/sla.rs
+++ b/backend/src/services/sla.rs
@@ -778,6 +778,10 @@ mod tests {
             sla_response_breached_at: None,
             sla_resolution_target_at: None,
             sla_resolution_breached_at: None,
+            merged_into_ticket_id: None,
+            merged_at: None,
+            merged_by_user_uuid: None,
+            merge_reason: None,
         }
     }
 

--- a/backend/src/services/webhooks/types.rs
+++ b/backend/src/services/webhooks/types.rs
@@ -195,6 +195,9 @@ impl WebhookEventType {
             // hit /api/sync/delta directly), so no resource_type to
             // report.
             SseEvent::SyncActions { .. } => None,
+            // No dedicated merge webhook contract in v1; the per-source
+            // ticket.updated events already fire for the state change.
+            SseEvent::TicketMerged { .. } => None,
             SseEvent::SlaBreached { .. } => Some(Self::TicketSlaBreached),
         }
     }

--- a/backend/sync-models/ticket.json
+++ b/backend/sync-models/ticket.json
@@ -25,7 +25,9 @@
     { "type": "ticket.priority_changed", "op": "U" },
     { "type": "ticket.title_changed", "op": "U" },
     { "type": "ticket.category_changed", "op": "U" },
-    { "type": "ticket.verification_changed", "op": "U" }
+    { "type": "ticket.verification_changed", "op": "U" },
+    { "type": "ticket.merged", "op": "U" },
+    { "type": "ticket.merged_into", "op": "U" }
   ],
   "groups": [
     "workspace:1",

--- a/backend/tests/ticket_merge.rs
+++ b/backend/tests/ticket_merge.rs
@@ -10,6 +10,9 @@
 
 #![allow(clippy::expect_used)]
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use actix_web::dev::Service;
 use actix_web::{web, App, HttpMessage};
 use diesel::prelude::*;
@@ -17,8 +20,10 @@ use serde_json::json;
 use uuid::Uuid;
 
 use backend::extractors::WorkspaceContext;
+use backend::handlers::sse::{SseEvent, SseState};
 use backend::middleware::RequestContext;
 use backend::models::{Claims, NewTicket, NewUser, Ticket, User};
+use backend::services::search::SearchService;
 use backend::sync::actor::ActorContext;
 
 mod common;
@@ -93,14 +98,23 @@ fn claims_for(user: &User) -> Claims {
 }
 
 /// Start a test server that runs every request as `user`, with the
-/// workspace context pinned to workspace 1.
-fn spawn(pool: &common::TestPool, user: &User) -> actix_test::TestServer {
+/// workspace context pinned to workspace 1. Returns the shared
+/// `SseState` so a test can subscribe and assert broadcasts.
+fn spawn(pool: &common::TestPool, user: &User) -> (actix_test::TestServer, Arc<SseState>) {
+    let sse = Arc::new(SseState::new());
+    let sse_app = sse.clone();
     let pool = pool.clone();
     let claims = claims_for(user);
     let user_uuid = user.uuid;
-    actix_test::start(move || {
+    let srv = actix_test::start(move || {
         let pool = pool.clone();
         let claims = claims.clone();
+        let sse_app = sse_app.clone();
+        // Per-worker throwaway search index; the merge handler reindexes
+        // sources through it. Leak the tempdir for the server's life.
+        let tmp = tempfile::tempdir().expect("temp search dir");
+        let search = Arc::new(SearchService::new(tmp.path(), &pool).expect("init search"));
+        std::mem::forget(tmp);
         let corr = Uuid::now_v7();
         let actor = ActorContext::user(user_uuid, Some(corr)).with_workspace(WS);
         let ws = WorkspaceContext {
@@ -112,6 +126,8 @@ fn spawn(pool: &common::TestPool, user: &User) -> actix_test::TestServer {
         };
         App::new()
             .app_data(web::Data::new(pool))
+            .app_data(web::Data::from(sse_app))
+            .app_data(web::Data::new(search))
             .wrap_fn(move |req, srv| {
                 req.extensions_mut().insert(ws.clone());
                 req.extensions_mut().insert(claims.clone());
@@ -130,7 +146,8 @@ fn spawn(pool: &common::TestPool, user: &User) -> actix_test::TestServer {
                         web::get().to(backend::handlers::ticket_merge::get_merge_history),
                     ),
             )
-    })
+    });
+    (srv, sse)
 }
 
 #[actix_web::test]
@@ -145,7 +162,8 @@ async fn merge_happy_path_returns_200() {
     let dest = ticket(&mut conn, "Dest", state, agent.uuid);
     let src = ticket(&mut conn, "Source", state, agent.uuid);
 
-    let srv = spawn(&pool, &agent);
+    let (srv, sse) = spawn(&pool, &agent);
+    let mut rx = sse.subscribe_global();
     let client = awc::Client::new();
     let mut resp = client
         .post(srv.url("/api/tickets/merge"))
@@ -163,6 +181,28 @@ async fn merge_happy_path_returns_200() {
     assert_eq!(body["destination_ticket"]["id"], dest.id);
     assert_eq!(body["merged_sources"].as_array().unwrap().len(), 1);
     assert_eq!(body["merged_sources"][0]["id"], src.id);
+
+    // The merge broadcasts a TicketMerged event to connected clients.
+    let mut saw_merged = false;
+    for _ in 0..5 {
+        match tokio::time::timeout(Duration::from_secs(2), rx.recv()).await {
+            Ok(Ok(env)) => {
+                if let SseEvent::TicketMerged {
+                    target_ticket_id,
+                    source_ticket_ids,
+                    ..
+                } = env.event
+                {
+                    assert_eq!(target_ticket_id, dest.id);
+                    assert_eq!(source_ticket_ids, vec![src.id]);
+                    saw_merged = true;
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    assert!(saw_merged, "expected a TicketMerged SSE event");
 }
 
 #[actix_web::test]
@@ -176,7 +216,7 @@ async fn self_merge_returns_400() {
     let state = default_state_id(&mut conn);
     let t = ticket(&mut conn, "T", state, agent.uuid);
 
-    let srv = spawn(&pool, &agent);
+    let (srv, _sse) = spawn(&pool, &agent);
     let client = awc::Client::new();
     let mut resp = client
         .post(srv.url("/api/tickets/merge"))
@@ -201,7 +241,7 @@ async fn chain_merge_returns_400() {
     let other = ticket(&mut conn, "Other", state, agent.uuid);
     let src = ticket(&mut conn, "Source", state, agent.uuid);
 
-    let srv = spawn(&pool, &agent);
+    let (srv, _sse) = spawn(&pool, &agent);
     let client = awc::Client::new();
 
     let first = client
@@ -234,7 +274,7 @@ async fn non_agent_returns_403() {
     let dest = ticket(&mut conn, "Dest", state, regular.uuid);
     let src = ticket(&mut conn, "Source", state, regular.uuid);
 
-    let srv = spawn(&pool, &regular);
+    let (srv, _sse) = spawn(&pool, &regular);
     let client = awc::Client::new();
     let resp = client
         .post(srv.url("/api/tickets/merge"))
@@ -255,7 +295,7 @@ async fn missing_ticket_returns_404() {
     let state = default_state_id(&mut conn);
     let dest = ticket(&mut conn, "Dest", state, agent.uuid);
 
-    let srv = spawn(&pool, &agent);
+    let (srv, _sse) = spawn(&pool, &agent);
     let client = awc::Client::new();
     let resp = client
         .post(srv.url("/api/tickets/merge"))
@@ -277,7 +317,7 @@ async fn optimistic_conflict_returns_409() {
     let dest = ticket(&mut conn, "Dest", state, agent.uuid);
     let src = ticket(&mut conn, "Source", state, agent.uuid);
 
-    let srv = spawn(&pool, &agent);
+    let (srv, _sse) = spawn(&pool, &agent);
     let client = awc::Client::new();
     let mut resp = client
         .post(srv.url("/api/tickets/merge"))

--- a/backend/tests/ticket_merge.rs
+++ b/backend/tests/ticket_merge.rs
@@ -1,0 +1,294 @@
+//! HTTP-layer integration tests for the ticket merge endpoints.
+//!
+//! The repository lifecycle is covered exhaustively by the unit tests
+//! in `repository::ticket_merge::tests`. These tests exercise the
+//! handler wiring: routing, the workspace-role gate, the MergeError ->
+//! status-code mapping, and the response JSON shape. Auth + workspace
+//! middleware is replaced by a `wrap_fn` that injects the same request
+//! extensions the production middleware would (Claims, WorkspaceContext,
+//! RequestContext), so each test runs as a chosen user + role.
+
+#![allow(clippy::expect_used)]
+
+use actix_web::dev::Service;
+use actix_web::{web, App, HttpMessage};
+use diesel::prelude::*;
+use serde_json::json;
+use uuid::Uuid;
+
+use backend::extractors::WorkspaceContext;
+use backend::middleware::RequestContext;
+use backend::models::{Claims, NewTicket, NewUser, Ticket, User};
+use backend::sync::actor::ActorContext;
+
+mod common;
+
+const WS: i32 = 1;
+
+fn default_state_id(conn: &mut PgConnection) -> i32 {
+    use backend::schema::workflow_states::dsl as s;
+    s::workflow_states
+        .filter(s::workspace_id.eq(WS))
+        .filter(s::is_default.eq(true))
+        .select(s::id)
+        .first(conn)
+        .expect("default workflow state seeded")
+}
+
+/// Insert a user and grant them `role` in workspace 1.
+fn member(conn: &mut PgConnection, name: &str, role: &str) -> User {
+    use backend::schema::{users, workspace_members};
+    let user: User = diesel::insert_into(users::table)
+        .values(&NewUser {
+            uuid: Uuid::new_v4(),
+            name: name.to_string(),
+            pronouns: None,
+            avatar_url: None,
+            banner_url: None,
+            avatar_thumb: None,
+            microsoft_uuid: None,
+            mfa_secret: None,
+            mfa_secret_kek_id: None,
+            mfa_enabled: false,
+            platform_role: None,
+        })
+        .get_result(conn)
+        .expect("insert user");
+    diesel::insert_into(workspace_members::table)
+        .values((
+            workspace_members::workspace_id.eq(WS),
+            workspace_members::user_uuid.eq(user.uuid),
+            workspace_members::role.eq(role),
+        ))
+        .execute(conn)
+        .expect("insert workspace member");
+    user
+}
+
+fn ticket(conn: &mut PgConnection, title: &str, state_id: i32, requester: Uuid) -> Ticket {
+    use backend::schema::tickets;
+    diesel::insert_into(tickets::table)
+        .values(&NewTicket {
+            title: title.to_string(),
+            workflow_state_id: state_id,
+            requester_uuid: Some(requester),
+            ..Default::default()
+        })
+        .get_result(conn)
+        .expect("insert ticket")
+}
+
+fn claims_for(user: &User) -> Claims {
+    Claims {
+        sub: user.uuid.to_string(),
+        name: user.name.clone(),
+        email: "agent@example.com".to_string(),
+        role: "technician".to_string(),
+        platform_role: None,
+        scope: "full".to_string(),
+        sid: None,
+        exp: (chrono::Utc::now().timestamp() + 3600) as usize,
+        iat: chrono::Utc::now().timestamp() as usize,
+    }
+}
+
+/// Start a test server that runs every request as `user`, with the
+/// workspace context pinned to workspace 1.
+fn spawn(pool: &common::TestPool, user: &User) -> actix_test::TestServer {
+    let pool = pool.clone();
+    let claims = claims_for(user);
+    let user_uuid = user.uuid;
+    actix_test::start(move || {
+        let pool = pool.clone();
+        let claims = claims.clone();
+        let corr = Uuid::now_v7();
+        let actor = ActorContext::user(user_uuid, Some(corr)).with_workspace(WS);
+        let ws = WorkspaceContext {
+            workspace_id: WS,
+            workspace_uuid: Uuid::nil(),
+            slug: "default".to_string(),
+            name: "Default".to_string(),
+            organisation_id: None,
+        };
+        App::new()
+            .app_data(web::Data::new(pool))
+            .wrap_fn(move |req, srv| {
+                req.extensions_mut().insert(ws.clone());
+                req.extensions_mut().insert(claims.clone());
+                req.extensions_mut()
+                    .insert(RequestContext::new(corr, actor.clone()));
+                srv.call(req)
+            })
+            .service(
+                web::scope("/api")
+                    .route(
+                        "/tickets/merge",
+                        web::post().to(backend::handlers::ticket_merge::merge_tickets),
+                    )
+                    .route(
+                        "/tickets/{id}/merge-history",
+                        web::get().to(backend::handlers::ticket_merge::get_merge_history),
+                    ),
+            )
+    })
+}
+
+#[actix_web::test]
+async fn merge_happy_path_returns_200() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(4);
+    let mut conn = pool.get().expect("conn");
+
+    let agent = member(&mut conn, "Agent", "agent");
+    let state = default_state_id(&mut conn);
+    let dest = ticket(&mut conn, "Dest", state, agent.uuid);
+    let src = ticket(&mut conn, "Source", state, agent.uuid);
+
+    let srv = spawn(&pool, &agent);
+    let client = awc::Client::new();
+    let mut resp = client
+        .post(srv.url("/api/tickets/merge"))
+        .send_json(&json!({
+            "destination_ticket_id": dest.id,
+            "source_ticket_ids": [src.id],
+            "reason": "same outage",
+            "notify_customer": false,
+        }))
+        .await
+        .expect("send merge");
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["destination_ticket"]["id"], dest.id);
+    assert_eq!(body["merged_sources"].as_array().unwrap().len(), 1);
+    assert_eq!(body["merged_sources"][0]["id"], src.id);
+}
+
+#[actix_web::test]
+async fn self_merge_returns_400() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(4);
+    let mut conn = pool.get().expect("conn");
+
+    let agent = member(&mut conn, "Agent", "agent");
+    let state = default_state_id(&mut conn);
+    let t = ticket(&mut conn, "T", state, agent.uuid);
+
+    let srv = spawn(&pool, &agent);
+    let client = awc::Client::new();
+    let mut resp = client
+        .post(srv.url("/api/tickets/merge"))
+        .send_json(&json!({ "destination_ticket_id": t.id, "source_ticket_ids": [t.id] }))
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["code"], "MERGE_VALIDATION");
+}
+
+#[actix_web::test]
+async fn chain_merge_returns_400() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(4);
+    let mut conn = pool.get().expect("conn");
+
+    let agent = member(&mut conn, "Agent", "agent");
+    let state = default_state_id(&mut conn);
+    let dest = ticket(&mut conn, "Dest", state, agent.uuid);
+    let other = ticket(&mut conn, "Other", state, agent.uuid);
+    let src = ticket(&mut conn, "Source", state, agent.uuid);
+
+    let srv = spawn(&pool, &agent);
+    let client = awc::Client::new();
+
+    let first = client
+        .post(srv.url("/api/tickets/merge"))
+        .send_json(&json!({ "destination_ticket_id": dest.id, "source_ticket_ids": [src.id] }))
+        .await
+        .expect("send first");
+    assert_eq!(first.status(), 200);
+
+    // src is now merged; merging it again must be refused.
+    let mut second = client
+        .post(srv.url("/api/tickets/merge"))
+        .send_json(&json!({ "destination_ticket_id": other.id, "source_ticket_ids": [src.id] }))
+        .await
+        .expect("send second");
+    assert_eq!(second.status(), 400);
+    let body: serde_json::Value = second.json().await.expect("json");
+    assert_eq!(body["code"], "MERGE_VALIDATION");
+}
+
+#[actix_web::test]
+async fn non_agent_returns_403() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(4);
+    let mut conn = pool.get().expect("conn");
+
+    let regular = member(&mut conn, "Regular", "member");
+    let state = default_state_id(&mut conn);
+    let dest = ticket(&mut conn, "Dest", state, regular.uuid);
+    let src = ticket(&mut conn, "Source", state, regular.uuid);
+
+    let srv = spawn(&pool, &regular);
+    let client = awc::Client::new();
+    let resp = client
+        .post(srv.url("/api/tickets/merge"))
+        .send_json(&json!({ "destination_ticket_id": dest.id, "source_ticket_ids": [src.id] }))
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 403);
+}
+
+#[actix_web::test]
+async fn missing_ticket_returns_404() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(4);
+    let mut conn = pool.get().expect("conn");
+
+    let agent = member(&mut conn, "Agent", "agent");
+    let state = default_state_id(&mut conn);
+    let dest = ticket(&mut conn, "Dest", state, agent.uuid);
+
+    let srv = spawn(&pool, &agent);
+    let client = awc::Client::new();
+    let resp = client
+        .post(srv.url("/api/tickets/merge"))
+        .send_json(&json!({ "destination_ticket_id": dest.id, "source_ticket_ids": [999_999] }))
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 404);
+}
+
+#[actix_web::test]
+async fn optimistic_conflict_returns_409() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(4);
+    let mut conn = pool.get().expect("conn");
+
+    let agent = member(&mut conn, "Agent", "agent");
+    let state = default_state_id(&mut conn);
+    let dest = ticket(&mut conn, "Dest", state, agent.uuid);
+    let src = ticket(&mut conn, "Source", state, agent.uuid);
+
+    let srv = spawn(&pool, &agent);
+    let client = awc::Client::new();
+    let mut resp = client
+        .post(srv.url("/api/tickets/merge"))
+        .send_json(&json!({
+            "destination_ticket_id": dest.id,
+            "source_ticket_ids": [src.id],
+            "expected_state": [{ "ticket_id": dest.id, "workflow_state_id": state + 9999 }],
+        }))
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 409);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["code"], "MERGE_STATE_CONFLICT");
+}

--- a/frontend/src/components/ticketComponents/CommentsAndAttachments.vue
+++ b/frontend/src/components/ticketComponents/CommentsAndAttachments.vue
@@ -464,6 +464,7 @@ const handlePastedFiles = async (files: File[]) => {
                   rather than a nested card.
                 -->
                 <div
+                    v-if="!readonly"
                     class="print:hidden border-b relative p-3 transition-colors"
                     :class="
                         isInternal
@@ -527,7 +528,6 @@ const handlePastedFiles = async (files: File[]) => {
                             :placeholder="isInternal ? $t('ticket-comments-placeholder-internal') : $t('ticket-comments-placeholder-public')"
                             min-height="60px"
                             max-height="200px"
-                            :disabled="readonly"
                             @submit="addComment"
                             @paste-files="handlePastedFiles"
                         />

--- a/frontend/src/components/ticketComponents/CommentsAndAttachments.vue
+++ b/frontend/src/components/ticketComponents/CommentsAndAttachments.vue
@@ -34,6 +34,9 @@ const props = defineProps<{
      *  ticket context. */
     ticketId?: number;
     recentlyAddedCommentIds?: Set<number>;
+    /** When true the composer is disabled (merged tickets are
+     *  terminal and read-only). Existing comments still render. */
+    readonly?: boolean;
     /** Optional template context for the canned-response picker —
         `{{ticket_id}}`, `{{customer_name}}` etc. substitute at
         insert time. Omit when the composer isn't on a ticket. */
@@ -524,6 +527,7 @@ const handlePastedFiles = async (files: File[]) => {
                             :placeholder="isInternal ? $t('ticket-comments-placeholder-internal') : $t('ticket-comments-placeholder-public')"
                             min-height="60px"
                             max-height="200px"
+                            :disabled="readonly"
                             @submit="addComment"
                             @paste-files="handlePastedFiles"
                         />

--- a/frontend/src/components/ticketComponents/MergeTicketsDialog.vue
+++ b/frontend/src/components/ticketComponents/MergeTicketsDialog.vue
@@ -1,0 +1,196 @@
+<!--
+Merge dialog for the bulk "Merge" action. Phase 1 is a single-agent
+form (the Yjs co-edit upgrade is Phase 2). The agent picks a
+destination, optionally edits the merge-marker comment body and a
+reason, and chooses whether to notify the customer. On open it snapshots
+each ticket's workflow_state_id as an optimistic-lock token; a 409 means
+a ticket changed underneath and the agent is asked to refresh.
+-->
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useFluent } from 'fluent-vue'
+import Modal from '@/components/Modal.vue'
+import Button from '@/components/common/Button.vue'
+import FormTextarea from '@/components/common/FormTextarea.vue'
+import Checkbox from '@/components/common/Checkbox.vue'
+import { useToastStore } from '@/stores/toast'
+import { mergeTickets } from '@/services/ticketService'
+import type { Ticket } from '@/types/ticket'
+
+const props = defineProps<{
+  open: boolean
+  selectedTickets: Ticket[]
+}>()
+
+const emit = defineEmits<{
+  close: []
+  /** Emitted with the destination id after a successful merge so the
+   *  parent can clear its selection. */
+  merged: [destinationId: number]
+}>()
+
+const fluent = useFluent()
+const toast = useToastStore()
+const router = useRouter()
+
+const destinationId = ref<number | null>(null)
+const description = ref('')
+const reason = ref('')
+const notifyCustomer = ref(false)
+const submitting = ref(false)
+// ticket_id -> workflow_state_id snapshot taken when the dialog opened.
+const stateSnapshot = ref<Record<number, number>>({})
+
+const count = computed(() => props.selectedTickets.length)
+const canSubmit = computed(() => count.value >= 2 && destinationId.value !== null)
+
+const sources = computed(() =>
+  props.selectedTickets.filter((t) => t.id !== destinationId.value),
+)
+
+/** Oldest selected ticket by created timestamp (ISO strings sort
+ *  lexicographically). The agent can override via the picker. */
+function oldest(tickets: Ticket[]): Ticket | null {
+  if (tickets.length === 0) return null
+  return [...tickets].sort((a, b) => (a.created || '').localeCompare(b.created || ''))[0]
+}
+
+function seedDescription() {
+  const dest = props.selectedTickets.find((t) => t.id === destinationId.value)
+  const lines: string[] = []
+  if (dest) lines.push(dest.title)
+  lines.push('')
+  lines.push('Incoming from:')
+  for (const s of sources.value) {
+    lines.push(`- #${s.id}: ${s.title}`)
+  }
+  description.value = lines.join('\n')
+}
+
+watch(
+  () => props.open,
+  (open) => {
+    if (!open) return
+    destinationId.value = oldest(props.selectedTickets)?.id ?? null
+    reason.value = ''
+    notifyCustomer.value = false
+    submitting.value = false
+    const snap: Record<number, number> = {}
+    for (const t of props.selectedTickets) {
+      if (t.workflow_state_id != null) snap[t.id] = t.workflow_state_id
+    }
+    stateSnapshot.value = snap
+    seedDescription()
+  },
+  { immediate: true },
+)
+
+// Re-seed the description when the agent changes the destination.
+watch(destinationId, () => {
+  if (props.open) seedDescription()
+})
+
+async function submit() {
+  if (!canSubmit.value || submitting.value || destinationId.value === null) return
+  submitting.value = true
+  const target = destinationId.value
+  try {
+    await mergeTickets({
+      destination_ticket_id: target,
+      source_ticket_ids: sources.value.map((t) => t.id),
+      reason: reason.value.trim() || null,
+      notify_customer: notifyCustomer.value,
+      marker_body: description.value.trim() || null,
+      expected_state: Object.entries(stateSnapshot.value).map(([ticket_id, workflow_state_id]) => ({
+        ticket_id: Number(ticket_id),
+        workflow_state_id,
+      })),
+    })
+    toast.success(
+      fluent.$t('ticket-merge-success-toast', { count: count.value, target_id: target }),
+    )
+    emit('merged', target)
+    emit('close')
+    router.push(`/tickets/${target}`)
+  } catch (err: unknown) {
+    const status = (err as { response?: { status?: number } })?.response?.status
+    if (status === 409) {
+      toast.warning(fluent.$t('ticket-merge-conflict-toast'))
+    } else {
+      toast.error(fluent.$t('ticket-merge-cancel-button'), String(err))
+    }
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <Modal
+    :show="open"
+    :title="$t('ticket-merge-dialog-title', { count })"
+    size="lg"
+    @close="emit('close')"
+  >
+    <div class="flex flex-col gap-4">
+      <!-- Destination picker -->
+      <label class="flex flex-col gap-1.5 text-sm">
+        <span class="text-tertiary">{{ $t('ticket-merge-destination-label') }}</span>
+        <select
+          v-model.number="destinationId"
+          class="w-full px-3 py-2 text-sm rounded border border-default bg-surface focus:outline-none focus:border-accent"
+        >
+          <option v-for="t in selectedTickets" :key="t.id" :value="t.id">
+            #{{ t.id }} {{ t.title }}
+          </option>
+        </select>
+      </label>
+
+      <!-- Source list (the non-destination selected tickets) -->
+      <div class="flex flex-col gap-1">
+        <ul class="flex flex-col gap-1">
+          <li
+            v-for="s in sources"
+            :key="s.id"
+            class="flex items-center gap-2 rounded border border-subtle bg-surface-alt px-3 py-2 text-sm"
+          >
+            <span class="text-tertiary">#{{ s.id }}</span>
+            <span class="truncate">{{ s.title }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Description preview (becomes the merge-marker comment body) -->
+      <FormTextarea v-model="description" :rows="5" />
+
+      <!-- Reason -->
+      <label class="flex flex-col gap-1.5 text-sm">
+        <span class="text-tertiary">{{ $t('ticket-merge-reason-label') }}</span>
+        <input
+          v-model="reason"
+          type="text"
+          :placeholder="$t('ticket-merge-reason-placeholder')"
+          class="w-full px-3 py-2 text-sm rounded border border-default bg-surface focus:outline-none focus:border-accent"
+        />
+      </label>
+
+      <!-- Customer notification -->
+      <div class="flex flex-col gap-1">
+        <Checkbox v-model="notifyCustomer" :label="$t('ticket-merge-notify-customer-label')" />
+        <span class="text-xs text-tertiary">{{ $t('ticket-merge-notify-customer-help') }}</span>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <Button variant="secondary" @click="emit('close')">
+          {{ $t('ticket-merge-cancel-button') }}
+        </Button>
+        <Button variant="primary" :disabled="!canSubmit" :loading="submitting" @click="submit">
+          {{ $t('ticket-merge-submit-button', { count }) }}
+        </Button>
+      </div>
+    </template>
+  </Modal>
+</template>

--- a/frontend/src/components/ticketComponents/MergeTicketsDialog.vue
+++ b/frontend/src/components/ticketComponents/MergeTicketsDialog.vue
@@ -16,11 +16,21 @@ import FormTextarea from '@/components/common/FormTextarea.vue'
 import Checkbox from '@/components/common/Checkbox.vue'
 import { useToastStore } from '@/stores/toast'
 import { mergeTickets } from '@/services/ticketService'
-import type { Ticket } from '@/types/ticket'
+
+/** Minimal ticket shape the dialog needs. Both the API `Ticket` and the
+ *  sync store's `SyncTicket` satisfy it, so the bulk bar can pass either.
+ *  `created` is optional; when absent the oldest-default falls back to
+ *  the lowest id (ids are monotonic, so the smallest is the oldest). */
+export interface MergeDialogTicket {
+  id: number
+  title: string
+  workflow_state_id?: number
+  created?: string
+}
 
 const props = defineProps<{
   open: boolean
-  selectedTickets: Ticket[]
+  selectedTickets: MergeDialogTicket[]
 }>()
 
 const emit = defineEmits<{
@@ -49,11 +59,15 @@ const sources = computed(() =>
   props.selectedTickets.filter((t) => t.id !== destinationId.value),
 )
 
-/** Oldest selected ticket by created timestamp (ISO strings sort
- *  lexicographically). The agent can override via the picker. */
-function oldest(tickets: Ticket[]): Ticket | null {
+/** Oldest selected ticket: by created timestamp when present (ISO
+ *  strings sort lexicographically), else by lowest id. The agent can
+ *  override via the picker. */
+function oldest(tickets: MergeDialogTicket[]): MergeDialogTicket | null {
   if (tickets.length === 0) return null
-  return [...tickets].sort((a, b) => (a.created || '').localeCompare(b.created || ''))[0]
+  return [...tickets].sort((a, b) => {
+    if (a.created && b.created) return a.created.localeCompare(b.created)
+    return a.id - b.id
+  })[0]
 }
 
 function seedDescription() {

--- a/frontend/src/components/ticketComponents/MergeTicketsDialog.vue
+++ b/frontend/src/components/ticketComponents/MergeTicketsDialog.vue
@@ -13,6 +13,7 @@ import { useFluent } from 'fluent-vue'
 import Modal from '@/components/Modal.vue'
 import Button from '@/components/common/Button.vue'
 import FormTextarea from '@/components/common/FormTextarea.vue'
+import FormInput from '@/components/common/FormInput.vue'
 import Checkbox from '@/components/common/Checkbox.vue'
 import { useToastStore } from '@/stores/toast'
 import { mergeTickets } from '@/services/ticketService'
@@ -46,6 +47,9 @@ const router = useRouter()
 
 const destinationId = ref<number | null>(null)
 const description = ref('')
+// The last auto-generated seed, so we only reseed on a destination
+// change while the agent hasn't edited the buffer.
+const lastSeed = ref('')
 const reason = ref('')
 const notifyCustomer = ref(false)
 const submitting = ref(false)
@@ -80,6 +84,17 @@ function seedDescription() {
     lines.push(`- #${s.id}: ${s.title}`)
   }
   description.value = lines.join('\n')
+  lastSeed.value = description.value
+}
+
+// Snapshot each ticket's workflow_state_id as the optimistic-lock
+// token. Re-taken on a 409 so an immediate retry uses fresh tokens.
+function snapshotStates() {
+  const snap: Record<number, number> = {}
+  for (const t of props.selectedTickets) {
+    if (t.workflow_state_id != null) snap[t.id] = t.workflow_state_id
+  }
+  stateSnapshot.value = snap
 }
 
 watch(
@@ -90,19 +105,16 @@ watch(
     reason.value = ''
     notifyCustomer.value = false
     submitting.value = false
-    const snap: Record<number, number> = {}
-    for (const t of props.selectedTickets) {
-      if (t.workflow_state_id != null) snap[t.id] = t.workflow_state_id
-    }
-    stateSnapshot.value = snap
+    snapshotStates()
     seedDescription()
   },
   { immediate: true },
 )
 
-// Re-seed the description when the agent changes the destination.
+// Re-seed when the destination changes, but only if the agent hasn't
+// edited the buffer (so we never clobber their wording).
 watch(destinationId, () => {
-  if (props.open) seedDescription()
+  if (props.open && description.value === lastSeed.value) seedDescription()
 })
 
 async function submit() {
@@ -130,9 +142,12 @@ async function submit() {
   } catch (err: unknown) {
     const status = (err as { response?: { status?: number } })?.response?.status
     if (status === 409) {
+      // Stale optimistic-lock token. Refresh the snapshot so the agent
+      // can retry immediately without reopening the dialog.
+      snapshotStates()
       toast.warning(fluent.$t('ticket-merge-conflict-toast'))
     } else {
-      toast.error(fluent.$t('ticket-merge-cancel-button'), String(err))
+      toast.error(fluent.$t('ticket-merge-error-toast'))
     }
   } finally {
     submitting.value = false
@@ -162,32 +177,30 @@ async function submit() {
       </label>
 
       <!-- Source list (the non-destination selected tickets) -->
-      <div class="flex flex-col gap-1">
-        <ul class="flex flex-col gap-1">
-          <li
-            v-for="s in sources"
-            :key="s.id"
-            class="flex items-center gap-2 rounded border border-subtle bg-surface-alt px-3 py-2 text-sm"
-          >
-            <span class="text-tertiary">#{{ s.id }}</span>
-            <span class="truncate">{{ s.title }}</span>
-          </li>
-        </ul>
-      </div>
+      <ul class="flex flex-col gap-1" :aria-label="$t('ticket-merge-sidebar-merged-in')">
+        <li
+          v-for="s in sources"
+          :key="s.id"
+          class="flex items-center gap-2 rounded border border-subtle bg-surface-alt px-3 py-2 text-sm"
+        >
+          <span class="text-tertiary">#{{ s.id }}</span>
+          <span class="truncate">{{ s.title }}</span>
+        </li>
+      </ul>
 
       <!-- Description preview (becomes the merge-marker comment body) -->
-      <FormTextarea v-model="description" :rows="5" />
+      <FormTextarea
+        v-model="description"
+        :label="$t('ticket-merge-marker-comment-header', { count })"
+        :rows="5"
+      />
 
       <!-- Reason -->
-      <label class="flex flex-col gap-1.5 text-sm">
-        <span class="text-tertiary">{{ $t('ticket-merge-reason-label') }}</span>
-        <input
-          v-model="reason"
-          type="text"
-          :placeholder="$t('ticket-merge-reason-placeholder')"
-          class="w-full px-3 py-2 text-sm rounded border border-default bg-surface focus:outline-none focus:border-accent"
-        />
-      </label>
+      <FormInput
+        v-model="reason"
+        :label="$t('ticket-merge-reason-label')"
+        :placeholder="$t('ticket-merge-reason-placeholder')"
+      />
 
       <!-- Customer notification -->
       <div class="flex flex-col gap-1">

--- a/frontend/src/components/ticketComponents/MergedInField.vue
+++ b/frontend/src/components/ticketComponents/MergedInField.vue
@@ -2,30 +2,27 @@
 Destination-side cross-reference: lists the source tickets merged into
 this one, under a "Merged in" heading. Sourced from the merge-history
 endpoint (the ticket's linked_tickets only carry ids, not relation
-types). Renders nothing when no merges target this ticket.
+types). Cached per ticket via Pinia Colada, so it renders instantly from
+cache on revisit and revalidates in the background. Renders nothing when
+no merges target this ticket.
 -->
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed } from 'vue'
+import { useQuery } from '@pinia/colada'
 import { fetchMergeHistory } from '@/services/ticketService'
 
 const props = defineProps<{ ticketId: number }>()
 
-const sourceIds = ref<number[]>([])
+const { data } = useQuery({
+  key: () => ['merge-history', props.ticketId],
+  query: () => fetchMergeHistory(props.ticketId),
+})
 
-async function load() {
-  try {
-    const history = await fetchMergeHistory(props.ticketId)
-    const ids = new Set<number>()
-    for (const ev of history.merge_events) {
-      for (const id of ev.source_ticket_ids) ids.add(id)
-    }
-    sourceIds.value = [...ids]
-  } catch {
-    sourceIds.value = []
-  }
-}
-
-watch(() => props.ticketId, load, { immediate: true })
+// Unique source ids across every merge that targeted this ticket.
+const sourceIds = computed<number[]>(() => {
+  const events = data.value?.merge_events ?? []
+  return [...new Set(events.flatMap((ev) => ev.source_ticket_ids))]
+})
 </script>
 
 <template>

--- a/frontend/src/components/ticketComponents/MergedInField.vue
+++ b/frontend/src/components/ticketComponents/MergedInField.vue
@@ -1,0 +1,45 @@
+<!--
+Destination-side cross-reference: lists the source tickets merged into
+this one, under a "Merged in" heading. Sourced from the merge-history
+endpoint (the ticket's linked_tickets only carry ids, not relation
+types). Renders nothing when no merges target this ticket.
+-->
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { fetchMergeHistory } from '@/services/ticketService'
+
+const props = defineProps<{ ticketId: number }>()
+
+const sourceIds = ref<number[]>([])
+
+async function load() {
+  try {
+    const history = await fetchMergeHistory(props.ticketId)
+    const ids = new Set<number>()
+    for (const ev of history.merge_events) {
+      for (const id of ev.source_ticket_ids) ids.add(id)
+    }
+    sourceIds.value = [...ids]
+  } catch {
+    sourceIds.value = []
+  }
+}
+
+watch(() => props.ticketId, load, { immediate: true })
+</script>
+
+<template>
+  <div v-if="sourceIds.length > 0" class="flex flex-col gap-1.5">
+    <span class="text-xs font-semibold text-secondary">{{ $t('ticket-merge-sidebar-merged-in') }}</span>
+    <div class="flex flex-wrap gap-1.5">
+      <RouterLink
+        v-for="id in sourceIds"
+        :key="id"
+        :to="`/tickets/${id}`"
+        class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border border-subtle bg-surface-alt text-secondary hover:text-primary hover:border-default transition-colors"
+      >
+        #{{ id }}
+      </RouterLink>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/ticketComponents/MergedIntoBanner.vue
+++ b/frontend/src/components/ticketComponents/MergedIntoBanner.vue
@@ -1,0 +1,47 @@
+<!--
+Persistent banner shown above the ticket details panel when the ticket
+is a merge source (merged_into_ticket_id is set). Links through to the
+destination. The ticket is terminal: its comments and article are
+read-only (gated separately in TicketView).
+-->
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import Icon from '@/components/common/Icon.vue'
+
+const props = defineProps<{
+  targetId: number
+  actor?: string | null
+  when?: string | null
+}>()
+
+const router = useRouter()
+
+function openDestination() {
+  router.push(`/tickets/${props.targetId}`)
+}
+</script>
+
+<template>
+  <div
+    class="flex items-center gap-3 rounded-lg border border-default bg-surface-alt px-4 py-2.5 text-sm"
+    role="status"
+  >
+    <Icon name="info" class="w-4 h-4 text-tertiary shrink-0" />
+    <span class="text-secondary">
+      {{
+        $t('ticket-merge-banner-merged-into', {
+          target_id: targetId,
+          actor: actor || '',
+          when: when || '',
+        })
+      }}
+    </span>
+    <button
+      type="button"
+      class="ml-auto inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-accent hover:bg-accent/10 transition-colors"
+      @click="openDestination"
+    >
+      {{ $t('ticket-merge-banner-open-destination') }}
+    </button>
+  </div>
+</template>

--- a/frontend/src/components/ticketComponents/MergedIntoBanner.vue
+++ b/frontend/src/components/ticketComponents/MergedIntoBanner.vue
@@ -1,24 +1,17 @@
 <!--
 Persistent banner shown above the ticket details panel when the ticket
 is a merge source (merged_into_ticket_id is set). Links through to the
-destination. The ticket is terminal: its comments and article are
-read-only (gated separately in TicketView).
+destination. The ticket is terminal: its comments are read-only (gated
+separately in TicketView).
 -->
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
 import Icon from '@/components/common/Icon.vue'
 
-const props = defineProps<{
+defineProps<{
   targetId: number
   actor?: string | null
   when?: string | null
 }>()
-
-const router = useRouter()
-
-function openDestination() {
-  router.push(`/tickets/${props.targetId}`)
-}
 </script>
 
 <template>
@@ -36,12 +29,11 @@ function openDestination() {
         })
       }}
     </span>
-    <button
-      type="button"
+    <RouterLink
+      :to="`/tickets/${targetId}`"
       class="ml-auto inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-accent hover:bg-accent/10 transition-colors"
-      @click="openDestination"
     >
       {{ $t('ticket-merge-banner-open-destination') }}
-    </button>
+    </RouterLink>
   </div>
 </template>

--- a/frontend/src/components/ticketComponents/TicketActivity.vue
+++ b/frontend/src/components/ticketComponents/TicketActivity.vue
@@ -304,6 +304,16 @@ function phraseFor(ev: TicketActivityEvent, ctx: PhraseContext): string {
     }
     case 'ticket.updated':
       return t('ticket-activity-phrase-updated')
+    case 'ticket.merged': {
+      const count = (data.source_ticket_ids as number[] | undefined)?.length ?? 0
+      return t('ticket-activity-phrase-merged', { count })
+    }
+    case 'ticket.merged_into': {
+      const dest = data.merged_into_ticket_id as number | undefined
+      return dest != null
+        ? t('ticket-activity-phrase-merged-into', { target_id: dest })
+        : t('ticket-activity-phrase-generic')
+    }
     case 'comment.created': {
       if (data.is_internal) return t('ticket-activity-phrase-internal-note')
       const cv = readCreatedVia(ev)

--- a/frontend/src/components/views/TicketsBulkBar.vue
+++ b/frontend/src/components/views/TicketsBulkBar.vue
@@ -22,6 +22,9 @@ import { computed, ref } from 'vue'
 import Popover from '@/components/common/Popover.vue'
 import Icon from '@/components/common/Icon.vue'
 import UserSelectionModal from '@/components/UserSelectionModal.vue'
+import MergeTicketsDialog, {
+  type MergeDialogTicket,
+} from '@/components/ticketComponents/MergeTicketsDialog.vue'
 import type { PopoverAnchor } from '@/composables/usePopover'
 import { useWorkflowStatesStore } from '@/stores/workflowStates'
 import { PRIORITY_OPTIONS } from '@/constants/ticketOptions'
@@ -133,6 +136,24 @@ function pickPriority(priority: string): void {
 function onAssignSelect(user: { uuid: string }): void {
   showAssignModal.value = false
   emit('set-assignee', user.uuid, ids.value)
+}
+
+// ---- Merge ----------------------------------------------------
+const showMergeDialog = ref(false)
+// Resolve the selection to the minimal shape the merge dialog needs.
+// (The sync store's SyncTicket carries id / title / workflow_state_id;
+// merged tickets are filtered out of the list, and the backend rejects
+// an already-merged source, so the count check is enough here.)
+const selectedTickets = computed<MergeDialogTicket[]>(() =>
+  ids.value
+    .map((id) => ticketsStore.byId(id).value)
+    .filter((t): t is NonNullable<typeof t> => !!t)
+    .map((t) => ({ id: t.id, title: t.title, workflow_state_id: t.workflow_state_id })),
+)
+const canMerge = computed(() => selectedTickets.value.length >= 2)
+function onMerged(): void {
+  showMergeDialog.value = false
+  emit('clear')
 }
 </script>
 
@@ -259,6 +280,20 @@ function onAssignSelect(user: { uuid: string }): void {
         <span>{{ $t('ticket-list-bulk-assign') }}</span>
       </button>
 
+      <!-- Merge — only when 2+ tickets are selected and none is
+           already merged. Opens the merge dialog with the selection. -->
+      <template v-if="canMerge">
+        <span class="h-4 w-px bg-default mx-1" aria-hidden="true" />
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-secondary hover:text-primary hover:bg-surface-hover transition-colors"
+          @click="showMergeDialog = true"
+        >
+          <Icon name="link" class="w-3.5 h-3.5" />
+          <span>{{ $t('ticket-list-bulk-merge') }}</span>
+        </button>
+      </template>
+
       <span class="h-4 w-px bg-default mx-1" aria-hidden="true" />
 
       <button
@@ -277,5 +312,12 @@ function onAssignSelect(user: { uuid: string }): void {
     :show="showAssignModal"
     @close="showAssignModal = false"
     @select-user="onAssignSelect"
+  />
+
+  <MergeTicketsDialog
+    :open="showMergeDialog"
+    :selected-tickets="selectedTickets"
+    @close="showMergeDialog = false"
+    @merged="onMerged"
   />
 </template>

--- a/frontend/src/composables/useTicketSSE.ts
+++ b/frontend/src/composables/useTicketSSE.ts
@@ -20,7 +20,11 @@ import {
   type ViewerInfo,
   type ViewersChangedEventData,
   type TicketFieldPreviewedEventData,
+  type TicketMergedEventData,
 } from "@/types/sse";
+import { useToastStore } from "@/stores/toast";
+import { useFluent } from "fluent-vue";
+import { getCommentsByTicketId } from "@/services/ticketService";
 
 // Enable debug logging only in development
 const DEBUG_SSE = import.meta.env.DEV && import.meta.env.VITE_DEBUG_SSE === 'true';
@@ -53,6 +57,8 @@ export function useTicketSSE(
   } = useSSE();
 
   const authStore = useAuthStore();
+  const toast = useToastStore();
+  const fluent = useFluent();
   const titleManager = useTitleManager();
   const recentTicketsStore = useRecentTicketsStore();
   const mutations = useTicketMutations(ticket);
@@ -201,6 +207,33 @@ export function useTicketSSE(
     }
 
     highlightComment(newComment.id);
+  }
+
+  // Handle a merge that involves the open ticket.
+  async function handleTicketMerged(rawData: unknown): Promise<void> {
+    const data = unwrapEventData(rawData as TicketMergedEventData);
+    if (!ticket.value) return;
+    const id = ticket.value.id;
+
+    if (data.source_ticket_ids?.includes(id)) {
+      // This source was just merged. Reflect the terminal state live so
+      // the persistent merged-into banner renders and the composer goes
+      // read-only without a reload.
+      ticket.value.merged_into_ticket_id = data.target_ticket_id;
+      ticket.value.merged_by_user_uuid = data.actor_uuid;
+      ticket.value.merged_at = new Date().toISOString();
+      toast.info(
+        fluent.$t('ticket-merge-toast-just-merged', { target_id: data.target_ticket_id }),
+      );
+    } else if (id === data.target_ticket_id) {
+      // A merge landed on this destination. Refresh the comment timeline
+      // so the merge-marker comment appears.
+      try {
+        ticket.value.commentsAndAttachments = await getCommentsByTicketId(id);
+      } catch {
+        // Best-effort; the next navigation picks it up.
+      }
+    }
   }
 
   // Handle comment deleted
@@ -368,7 +401,8 @@ export function useTicketSSE(
     | "project-assigned"
     | "project-unassigned"
     | "viewers-changed"
-    | "ticket-field-previewed";
+    | "ticket-field-previewed"
+    | "ticket-merged";
 
   // Event handler type for SSE events
   type SSEEventHandler = (data: unknown) => void | Promise<void>;
@@ -387,6 +421,7 @@ export function useTicketSSE(
     "project-unassigned": handleProjectUnassigned,
     "viewers-changed": handleViewersChanged,
     "ticket-field-previewed": handleTicketFieldPreviewed,
+    "ticket-merged": handleTicketMerged,
   };
 
   // Setup event listeners

--- a/frontend/src/services/sseService.ts
+++ b/frontend/src/services/sseService.ts
@@ -17,6 +17,7 @@ const ALL_SSE_EVENT_TYPES = [
   "ticket-updated",
   "ticket-created",
   "ticket-deleted",
+  "ticket-merged",
   "comment-added",
   "comment-deleted",
   "asset-linked",

--- a/frontend/src/services/ticketService.ts
+++ b/frontend/src/services/ticketService.ts
@@ -1,7 +1,16 @@
 import apiClient from './apiConfig';
 import { logger } from '@/utils/logger';
 import { RequestManager } from '@/utils/requestManager';
-import type { Ticket, RecentTicket, Comment, Attachment, Asset, Project } from '@/types/ticket';
+import type {
+  Ticket,
+  RecentTicket,
+  Comment,
+  Attachment,
+  Asset,
+  Project,
+  MergeResponse,
+  MergeHistory,
+} from '@/types/ticket';
 import type { UserInfo } from '@/types/user';
 import type { PaginatedResponse } from '@/types/pagination';
 import type { CommentWithAttachments } from '@/types/comment';
@@ -158,6 +167,37 @@ export const unlinkTicket = async (ticketId: number, linkedTicketId: number): Pr
     await apiClient.delete(`/tickets/${ticketId}/unlink/${linkedTicketId}`);
   } catch (error) {
     logger.error('Failed to unlink tickets', { error, ticketId, linkedTicketId });
+    throw error;
+  }
+};
+
+// Merge one or more source tickets into a destination ticket.
+export interface MergeTicketsInput {
+  destination_ticket_id: number
+  source_ticket_ids: number[]
+  reason: string | null
+  notify_customer: boolean
+  marker_body: string | null
+  expected_state: { ticket_id: number; workflow_state_id: number }[]
+}
+
+export const mergeTickets = async (input: MergeTicketsInput): Promise<MergeResponse> => {
+  try {
+    const response = await apiClient.post('/tickets/merge', input);
+    return response.data;
+  } catch (error) {
+    logger.error('Failed to merge tickets', { error, input });
+    throw error;
+  }
+};
+
+// Fetch the merge history for a ticket (both directions).
+export const fetchMergeHistory = async (ticketId: number): Promise<MergeHistory> => {
+  try {
+    const response = await apiClient.get(`/tickets/${ticketId}/merge-history`);
+    return response.data;
+  } catch (error) {
+    logger.error('Failed to fetch merge history', { error, ticketId });
     throw error;
   }
 };

--- a/frontend/src/types/sse.ts
+++ b/frontend/src/types/sse.ts
@@ -120,6 +120,18 @@ export interface TicketDeletedEventData {
 }
 
 /**
+ * ticket-merged event data. Broadcast when a merge commits so open
+ * viewers react: source viewers show the merged-into banner, the
+ * destination refetches.
+ */
+export interface TicketMergedEventData {
+  target_ticket_id: number
+  source_ticket_ids: number[]
+  actor_uuid: string
+  merge_event_id: number
+}
+
+/**
  * project-assigned / project-unassigned event data
  */
 export interface ProjectEventData {

--- a/frontend/src/types/ticket.ts
+++ b/frontend/src/types/ticket.ts
@@ -108,6 +108,50 @@ export interface Ticket {
    *  to "watching"; comment notifications fan out to every uuid
    *  in this set (in addition to requester / assignee). */
   watcher_uuids?: string[]
+  /** When this ticket was merged into another, the destination's id;
+   *  null when the ticket is not a merge source. Set together with
+   *  `merged_at` / `merged_by_user_uuid`. A non-null value makes the
+   *  ticket terminal: read-only UI, and future channel replies reroute
+   *  to the destination. */
+  merged_into_ticket_id?: number | null
+  merged_at?: string | null
+  merged_by_user_uuid?: string | null
+  merge_reason?: string | null
+}
+
+/** One merge that consumed sources into a ticket, from the
+ *  `ticket.merged` activity event. */
+export interface TicketMergeEvent {
+  event_id: number
+  merged_at: string
+  merged_by_user_uuid: string | null
+  merged_by_name: string | null
+  source_ticket_ids: number[]
+  reason: string | null
+  comments_moved: number
+  merge_marker_comment_id: number | null
+}
+
+/** Merge history for a ticket, from both directions. */
+export interface MergeHistory {
+  merged_into: {
+    destination_id: number
+    merged_at: string | null
+    merged_by: string | null
+    reason: string | null
+  } | null
+  merge_events: TicketMergeEvent[]
+}
+
+/** Response body of POST /api/tickets/merge. */
+export interface MergeResponse {
+  merge_event_id: number
+  destination_ticket: Ticket
+  merged_sources: Ticket[]
+  comments_moved: number
+  channel_messages_rerouted: number
+  watchers_added_to_destination: number
+  merge_marker_comment_id: number
 }
 
 export interface RecentTicket {

--- a/frontend/src/views/TicketView.vue
+++ b/frontend/src/views/TicketView.vue
@@ -29,6 +29,8 @@ import TicketDetails from "@/components/ticketComponents/TicketDetails.vue";
 import TicketActivity from "@/components/ticketComponents/TicketActivity.vue";
 import DeviceSelectionModal from "@/components/ticketComponents/AssetSelectionModal.vue";
 import CommentsAndAttachments from "@/components/ticketComponents/CommentsAndAttachments.vue";
+import MergedIntoBanner from "@/components/ticketComponents/MergedIntoBanner.vue";
+import MergedInField from "@/components/ticketComponents/MergedInField.vue";
 import LinkedTicketModal from "@/components/ticketComponents/LinkedTicketModal.vue";
 import ProjectSelectionModal from "@/components/ticketComponents/ProjectSelectionModal.vue";
 import TicketGapFlag from "@/components/ticketComponents/TicketGapFlag.vue";
@@ -599,6 +601,13 @@ useCreateTicketAction();
                             @drop.prevent="handleLinkDrop"
                             class="contents"
                         >
+                            <MergedIntoBanner
+                                v-if="ticket.merged_into_ticket_id != null"
+                                :target-id="ticket.merged_into_ticket_id"
+                                :actor="ticket.merged_by_user_uuid"
+                                :when="ticket.merged_at"
+                            />
+                            <MergedInField v-if="ticket" :ticket-id="ticket.id" />
                             <TicketDetails
                                 :ticket="ticket"
                                 :created-date="formattedCreatedDate"
@@ -730,6 +739,7 @@ useCreateTicketAction();
                                 :recently-added-comment-ids="
                                     recentlyAddedCommentIds
                                 "
+                                :readonly="ticket.merged_into_ticket_id != null"
                                 @add-comment="addComment"
                                 @delete-attachment="deleteAttachment"
                                 @delete-comment="deleteComment"

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -375,6 +375,7 @@ ticket-merge-notify-customer-help = Sends a templated reply on each source ticke
 ticket-merge-submit-button = Merge { $count } tickets
 ticket-merge-cancel-button = Cancel
 ticket-merge-conflict-toast = Some of these tickets changed since you opened this dialog. Refresh and retry.
+ticket-merge-error-toast = Could not merge the tickets. Please try again.
 ticket-merge-success-toast = Merged { $count } tickets into #{ $target_id }
 ticket-merge-marker-comment-header = Merged { $count } tickets into this one
 ticket-merge-banner-merged-into = This ticket was merged into #{ $target_id } by { $actor } on { $when }.

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -357,6 +357,10 @@ settings-localization-save-failed = Failed to save preferences
 # bypasses this entirely (custom copy is the source of truth).
 auto-ack-default-template = Your request (#{ $ticket_id }) has been received and is being reviewed by our support team. To add additional comments, reply to this email.
 
+# Sent to a customer when their ticket is merged into another, only if
+# the agent ticks "Tell the customer" in the merge dialog.
+merge-notification-customer-template = We're combining your request with a related ticket so our team can respond once. We'll continue to update you on this thread.
+
 # Inbox-time connecting copy. The bare time string ("3:42 PM"),
 # weekday ("Mon"), and relative phrases ("5 minutes ago") all
 # come from Intl.DateTimeFormat / Intl.RelativeTimeFormat in the

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -299,6 +299,7 @@ ticket-list-bulk-actions-aria = Bulk actions
 ticket-list-bulk-status = Status
 ticket-list-bulk-priority = Priority
 ticket-list-bulk-assign = Assign
+ticket-list-bulk-merge = Merge
 ticket-list-bulk-clear-title = Clear selection (Esc)
 ticket-list-bulk-clear = Clear
 ticket-list-row-density-aria = Row density

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -380,6 +380,7 @@ ticket-merge-marker-comment-header = Merged { $count } tickets into this one
 ticket-merge-banner-merged-into = This ticket was merged into #{ $target_id } by { $actor } on { $when }.
 ticket-merge-banner-open-destination = Open destination
 ticket-merge-sidebar-merged-in = Merged in
+ticket-merge-toast-just-merged = This ticket was just merged into #{ $target_id }.
 
 # Inbox-time connecting copy. The bare time string ("3:42 PM"),
 # weekday ("Mon"), and relative phrases ("5 minutes ago") all

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -361,6 +361,25 @@ auto-ack-default-template = Your request (#{ $ticket_id }) has been received and
 # the agent ticks "Tell the customer" in the merge dialog.
 merge-notification-customer-template = We're combining your request with a related ticket so our team can respond once. We'll continue to update you on this thread.
 
+# Ticket merge dialog + activity surfaces.
+ticket-merge-dialog-title = Merge { $count ->
+    [one] 1 ticket
+   *[other] { $count } tickets
+  }
+ticket-merge-destination-label = Destination ticket
+ticket-merge-reason-label = Reason (optional)
+ticket-merge-reason-placeholder = What ties these tickets together?
+ticket-merge-notify-customer-label = Tell the customer their ticket was merged
+ticket-merge-notify-customer-help = Sends a templated reply on each source ticket's existing channel thread. Off by default.
+ticket-merge-submit-button = Merge { $count } tickets
+ticket-merge-cancel-button = Cancel
+ticket-merge-conflict-toast = Some of these tickets changed since you opened this dialog. Refresh and retry.
+ticket-merge-success-toast = Merged { $count } tickets into #{ $target_id }
+ticket-merge-marker-comment-header = Merged { $count } tickets into this one
+ticket-merge-banner-merged-into = This ticket was merged into #{ $target_id } by { $actor } on { $when }.
+ticket-merge-banner-open-destination = Open destination
+ticket-merge-sidebar-merged-in = Merged in
+
 # Inbox-time connecting copy. The bare time string ("3:42 PM"),
 # weekday ("Mon"), and relative phrases ("5 minutes ago") all
 # come from Intl.DateTimeFormat / Intl.RelativeTimeFormat in the

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -3667,6 +3667,11 @@ ticket-activity-phrase-replied-via = replied via { $channel }
 ticket-activity-phrase-comment-via = added a comment via { $channel }
 ticket-activity-phrase-commented = commented on this ticket
 ticket-activity-phrase-comment-deleted = deleted a comment
+ticket-activity-phrase-merged = merged { $count ->
+    [one] 1 ticket
+   *[other] { $count } tickets
+  } into this one
+ticket-activity-phrase-merged-into = merged this ticket into #{ $target_id }
 ticket-activity-phrase-generic = made a change
 
 # Ticket: tag picker sidebar surface (TicketTagsField).

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -5091,3 +5091,30 @@ gantt-tickets-of-total-in-view =
     }
 saved-view-name-this = Nommer cette vue
 saved-view-copy-suffix = Copie de { $name }
+
+# Fusion de tickets.
+merge-notification-customer-template = Nous regroupons votre demande avec un ticket associé afin que notre équipe puisse répondre une seule fois. Nous continuerons à vous tenir informé sur ce fil.
+ticket-merge-dialog-title = Fusionner { $count ->
+    [one] 1 ticket
+   *[other] { $count } tickets
+  }
+ticket-merge-destination-label = Ticket de destination
+ticket-merge-reason-label = Raison (facultatif)
+ticket-merge-reason-placeholder = Qu'est-ce qui relie ces tickets ?
+ticket-merge-notify-customer-label = Informer le client que son ticket a été fusionné
+ticket-merge-notify-customer-help = Envoie une réponse type sur le fil existant de chaque ticket source. Désactivé par défaut.
+ticket-merge-submit-button = Fusionner { $count } tickets
+ticket-merge-cancel-button = Annuler
+ticket-merge-conflict-toast = Certains de ces tickets ont changé depuis l'ouverture de cette fenêtre. Actualisez et réessayez.
+ticket-merge-success-toast = { $count } tickets fusionnés dans le #{ $target_id }
+ticket-merge-marker-comment-header = { $count } tickets fusionnés dans celui-ci
+ticket-merge-banner-merged-into = Ce ticket a été fusionné dans le #{ $target_id } par { $actor } le { $when }.
+ticket-merge-banner-open-destination = Ouvrir la destination
+ticket-merge-sidebar-merged-in = Fusionnés ici
+ticket-merge-toast-just-merged = Ce ticket vient d'être fusionné dans le #{ $target_id }.
+ticket-list-bulk-merge = Fusionner
+ticket-activity-phrase-merged = a fusionné { $count ->
+    [one] 1 ticket
+   *[other] { $count } tickets
+  } dans celui-ci
+ticket-activity-phrase-merged-into = a fusionné ce ticket dans le #{ $target_id }

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -5106,6 +5106,7 @@ ticket-merge-notify-customer-help = Envoie une réponse type sur le fil existant
 ticket-merge-submit-button = Fusionner { $count } tickets
 ticket-merge-cancel-button = Annuler
 ticket-merge-conflict-toast = Certains de ces tickets ont changé depuis l'ouverture de cette fenêtre. Actualisez et réessayez.
+ticket-merge-error-toast = Impossible de fusionner les tickets. Veuillez réessayer.
 ticket-merge-success-toast = { $count } tickets fusionnés dans le #{ $target_id }
 ticket-merge-marker-comment-header = { $count } tickets fusionnés dans celui-ci
 ticket-merge-banner-merged-into = Ce ticket a été fusionné dans le #{ $target_id } par { $actor } le { $when }.

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -5097,6 +5097,7 @@ ticket-merge-notify-customer-help = Stuurt een standaardantwoord op het bestaand
 ticket-merge-submit-button = { $count } tickets samenvoegen
 ticket-merge-cancel-button = Annuleren
 ticket-merge-conflict-toast = Sommige van deze tickets zijn gewijzigd sinds u dit venster opende. Vernieuw en probeer opnieuw.
+ticket-merge-error-toast = Kan de tickets niet samenvoegen. Probeer het opnieuw.
 ticket-merge-success-toast = { $count } tickets samengevoegd in #{ $target_id }
 ticket-merge-marker-comment-header = { $count } tickets samengevoegd in dit ticket
 ticket-merge-banner-merged-into = Dit ticket is samengevoegd in #{ $target_id } door { $actor } op { $when }.

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -5082,3 +5082,30 @@ gantt-tickets-of-total-in-view =
     }
 saved-view-name-this = Geef deze weergave een naam
 saved-view-copy-suffix = Kopie van { $name }
+
+# Tickets samenvoegen.
+merge-notification-customer-template = We voegen uw verzoek samen met een gerelateerd ticket zodat ons team in één keer kan reageren. We houden u op de hoogte in dit gesprek.
+ticket-merge-dialog-title = { $count ->
+    [one] 1 ticket samenvoegen
+   *[other] { $count } tickets samenvoegen
+  }
+ticket-merge-destination-label = Doelticket
+ticket-merge-reason-label = Reden (optioneel)
+ticket-merge-reason-placeholder = Wat verbindt deze tickets?
+ticket-merge-notify-customer-label = De klant laten weten dat hun ticket is samengevoegd
+ticket-merge-notify-customer-help = Stuurt een standaardantwoord op het bestaande gesprek van elk bronticket. Standaard uit.
+ticket-merge-submit-button = { $count } tickets samenvoegen
+ticket-merge-cancel-button = Annuleren
+ticket-merge-conflict-toast = Sommige van deze tickets zijn gewijzigd sinds u dit venster opende. Vernieuw en probeer opnieuw.
+ticket-merge-success-toast = { $count } tickets samengevoegd in #{ $target_id }
+ticket-merge-marker-comment-header = { $count } tickets samengevoegd in dit ticket
+ticket-merge-banner-merged-into = Dit ticket is samengevoegd in #{ $target_id } door { $actor } op { $when }.
+ticket-merge-banner-open-destination = Doelticket openen
+ticket-merge-sidebar-merged-in = Samengevoegd in
+ticket-merge-toast-just-merged = Dit ticket is zojuist samengevoegd in #{ $target_id }.
+ticket-list-bulk-merge = Samenvoegen
+ticket-activity-phrase-merged = heeft { $count ->
+    [one] 1 ticket
+   *[other] { $count } tickets
+  } samengevoegd in dit ticket
+ticket-activity-phrase-merged-into = heeft dit ticket samengevoegd in #{ $target_id }


### PR DESCRIPTION
## Summary

Implements ticket merge per `docs/ticket-merge-plan.md`:

- One-transaction lifecycle in `repository::ticket_merge::execute_merge`: advisory-locked pre-flight, atomic move of comments and channel messages and watchers (OR-union of notify flags), project/cycle/asset union with source clear, tag/doc accumulation, linked-tickets bidirectional rewrite, `duplicate_of` edges, structured merge-marker comment, `ticket.merged` + `ticket.merged_into` sync events stitched via the actor's correlation_id.
- `POST /api/tickets/merge` + `GET /api/tickets/{id}/merge-history`, Agent role required, structured `{ error, code }` envelope (`MERGE_VALIDATION` 400, `MERGE_STATE_CONFLICT` 409).
- Live SSE: `TicketMerged` broadcast + per-source `ticket.updated`, so open viewers reflect the terminal state without a reload.
- Opt-in customer notification (off by default), enqueued post-commit and best-effort.
- Frontend: dialog (FormInput/FormTextarea, optimistic-lock snapshot, 409 refresh-and-retry), bulk action in TicketsBulkBar, MergedIntoBanner, MergedInField (Pinia Colada cached), activity-feed phrases, hidden composer on merged sources.
- fr-FR + nl-NL translations in the same PR (native review still pending per the i18n workflow).

## Non-blocking follow-ups

- Source preflight only checks `merged_into_ticket_id IS NOT NULL`, not `workflow_state.category = 'merged'`. The `tickets_merge_complete` CHECK plus the always-atomic update means this gap is unreachable from production code paths; a defense-in-depth check would be cheap if a follow-up wanted it.
- The handler's r2d2 connection is held across the SSE broadcast loop. Release-and-reacquire would be marginally better under load.
- Pre-existing: new workspaces created via `repository::workspaces::create_workspace` don't seed any workflow_states; merge inherits this gap (every state has it, not just Merged).