### PR TITLE
fix(oauth_provisioning): hard-fail email-fallback on identity attach error

### DIFF
--- a/backend/src/services/oauth_provisioning.rs
+++ b/backend/src/services/oauth_provisioning.rs
@@ -36,8 +36,8 @@
 //! so the eager endpoint can pick its 201/200 response code and
 //! the lazy caller can ignore the bool.
 
-use diesel::result::Error as DieselError;
-use tracing::{error, warn};
+use diesel::result::{DatabaseErrorKind, Error as DieselError};
+use tracing::error;
 
 use crate::db::DbConnection;
 use crate::models::{NewUserAuthIdentity, NewUserEmail, User, UserRole};
@@ -138,22 +138,43 @@ pub fn find_or_create_projected_user(
                         metadata: metadata.clone(),
                         password_hash: password_hash.clone(),
                     };
-                    if let Err(e) = user_auth_identities::create_identity(new_identity, conn) {
-                        warn!(
-                            iss = %iss,
-                            user_uuid = %user.uuid,
-                            error = ?e,
-                            "found user by email but failed to attach OIDC identity; \
-                             proceeding without identity row"
-                        );
-                    } else {
-                        // Mirror the OIDC-provided email into
-                        // user_emails if it isn't already there.
-                        // Matches the existing lazy path's
-                        // diagnostic-on-error treatment.
-                        ensure_email_linked(conn, &user, &iss, &email);
+                    // Step 1 found no identity under (iss, sub), so a
+                    // UniqueViolation here means a SEPARATE identity row
+                    // already owns (iss, sub) and points at a different
+                    // user. Silently linking would route the projected
+                    // workspace member to user A while OIDC login would
+                    // resolve (iss, sub) to user B at line 123, so B
+                    // would log in with no membership and access would
+                    // be broken with no failure surfaced. Surface as a
+                    // hard error instead. The transient case (any other
+                    // DieselError) also returns Err so the control
+                    // plane retries via the idempotency key rather than
+                    // being told `created: false` for a row we did not
+                    // actually link.
+                    match user_auth_identities::create_identity(new_identity, conn) {
+                        Ok(_) => {
+                            // Mirror the OIDC-provided email into
+                            // user_emails if it isn't already there.
+                            ensure_email_linked(conn, &user, &iss, &email);
+                            ProjectionOutcome::Existed(user)
+                        }
+                        Err(DieselError::DatabaseError(
+                            DatabaseErrorKind::UniqueViolation,
+                            _,
+                        )) => {
+                            return Err(format!(
+                                "OIDC identity ({iss}, {sub}) is already attached to a \
+                                 different user; refusing to silently link to the \
+                                 email-matched user {user_uuid}",
+                                user_uuid = user.uuid,
+                            ));
+                        }
+                        Err(e) => {
+                            return Err(format!(
+                                "attach OIDC identity to email-matched user: {e:?}"
+                            ));
+                        }
                     }
-                    ProjectionOutcome::Existed(user)
                 }
                 Err(_) => {
                     // --- 3. create fresh user + identity + email ---


### PR DESCRIPTION
## Summary

Audit finding on the eager owner-projection path (M5 internal callback):
the email-fallback branch in `find_or_create_projected_user` swallowed
`create_identity` errors with a `warn!` and reported the user as
`Existed`. On a `UniqueViolation` against `(iss, sub)`, the row was
never attached to the email-matched user, but the eager endpoint
still returned `200 created: false` to the control plane. Worst case:
the workspace membership pointed at user A, the OIDC identity stayed
on user B, and on first login the owner landed without access with
no failure surfaced.

This change distinguishes the two error kinds in the fallback branch:

- `DatabaseErrorKind::UniqueViolation`: return Err with both the
  projected `(iss, sub)` and the email-matched user's UUID, so an
  operator inspecting logs can spot the cross-link.
- Any other `DieselError`: also return Err, so the control plane
  retries via the idempotency key rather than being told `created: false`
  for an identity row that was never written.

The fresh-user branch (step 3 of the resolution rules) already
returned Err on attach failure; only step 2 was asymmetric.

## Related

A companion update to `docs/m5-integration-contract.md` (not tracked
in git because `docs/` is gitignored) calls out the operational
dependency: `handlers::auth_providers::find_or_create_oauth_user`
uses `auth_providers.provider_type` as the lookup `iss` rather than
extracting it from the id_token, so the operator wiring the M5 OIDC
provider row must set `provider_type = 'https://api.nosdesk.com/'`
byte-identically. A staging-login assertion comparing the stored
`provider_type` to the projected value is the only real way to
verify byte-identicality.