### PR TITLE
feat(rules): unified rules engine, Phase 1 (manual surface)

### DIFF
--- a/backend/data/starter-rules.json
+++ b/backend/data/starter-rules.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "ack-and-acknowledge",
+    "name_en": "Acknowledge and triage",
+    "name_fr": "Accuser réception et trier",
+    "name_nl": "Bevestigen en triage",
+    "description_en": "Quick acknowledgement reply to confirm the ticket reached us and set status to in-progress.",
+    "description_fr": "Réponse rapide pour confirmer la réception du ticket et passer en cours.",
+    "description_nl": "Snelle bevestiging dat het ticket is ontvangen en de status op in behandeling zetten.",
+    "trigger_kind": "manual",
+    "conditions": [],
+    "actions": [
+      {
+        "kind": "reply",
+        "config": {
+          "visibility": "public",
+          "body": "Hi {{customer_name}},\n\nThanks for reaching out about ticket #{{ticket_id}}. We've seen it and are looking into it now.\n\nCheers,\n{{agent_first_name}}"
+        }
+      }
+    ]
+  },
+  {
+    "id": "request-more-info",
+    "name_en": "Request more information",
+    "name_fr": "Demander plus d'informations",
+    "name_nl": "Meer informatie vragen",
+    "description_en": "Polite ask for steps to reproduce or additional context. Keeps the ticket open.",
+    "description_fr": "Demande polie de plus de contexte ou d'étapes de reproduction. Garde le ticket ouvert.",
+    "description_nl": "Beleefd verzoek om reproductiestappen of meer context. Houdt het ticket open.",
+    "trigger_kind": "manual",
+    "conditions": [],
+    "actions": [
+      {
+        "kind": "reply",
+        "config": {
+          "visibility": "public",
+          "body": "Hi {{customer_name}},\n\nCould you share a few more details? Specifically:\n\n- What were you trying to do when the issue happened?\n- Any error messages you saw?\n- Roughly when did it start?\n\nThanks,\n{{agent_first_name}}"
+        }
+      }
+    ]
+  },
+  {
+    "id": "mark-resolved-with-summary",
+    "name_en": "Resolve with summary",
+    "name_fr": "Résoudre avec résumé",
+    "name_nl": "Oplossen met samenvatting",
+    "description_en": "Send a wrap-up reply summarising what was done and close the ticket.",
+    "description_fr": "Envoyer une réponse de clôture résumant ce qui a été fait et clore le ticket.",
+    "description_nl": "Een afsluitend antwoord met samenvatting versturen en het ticket sluiten.",
+    "trigger_kind": "manual",
+    "conditions": [],
+    "actions": [
+      {
+        "kind": "reply",
+        "config": {
+          "visibility": "public",
+          "body": "Hi {{customer_name}},\n\nWe've sorted this out. If anything else comes up, just reply to this thread and the ticket will reopen automatically.\n\nCheers,\n{{agent_first_name}}"
+        }
+      }
+    ]
+  },
+  {
+    "id": "escalate-to-on-call",
+    "name_en": "Escalate to on-call",
+    "name_fr": "Escalader à l'astreinte",
+    "name_nl": "Escaleren naar pikettelefoon",
+    "description_en": "Add an escalated tag, drop an internal note for the next pager. No customer-facing reply.",
+    "description_fr": "Ajouter une étiquette escaladée, ajouter une note interne pour le prochain bipeur. Pas de réponse client.",
+    "description_nl": "Voeg een escalated-tag toe en laat een interne notitie achter voor de volgende pikettelefoon. Geen klantantwoord.",
+    "trigger_kind": "manual",
+    "conditions": [],
+    "actions": [
+      {
+        "kind": "reply",
+        "config": {
+          "visibility": "internal",
+          "body": "Escalated by {{agent_name}}. Marked for the on-call queue."
+        }
+      }
+    ]
+  },
+  {
+    "id": "set-high-priority",
+    "name_en": "Bump to high priority",
+    "name_fr": "Passer en priorité haute",
+    "name_nl": "Verhoog naar hoge prioriteit",
+    "description_en": "Raise the ticket priority to high without sending a customer reply.",
+    "description_fr": "Augmente la priorité du ticket sans envoyer de réponse au client.",
+    "description_nl": "Verhoog de ticketprioriteit zonder een klantantwoord te sturen.",
+    "trigger_kind": "manual",
+    "conditions": [],
+    "actions": [
+      {
+        "kind": "set_priority",
+        "config": { "priority": "high" }
+      }
+    ]
+  },
+  {
+    "id": "tag-and-note",
+    "name_en": "Tag as duplicate",
+    "name_fr": "Étiqueter comme doublon",
+    "name_nl": "Markeer als duplicaat",
+    "description_en": "Add a 'duplicate' tag and an internal note flagging it for review.",
+    "description_fr": "Ajoute une étiquette 'doublon' et une note interne pour révision.",
+    "description_nl": "Voegt een 'duplicaat'-tag toe en een interne notitie voor beoordeling.",
+    "trigger_kind": "manual",
+    "conditions": [],
+    "actions": [
+      {
+        "kind": "reply",
+        "config": {
+          "visibility": "internal",
+          "body": "Likely a duplicate of an existing ticket. Tagged for review by {{agent_first_name}}."
+        }
+      }
+    ]
+  }
+]

--- a/backend/migrations/2026-06-07-000000_rules_engine_schema/down.sql
+++ b/backend/migrations/2026-06-07-000000_rules_engine_schema/down.sql
@@ -1,0 +1,17 @@
+-- Reverse of up.sql. RLS policies, ownership, and grants disappear
+-- with the tables. We only need to drop the triggers/functions
+-- explicitly since they aren't owned by the parent table.
+
+DROP TRIGGER IF EXISTS rules_version_on_update ON rules;
+DROP TRIGGER IF EXISTS rules_version_on_insert ON rules;
+DROP FUNCTION IF EXISTS rules_write_update_version();
+DROP FUNCTION IF EXISTS rules_write_initial_version();
+
+DROP TABLE IF EXISTS ticket_rule_runs;
+DROP TABLE IF EXISTS rule_applications;
+DROP TABLE IF EXISTS rule_versions;
+DROP TABLE IF EXISTS rules;
+
+DROP TYPE IF EXISTS rule_application_status;
+DROP TYPE IF EXISTS rule_trigger_kind;
+DROP TYPE IF EXISTS rule_state;

--- a/backend/migrations/2026-06-07-000000_rules_engine_schema/up.sql
+++ b/backend/migrations/2026-06-07-000000_rules_engine_schema/up.sql
@@ -184,15 +184,33 @@ CREATE INDEX ticket_rule_runs_age_idx
     ON ticket_rule_runs (fired_at);
 
 -- =====================================================================
--- Versioning triggers: every INSERT + UPDATE on rules writes a
--- rule_versions snapshot row. Numbering is per-rule, monotonically
--- increasing, atomic under the row lock the INSERT/UPDATE takes. We
--- split AFTER INSERT (initial version row, NEW already exists) from
--- BEFORE UPDATE (new version row plus bumping updated_at on the row
--- being written) because AFTER triggers cannot mutate NEW. The
--- WHEN clause on the UPDATE skips no-op writes.
+-- Versioning triggers: every INSERT + meaningful UPDATE on rules
+-- writes a rule_versions snapshot row. Numbering is per-rule,
+-- monotonically increasing, atomic under the row lock the
+-- INSERT/UPDATE takes. We split AFTER INSERT (initial version row,
+-- NEW already exists) from BEFORE UPDATE (new version row plus
+-- bumping updated_at) because AFTER triggers cannot mutate NEW.
+--
+-- The UPDATE trigger's WHEN clause compares ONLY the snapshot-
+-- relevant content columns. Bookkeeping bumps (fire_count,
+-- last_fired_at) from apply_manual must not produce a version row;
+-- those columns change on every fire and would otherwise flood
+-- rule_versions with identical-content snapshots and misnumber
+-- rule_applications.rule_version. The fields below are exactly
+-- what rule_versions records.
+--
+-- saved_by reads from the same `app.actor_uuid` session GUC the
+-- audit trigger uses, so an edit by admin B is credited to B even
+-- though rules.created_by stays pointed at A (the original
+-- creator). The GUC is NULL when the change comes from a system
+-- path that didn't go through with_actor_context; we fall back to
+-- NEW.created_by in that case rather than recording NULL, since
+-- "the original author probably authored this" is a safer default
+-- than "we don't know".
 -- =====================================================================
 CREATE OR REPLACE FUNCTION rules_write_initial_version() RETURNS TRIGGER AS $$
+DECLARE
+    actor UUID := NULLIF(current_setting('app.actor_uuid', true), '')::UUID;
 BEGIN
     INSERT INTO rule_versions (
         rule_id, workspace_id, version, name, description, trigger_kind,
@@ -202,7 +220,7 @@ BEGIN
     VALUES (
         NEW.id, NEW.workspace_id, 1, NEW.name, NEW.description, NEW.trigger_kind,
         NEW.trigger_config, NEW.conditions, NEW.actions, NEW.state, NEW.priority,
-        NEW.created_by, NEW.created_at
+        COALESCE(actor, NEW.created_by), NEW.created_at
     );
     RETURN NULL;
 END;
@@ -211,6 +229,7 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION rules_write_update_version() RETURNS TRIGGER AS $$
 DECLARE
     next_version INTEGER;
+    actor        UUID := NULLIF(current_setting('app.actor_uuid', true), '')::UUID;
 BEGIN
     SELECT COALESCE(MAX(version), 0) + 1
     INTO next_version
@@ -225,7 +244,7 @@ BEGIN
     VALUES (
         NEW.id, NEW.workspace_id, next_version, NEW.name, NEW.description, NEW.trigger_kind,
         NEW.trigger_config, NEW.conditions, NEW.actions, NEW.state, NEW.priority,
-        NEW.created_by, NOW()
+        COALESCE(actor, NEW.created_by), NOW()
     );
 
     NEW.updated_at := NOW();
@@ -241,7 +260,15 @@ CREATE TRIGGER rules_version_on_insert
 CREATE TRIGGER rules_version_on_update
     BEFORE UPDATE ON rules
     FOR EACH ROW
-    WHEN (OLD.* IS DISTINCT FROM NEW.*)
+    WHEN (
+        (OLD.name, OLD.description, OLD.trigger_kind, OLD.trigger_config,
+         OLD.conditions, OLD.actions, OLD.state, OLD.priority,
+         OLD.archived_at, OLD.reads_set, OLD.writes_set)
+        IS DISTINCT FROM
+        (NEW.name, NEW.description, NEW.trigger_kind, NEW.trigger_config,
+         NEW.conditions, NEW.actions, NEW.state, NEW.priority,
+         NEW.archived_at, NEW.reads_set, NEW.writes_set)
+    )
     EXECUTE FUNCTION rules_write_update_version();
 
 -- =====================================================================

--- a/backend/migrations/2026-06-07-000000_rules_engine_schema/up.sql
+++ b/backend/migrations/2026-06-07-000000_rules_engine_schema/up.sql
@@ -1,0 +1,324 @@
+-- Phase 1 of the unified rules engine.
+--
+-- Adds four tables (rules, rule_versions, rule_applications,
+-- ticket_rule_runs) plus three enum types that back them. Phase 1
+-- only ships the manual trigger surface (the "Actions" toolbar
+-- button) so the engine event subscription path is unused for now,
+-- but the schema is the same one Phase 2 (event triggers) and
+-- Phase 3 (time-elapsed) extend without changes. See
+-- docs/rules-and-actions-plan.md sections 4.1 - 4.4.
+--
+-- The existing assignment_rules / assignment_rule_state /
+-- assignment_log tables are untouched here; Phase 2 absorbs them in
+-- a hard cutover (decision 23 in the plan).
+
+CREATE TYPE rule_state AS ENUM ('draft', 'dry_run', 'live', 'archived');
+
+CREATE TYPE rule_trigger_kind AS ENUM (
+    'manual',
+    'ticket_created',
+    'ticket_updated',
+    'ticket_replied',
+    'time_elapsed'
+);
+
+CREATE TYPE rule_application_status AS ENUM (
+    'succeeded',
+    'dry_run',
+    'skipped_preflight',
+    'skipped_condition_unmet',
+    'suppressed_recursion_budget',
+    'suppressed_loop_guard',
+    'failed'
+);
+
+-- =====================================================================
+-- rules: the unified Rule entity. Phase 1 only inserts trigger_kind =
+-- 'manual' rows; later phases use the same table for event-triggered
+-- and time-elapsed rules. The rules_manual_no_conditions CHECK is
+-- load-bearing per decision 30: agents picking from the toolbar see
+-- every live manual rule (category-filtered), never one that fails
+-- preflight because the ticket doesn't match a condition.
+-- =====================================================================
+CREATE TABLE rules (
+    id SERIAL PRIMARY KEY,
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    trigger_kind rule_trigger_kind NOT NULL,
+    -- Trigger-specific config payload. Shape varies by trigger_kind;
+    -- the typed validator in repository::rules enforces it at save.
+    trigger_config JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- Condition tree (recursive AND/OR/NOT/leaf). Manual rules MUST
+    -- be []. The repository's reads_set derivation walks this tree
+    -- to populate the column below.
+    conditions JSONB NOT NULL DEFAULT '[]'::jsonb,
+    -- Ordered list of typed action objects. Always non-empty.
+    actions JSONB NOT NULL,
+    -- Derived at save time from conditions / actions. Drives the
+    -- self-referential save linter (writes ∩ reads != ∅) and the
+    -- engine's skip-on-no-reads-changed optimisation in Phase 2.
+    reads_set TEXT[] NOT NULL DEFAULT '{}',
+    writes_set TEXT[] NOT NULL DEFAULT '{}',
+    state rule_state NOT NULL DEFAULT 'draft',
+    -- Lower priority value evaluates earlier (matches the existing
+    -- assignment_rules convention).
+    priority INTEGER NOT NULL DEFAULT 100,
+    last_fired_at TIMESTAMPTZ NULL,
+    fire_count INTEGER NOT NULL DEFAULT 0,
+    created_by UUID REFERENCES users(uuid) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    archived_at TIMESTAMPTZ NULL,
+    CONSTRAINT rules_manual_no_conditions CHECK (
+        trigger_kind <> 'manual' OR conditions = '[]'::jsonb
+    ),
+    CONSTRAINT rules_actions_non_empty CHECK (
+        jsonb_typeof(actions) = 'array' AND jsonb_array_length(actions) > 0
+    )
+);
+
+-- General-purpose state filter for the admin list view.
+CREATE INDEX rules_workspace_state_idx
+    ON rules (workspace_id, state)
+    WHERE archived_at IS NULL;
+
+-- Event-engine scan (Phase 2): live rules of a given trigger kind in
+-- priority order.
+CREATE INDEX rules_workspace_trigger_idx
+    ON rules (workspace_id, trigger_kind, priority)
+    WHERE archived_at IS NULL AND state = 'live';
+
+-- Agent picker (Phase 1): live manual rules per workspace.
+CREATE INDEX rules_manual_pickable_idx
+    ON rules (workspace_id)
+    WHERE archived_at IS NULL
+      AND state = 'live'
+      AND trigger_kind = 'manual';
+
+-- =====================================================================
+-- rule_versions: every UPDATE on rules writes a snapshot row here.
+-- rule_applications.rule_version FKs into (rule_id, version) so the
+-- activity feed can deep-link to the exact rule shape that fired.
+-- =====================================================================
+CREATE TABLE rule_versions (
+    id SERIAL PRIMARY KEY,
+    rule_id INTEGER NOT NULL REFERENCES rules(id) ON DELETE CASCADE,
+    -- Denormalised from rules.workspace_id so RLS can scope this
+    -- table without joining the parent. The version-writing trigger
+    -- copies NEW.workspace_id.
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    trigger_kind rule_trigger_kind NOT NULL,
+    trigger_config JSONB NOT NULL,
+    conditions JSONB NOT NULL,
+    actions JSONB NOT NULL,
+    state rule_state NOT NULL,
+    priority INTEGER NOT NULL,
+    saved_by UUID REFERENCES users(uuid) ON DELETE SET NULL,
+    saved_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (rule_id, version)
+);
+
+CREATE INDEX rule_versions_rule_recent_idx
+    ON rule_versions (rule_id, saved_at DESC);
+
+-- =====================================================================
+-- rule_applications: the unified audit log. One row per fire attempt
+-- (manual apply, event match, time match, dry-run shadow); the status
+-- enum carries why nothing happened when nothing did. condition_eval /
+-- actions_taken / actions_skipped / failure_reason are populated only
+-- on dry-run + failed + suppressed_* + skipped_*; succeeded rows stay
+-- tight (the hot-path retention case).
+-- =====================================================================
+CREATE TABLE rule_applications (
+    id BIGSERIAL PRIMARY KEY,
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    rule_id INTEGER NOT NULL REFERENCES rules(id) ON DELETE CASCADE,
+    rule_version INTEGER NOT NULL,
+    ticket_id INTEGER NOT NULL REFERENCES tickets(id) ON DELETE CASCADE,
+    status rule_application_status NOT NULL,
+    correlation_id UUID NULL,
+    actor_uuid UUID REFERENCES users(uuid) ON DELETE SET NULL,
+    actor_kind VARCHAR(16) NOT NULL,
+    originating_event_id UUID NULL,
+    originating_event_kind VARCHAR(64) NULL,
+    condition_evaluation JSONB NULL,
+    actions_taken JSONB NULL,
+    actions_skipped JSONB NULL,
+    failure_reason TEXT NULL,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT rule_applications_actor_kind_valid CHECK (
+        actor_kind IN ('user', 'system')
+    )
+);
+
+CREATE INDEX rule_applications_workspace_recent_idx
+    ON rule_applications (workspace_id, applied_at DESC);
+CREATE INDEX rule_applications_rule_recent_idx
+    ON rule_applications (rule_id, applied_at DESC);
+CREATE INDEX rule_applications_ticket_idx
+    ON rule_applications (ticket_id, applied_at DESC);
+CREATE INDEX rule_applications_failures_idx
+    ON rule_applications (workspace_id, applied_at DESC)
+    WHERE status IN ('failed', 'suppressed_recursion_budget', 'suppressed_loop_guard');
+
+-- =====================================================================
+-- ticket_rule_runs: per-event recursion budget. PRIMARY KEY enforces
+-- "at most one fire of rule R on ticket T per originating event E";
+-- the fired_at column drives the hourly sweeper. Unused in Phase 1
+-- (no event subscriber yet) but added now so Phase 2 has the
+-- substrate already in place.
+-- =====================================================================
+CREATE TABLE ticket_rule_runs (
+    event_id UUID NOT NULL,
+    ticket_id INTEGER NOT NULL,
+    rule_id INTEGER NOT NULL,
+    fired_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (event_id, ticket_id, rule_id)
+);
+
+CREATE INDEX ticket_rule_runs_age_idx
+    ON ticket_rule_runs (fired_at);
+
+-- =====================================================================
+-- Versioning triggers: every INSERT + UPDATE on rules writes a
+-- rule_versions snapshot row. Numbering is per-rule, monotonically
+-- increasing, atomic under the row lock the INSERT/UPDATE takes. We
+-- split AFTER INSERT (initial version row, NEW already exists) from
+-- BEFORE UPDATE (new version row plus bumping updated_at on the row
+-- being written) because AFTER triggers cannot mutate NEW. The
+-- WHEN clause on the UPDATE skips no-op writes.
+-- =====================================================================
+CREATE OR REPLACE FUNCTION rules_write_initial_version() RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO rule_versions (
+        rule_id, workspace_id, version, name, description, trigger_kind,
+        trigger_config, conditions, actions, state, priority,
+        saved_by, saved_at
+    )
+    VALUES (
+        NEW.id, NEW.workspace_id, 1, NEW.name, NEW.description, NEW.trigger_kind,
+        NEW.trigger_config, NEW.conditions, NEW.actions, NEW.state, NEW.priority,
+        NEW.created_by, NEW.created_at
+    );
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION rules_write_update_version() RETURNS TRIGGER AS $$
+DECLARE
+    next_version INTEGER;
+BEGIN
+    SELECT COALESCE(MAX(version), 0) + 1
+    INTO next_version
+    FROM rule_versions
+    WHERE rule_id = NEW.id;
+
+    INSERT INTO rule_versions (
+        rule_id, workspace_id, version, name, description, trigger_kind,
+        trigger_config, conditions, actions, state, priority,
+        saved_by, saved_at
+    )
+    VALUES (
+        NEW.id, NEW.workspace_id, next_version, NEW.name, NEW.description, NEW.trigger_kind,
+        NEW.trigger_config, NEW.conditions, NEW.actions, NEW.state, NEW.priority,
+        NEW.created_by, NOW()
+    );
+
+    NEW.updated_at := NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER rules_version_on_insert
+    AFTER INSERT ON rules
+    FOR EACH ROW
+    EXECUTE FUNCTION rules_write_initial_version();
+
+CREATE TRIGGER rules_version_on_update
+    BEFORE UPDATE ON rules
+    FOR EACH ROW
+    WHEN (OLD.* IS DISTINCT FROM NEW.*)
+    EXECUTE FUNCTION rules_write_update_version();
+
+-- =====================================================================
+-- Row-level security on the three workspace-scoped tables. Same
+-- `app.workspace_id` GUC pattern as the existing tenant tables (see
+-- `2026-05-24-110007_rls_groups_users` for the canonical shape).
+-- `ticket_rule_runs` is engine-internal (sweeper + recursion budget,
+-- never read by user-facing handlers) so it stays without RLS; its
+-- access surface is gated by callers fetching rules and tickets that
+-- are already workspace-scoped.
+-- =====================================================================
+ALTER TABLE rules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rules FORCE ROW LEVEL SECURITY;
+CREATE POLICY rules_workspace_isolation ON rules
+    USING (
+        workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::int
+        OR NULLIF(current_setting('app.bypass_workspace_check', true), '') = 'true'
+    )
+    WITH CHECK (
+        workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::int
+        OR NULLIF(current_setting('app.bypass_workspace_check', true), '') = 'true'
+    );
+
+ALTER TABLE rule_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rule_versions FORCE ROW LEVEL SECURITY;
+CREATE POLICY rule_versions_workspace_isolation ON rule_versions
+    USING (
+        workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::int
+        OR NULLIF(current_setting('app.bypass_workspace_check', true), '') = 'true'
+    )
+    WITH CHECK (
+        workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::int
+        OR NULLIF(current_setting('app.bypass_workspace_check', true), '') = 'true'
+    );
+
+ALTER TABLE rule_applications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rule_applications FORCE ROW LEVEL SECURITY;
+CREATE POLICY rule_applications_workspace_isolation ON rule_applications
+    USING (
+        workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::int
+        OR NULLIF(current_setting('app.bypass_workspace_check', true), '') = 'true'
+    )
+    WITH CHECK (
+        workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::int
+        OR NULLIF(current_setting('app.bypass_workspace_check', true), '') = 'true'
+    );
+
+-- =====================================================================
+-- Transfer ownership to nosdesk_admin so future DDL run by a less-
+-- privileged operator still owns these. Mirrors the M5 task-9 pattern
+-- from `2026-06-03-040000_tenant_table_ownership` but applied at
+-- creation time rather than retroactively. Sequences come along
+-- because they're SERIAL-derived.
+-- =====================================================================
+ALTER TABLE rules OWNER TO nosdesk_admin;
+ALTER TABLE rule_versions OWNER TO nosdesk_admin;
+ALTER TABLE rule_applications OWNER TO nosdesk_admin;
+ALTER TABLE ticket_rule_runs OWNER TO nosdesk_admin;
+
+ALTER SEQUENCE rules_id_seq OWNER TO nosdesk_admin;
+ALTER SEQUENCE rule_versions_id_seq OWNER TO nosdesk_admin;
+ALTER SEQUENCE rule_applications_id_seq OWNER TO nosdesk_admin;
+
+ALTER FUNCTION rules_write_initial_version() OWNER TO nosdesk_admin;
+ALTER FUNCTION rules_write_update_version() OWNER TO nosdesk_admin;
+
+-- =====================================================================
+-- Grants for the application role. `nosdesk_app` runs as a non-
+-- superuser and is subject to FORCE RLS; the GRANT lets it read /
+-- write rows that pass the workspace_id policy. Pattern matches
+-- the existing tenant tables.
+-- =====================================================================
+GRANT SELECT, INSERT, UPDATE, DELETE ON rules TO nosdesk_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON rule_versions TO nosdesk_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON rule_applications TO nosdesk_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ticket_rule_runs TO nosdesk_app;
+
+GRANT USAGE ON SEQUENCE rules_id_seq TO nosdesk_app;
+GRANT USAGE ON SEQUENCE rule_versions_id_seq TO nosdesk_app;
+GRANT USAGE ON SEQUENCE rule_applications_id_seq TO nosdesk_app;

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -47,6 +47,7 @@ pub mod plugin_collections;
 pub mod plugin_events;
 pub mod plugins;
 pub mod projects;
+pub mod rules;
 pub mod saved_views;
 pub mod scheduler;
 pub mod search;

--- a/backend/src/handlers/rules.rs
+++ b/backend/src/handlers/rules.rs
@@ -1,0 +1,934 @@
+//! HTTP handlers for the rules engine. Phase 1 surface: admin CRUD
+//! on the `rules` resource, the recent-applications log, the agent
+//! picker endpoint, and the self-referential save linter (a check
+//! that runs at create / update time, not a separate endpoint).
+//!
+//! The apply endpoint (`POST /api/rules/{id}/apply`) lives in Wave
+//! 6 alongside the atomic lifecycle in `repository::rules::apply`.
+//! Routes are wired in `main.rs` so the literal `/rules/{id}/apply`
+//! and `/rules/{id}/state` register before the wildcard
+//! `/rules/{id}` PATCH/DELETE per memory note
+//! `project_actix_route_shadowing`.
+//!
+//! Workspace isolation is via RLS + `require_workspace_role`. The
+//! repository layer doesn't add explicit `workspace_id = ?` filters
+//! to its queries; the session GUC the cookie-auth + workspace
+//! middleware sets up handles that uniformly.
+
+use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Responder};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::db::Pool;
+use crate::handlers::errors;
+use crate::middleware::request_context::RequestContext;
+use crate::models::{
+    NewRule, Rule, RuleApplicationStatus, RuleState, RuleTriggerKind, RuleUpdate, RuleVersion,
+    WorkspaceRole,
+};
+use crate::repository::rules;
+use crate::utils::rbac::require_workspace_role;
+
+// =====================================================================
+// Request / response DTOs.
+// =====================================================================
+
+/// Body of `POST /api/rules`. Only admins call this. `reads_set` /
+/// `writes_set` are derived server-side; clients don't send them.
+#[derive(Debug, Deserialize)]
+pub struct CreateRuleRequest {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub trigger_kind: RuleTriggerKind,
+    #[serde(default = "empty_object")]
+    pub trigger_config: Value,
+    #[serde(default = "empty_array")]
+    pub conditions: Value,
+    pub actions: Value,
+    #[serde(default = "default_priority")]
+    pub priority: i32,
+    /// Optional override for the self-referential save linter. The
+    /// editor sets this to `true` only when the admin clicks the
+    /// "I understand this rule may loop" checkbox. The server still
+    /// computes `reads_set` / `writes_set` and stores them; the flag
+    /// just changes whether an intersection blocks the save.
+    #[serde(default)]
+    pub override_self_reference: bool,
+}
+
+fn empty_object() -> Value {
+    Value::Object(serde_json::Map::new())
+}
+fn empty_array() -> Value {
+    Value::Array(Vec::new())
+}
+fn default_priority() -> i32 {
+    100
+}
+
+/// Body of `PUT /api/rules/{id}`. Every field is Option-wrapped so
+/// the editor's partial PATCH-equivalent round-trips without
+/// clobbering unsent fields. Same `override_self_reference` knob as
+/// create.
+#[derive(Debug, Deserialize)]
+pub struct UpdateRuleRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<Option<String>>,
+    #[serde(default)]
+    pub trigger_kind: Option<RuleTriggerKind>,
+    #[serde(default)]
+    pub trigger_config: Option<Value>,
+    #[serde(default)]
+    pub conditions: Option<Value>,
+    #[serde(default)]
+    pub actions: Option<Value>,
+    #[serde(default)]
+    pub priority: Option<i32>,
+    #[serde(default)]
+    pub override_self_reference: bool,
+}
+
+/// Body of `PATCH /api/rules/{id}/state`. The state machine is
+/// validated server-side; illegal transitions return 409 with the
+/// `RULE_STATE_TRANSITION` code so the editor can surface the
+/// allowed next states.
+#[derive(Debug, Deserialize)]
+pub struct StateTransitionRequest {
+    pub state: RuleState,
+}
+
+/// Filters for `GET /api/rules`. Pulled from query string.
+#[derive(Debug, Default, Deserialize)]
+pub struct ListRulesQuery {
+    pub trigger_kind: Option<RuleTriggerKind>,
+    pub state: Option<RuleState>,
+    pub q: Option<String>,
+    #[serde(default)]
+    pub include_archived: bool,
+}
+
+/// Filters for `GET /api/rule-applications`. Date bounds are
+/// optional RFC-3339 strings; the repo converts to `chrono`.
+#[derive(Debug, Default, Deserialize)]
+pub struct ListApplicationsQuery {
+    pub rule_id: Option<i32>,
+    pub ticket_id: Option<i32>,
+    pub status: Option<RuleApplicationStatus>,
+    pub actor_uuid: Option<Uuid>,
+    pub from: Option<chrono::DateTime<Utc>>,
+    pub to: Option<chrono::DateTime<Utc>>,
+    #[serde(default = "default_application_limit")]
+    pub limit: i64,
+}
+
+fn default_application_limit() -> i64 {
+    50
+}
+
+/// Query-string knob on `DELETE /api/rules/{id}`. `?hard=true`
+/// permanently deletes; otherwise the row is soft-archived (sets
+/// `archived_at`). Decision 32 in the plan: hard delete is only
+/// permitted on a row that's already archived.
+#[derive(Debug, Default, Deserialize)]
+pub struct DeleteRuleQuery {
+    #[serde(default)]
+    pub hard: bool,
+}
+
+/// `Rule` as it appears in API responses. Strips the
+/// `Vec<Option<String>>` schema-boundary on `reads_set` /
+/// `writes_set` (Diesel's nullable-elements view) into a flat
+/// `Vec<String>` for clients.
+#[derive(Debug, Serialize)]
+pub struct RuleDto {
+    pub id: i32,
+    pub workspace_id: i32,
+    pub name: String,
+    pub description: Option<String>,
+    pub trigger_kind: RuleTriggerKind,
+    pub trigger_config: Value,
+    pub conditions: Value,
+    pub actions: Value,
+    pub reads_set: Vec<String>,
+    pub writes_set: Vec<String>,
+    pub state: RuleState,
+    pub priority: i32,
+    pub last_fired_at: Option<chrono::DateTime<Utc>>,
+    pub fire_count: i32,
+    pub created_by: Option<Uuid>,
+    pub created_at: chrono::DateTime<Utc>,
+    pub updated_at: chrono::DateTime<Utc>,
+    pub archived_at: Option<chrono::DateTime<Utc>>,
+}
+
+impl From<Rule> for RuleDto {
+    fn from(r: Rule) -> Self {
+        Self {
+            id: r.id,
+            workspace_id: r.workspace_id,
+            name: r.name,
+            description: r.description,
+            trigger_kind: r.trigger_kind,
+            trigger_config: r.trigger_config,
+            conditions: r.conditions,
+            actions: r.actions,
+            reads_set: r.reads_set.into_iter().flatten().collect(),
+            writes_set: r.writes_set.into_iter().flatten().collect(),
+            state: r.state,
+            priority: r.priority,
+            last_fired_at: r.last_fired_at,
+            fire_count: r.fire_count,
+            created_by: r.created_by,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+            archived_at: r.archived_at,
+        }
+    }
+}
+
+/// `RuleVersion` as it appears in API responses. Same flat shape as
+/// `RuleDto` for the columns it shares; `reads_set` / `writes_set`
+/// aren't on `rule_versions` because the migration's trigger only
+/// snapshots the user-facing fields.
+#[derive(Debug, Serialize)]
+pub struct RuleVersionDto {
+    pub id: i32,
+    pub rule_id: i32,
+    pub workspace_id: i32,
+    pub version: i32,
+    pub name: String,
+    pub description: Option<String>,
+    pub trigger_kind: RuleTriggerKind,
+    pub trigger_config: Value,
+    pub conditions: Value,
+    pub actions: Value,
+    pub state: RuleState,
+    pub priority: i32,
+    pub saved_by: Option<Uuid>,
+    pub saved_at: chrono::DateTime<Utc>,
+}
+
+impl From<RuleVersion> for RuleVersionDto {
+    fn from(v: RuleVersion) -> Self {
+        Self {
+            id: v.id,
+            rule_id: v.rule_id,
+            workspace_id: v.workspace_id,
+            version: v.version,
+            name: v.name,
+            description: v.description,
+            trigger_kind: v.trigger_kind,
+            trigger_config: v.trigger_config,
+            conditions: v.conditions,
+            actions: v.actions,
+            state: v.state,
+            priority: v.priority,
+            saved_by: v.saved_by,
+            saved_at: v.saved_at,
+        }
+    }
+}
+
+// =====================================================================
+// Self-referential save linter (decision 8 in the plan / unit-11).
+// Lives in this module because it's a save-time HTTP-layer check, not
+// a repository invariant.
+// =====================================================================
+
+#[derive(Debug)]
+struct SelfReferentialError {
+    fields: Vec<String>,
+}
+
+/// Returns `Err` when the rule's `reads_set ∩ writes_set ≠ ∅` AND
+/// the caller didn't opt out via `override_self_reference`. The
+/// repository's `derive_*` helpers produce `Vec<Option<String>>`
+/// because the column is `Array<Nullable<Text>>`; we strip the
+/// `Option` wrapper at this boundary.
+fn check_self_referential(
+    reads: &[Option<String>],
+    writes: &[Option<String>],
+    override_flag: bool,
+) -> Result<(), SelfReferentialError> {
+    if override_flag {
+        return Ok(());
+    }
+    let writes_set: std::collections::HashSet<&str> = writes
+        .iter()
+        .filter_map(|w| w.as_deref())
+        .collect();
+    let overlap: Vec<String> = reads
+        .iter()
+        .filter_map(|r| r.as_deref())
+        .filter(|r| writes_set.contains(r))
+        .map(|s| s.to_string())
+        .collect();
+    if overlap.is_empty() {
+        Ok(())
+    } else {
+        Err(SelfReferentialError { fields: overlap })
+    }
+}
+
+// =====================================================================
+// Helpers.
+// =====================================================================
+
+fn actor_workspace_id(req: &HttpRequest) -> Option<i32> {
+    req.extensions()
+        .get::<RequestContext>()
+        .map(|c| c.actor.workspace_id)
+        .unwrap_or(None)
+}
+
+fn actor_uuid(req: &HttpRequest) -> Option<Uuid> {
+    req.extensions()
+        .get::<RequestContext>()
+        .and_then(|c| c.actor.uuid)
+}
+
+/// Cheap "this transition is one of the legal ones" check. The
+/// state machine: draft ↔ dry_run ↔ live → archived. From archived
+/// the row stays put; restore-to-draft would be a separate
+/// endpoint when we add it (out of scope for Phase 1 per decision
+/// 32).
+fn legal_state_transition(from: RuleState, to: RuleState) -> bool {
+    use RuleState::*;
+    matches!(
+        (from, to),
+        (Draft, DryRun)
+            | (Draft, Live)
+            | (Draft, Archived)
+            | (DryRun, Live)
+            | (DryRun, Draft)
+            | (DryRun, Archived)
+            | (Live, DryRun)
+            | (Live, Archived)
+    )
+}
+
+// =====================================================================
+// Handlers.
+// =====================================================================
+
+/// `POST /api/rules` (admin). Create a new rule. Manual rules
+/// require `conditions = []`; the `rules_manual_no_conditions`
+/// CHECK enforces this at the DB but we early-reject here with a
+/// clearer error.
+pub async fn create_rule(
+    req: HttpRequest,
+    body: web::Json<CreateRuleRequest>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let Some(workspace_id) = actor_workspace_id(&req) else {
+        return errors::unauthorized("Authentication required");
+    };
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let CreateRuleRequest {
+        name,
+        description,
+        trigger_kind,
+        trigger_config,
+        conditions,
+        actions,
+        priority,
+        override_self_reference,
+    } = body.into_inner();
+
+    if name.trim().is_empty() {
+        return errors::bad_request_with_code("name must not be empty", "RULE_VALIDATION");
+    }
+    if let Err(msg) = validate_actions(&actions) {
+        return errors::bad_request_with_code(msg, "RULE_VALIDATION");
+    }
+    if trigger_kind == RuleTriggerKind::Manual && !is_empty_conditions(&conditions) {
+        return errors::bad_request_with_code(
+            "manual rules must have an empty conditions list",
+            "RULE_VALIDATION",
+        );
+    }
+
+    let reads = rules::derive_reads_set(&conditions);
+    let writes = rules::derive_writes_set(&actions);
+
+    if let Err(e) = check_self_referential(&reads, &writes, override_self_reference) {
+        return errors::conflict_with_code(
+            format!(
+                "rule reads and writes the same fields: {} (set override_self_reference=true to bypass)",
+                e.fields.join(", ")
+            ),
+            "RULE_SELF_REFERENTIAL",
+        );
+    }
+
+    let new = NewRule {
+        workspace_id,
+        name,
+        description,
+        trigger_kind,
+        trigger_config,
+        conditions,
+        actions,
+        // derive_* output is what gets persisted; the repo's
+        // create() recomputes from the JSONB trees so passing it
+        // again here is redundant but explicit.
+        reads_set: reads,
+        writes_set: writes,
+        state: RuleState::Draft,
+        priority,
+        created_by: actor_uuid(&req),
+    };
+
+    match rules::create(&mut conn, new) {
+        Ok(rule) => HttpResponse::Created().json(RuleDto::from(rule)),
+        Err(e) => {
+            tracing::error!(error = ?e, "create_rule: repo error");
+            errors::db_error(&e)
+        }
+    }
+}
+
+/// `GET /api/rules` (admin). List rules in the caller's workspace.
+pub async fn list_rules(
+    req: HttpRequest,
+    query: web::Query<ListRulesQuery>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let q = query.into_inner();
+    let filter = rules::ListFilter {
+        trigger_kind: q.trigger_kind,
+        state: q.state,
+        include_archived: q.include_archived,
+        name_query: q.q,
+    };
+    match rules::list(&mut conn, filter) {
+        Ok(rs) => HttpResponse::Ok().json(rs.into_iter().map(RuleDto::from).collect::<Vec<_>>()),
+        Err(e) => errors::db_error(&e),
+    }
+}
+
+/// `GET /api/rules/{id}` (admin). Single rule.
+pub async fn get_rule(
+    req: HttpRequest,
+    path: web::Path<i32>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let id = path.into_inner();
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    match rules::find(&mut conn, id) {
+        Ok(Some(rule)) => HttpResponse::Ok().json(RuleDto::from(rule)),
+        Ok(None) => errors::not_found_msg(format!("rule {id} not found")),
+        Err(e) => errors::db_error(&e),
+    }
+}
+
+/// `PUT /api/rules/{id}` (admin). Apply a partial update; the
+/// migration's BEFORE UPDATE trigger writes a `rule_versions` row
+/// and bumps `updated_at`. `reads_set` / `writes_set` are
+/// recomputed by the repo when `conditions` or `actions` move.
+pub async fn update_rule(
+    req: HttpRequest,
+    path: web::Path<i32>,
+    body: web::Json<UpdateRuleRequest>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let id = path.into_inner();
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let UpdateRuleRequest {
+        name,
+        description,
+        trigger_kind,
+        trigger_config,
+        conditions,
+        actions,
+        priority,
+        override_self_reference,
+    } = body.into_inner();
+
+    if let Some(ref n) = name {
+        if n.trim().is_empty() {
+            return errors::bad_request_with_code("name must not be empty", "RULE_VALIDATION");
+        }
+    }
+    if let Some(ref a) = actions {
+        if let Err(msg) = validate_actions(a) {
+            return errors::bad_request_with_code(msg, "RULE_VALIDATION");
+        }
+    }
+
+    // Self-ref check needs the post-update conditions / actions, which
+    // means reading the existing row first if either is omitted. Same
+    // pattern the merge handler uses for optimistic-lock fetches.
+    let existing = match rules::find(&mut conn, id) {
+        Ok(Some(r)) => r,
+        Ok(None) => return errors::not_found_msg(format!("rule {id} not found")),
+        Err(e) => return errors::db_error(&e),
+    };
+    let effective_conditions = conditions.clone().unwrap_or(existing.conditions);
+    let effective_actions = actions.clone().unwrap_or(existing.actions);
+    let effective_trigger_kind = trigger_kind.unwrap_or(existing.trigger_kind);
+    if effective_trigger_kind == RuleTriggerKind::Manual
+        && !is_empty_conditions(&effective_conditions)
+    {
+        return errors::bad_request_with_code(
+            "manual rules must have an empty conditions list",
+            "RULE_VALIDATION",
+        );
+    }
+    let reads = rules::derive_reads_set(&effective_conditions);
+    let writes = rules::derive_writes_set(&effective_actions);
+    if let Err(e) = check_self_referential(&reads, &writes, override_self_reference) {
+        return errors::conflict_with_code(
+            format!(
+                "rule reads and writes the same fields: {} (set override_self_reference=true to bypass)",
+                e.fields.join(", ")
+            ),
+            "RULE_SELF_REFERENTIAL",
+        );
+    }
+
+    let change = RuleUpdate {
+        name,
+        description,
+        trigger_kind,
+        trigger_config,
+        conditions,
+        actions,
+        reads_set: None,
+        writes_set: None,
+        state: None,
+        priority,
+        last_fired_at: None,
+        fire_count: None,
+        archived_at: None,
+    };
+
+    match rules::update(&mut conn, id, change) {
+        Ok(rule) => HttpResponse::Ok().json(RuleDto::from(rule)),
+        Err(rules::WriteError::NotFound(_)) => {
+            errors::not_found_msg(format!("rule {id} not found"))
+        }
+        Err(rules::WriteError::Db(e)) => errors::db_error(&e),
+        Err(rules::WriteError::NotArchived(_)) => {
+            // Not reachable from update(); only hard_delete returns
+            // NotArchived. Defensive 500 if it ever leaks.
+            errors::internal("unexpected NotArchived from update")
+        }
+    }
+}
+
+/// `PATCH /api/rules/{id}/state` (admin). State transition with
+/// the legal-transition table; everything else returns 409
+/// `RULE_STATE_TRANSITION`.
+pub async fn transition_state(
+    req: HttpRequest,
+    path: web::Path<i32>,
+    body: web::Json<StateTransitionRequest>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let id = path.into_inner();
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let target = body.into_inner().state;
+
+    let existing = match rules::find(&mut conn, id) {
+        Ok(Some(r)) => r,
+        Ok(None) => return errors::not_found_msg(format!("rule {id} not found")),
+        Err(e) => return errors::db_error(&e),
+    };
+    if existing.state == target {
+        return HttpResponse::Ok().json(RuleDto::from(existing));
+    }
+    if !legal_state_transition(existing.state, target) {
+        return errors::conflict_with_code(
+            format!(
+                "cannot transition rule from {} to {}",
+                existing.state.as_str(),
+                target.as_str()
+            ),
+            "RULE_STATE_TRANSITION",
+        );
+    }
+    // Archive transitions stamp archived_at so the
+    // archived-vs-live filter in list_pickable_manual stays
+    // consistent with the state column. The reverse (un-archive)
+    // isn't a v1 transition; out-of-scope per decision 32.
+    let archived_at = match target {
+        RuleState::Archived => Some(Some(Utc::now())),
+        _ => None,
+    };
+    let change = RuleUpdate {
+        state: Some(target),
+        archived_at,
+        ..Default::default()
+    };
+    match rules::update(&mut conn, id, change) {
+        Ok(rule) => HttpResponse::Ok().json(RuleDto::from(rule)),
+        Err(rules::WriteError::NotFound(_)) => {
+            errors::not_found_msg(format!("rule {id} not found"))
+        }
+        Err(rules::WriteError::Db(e)) => errors::db_error(&e),
+        Err(rules::WriteError::NotArchived(_)) => {
+            errors::internal("unexpected NotArchived from state transition")
+        }
+    }
+}
+
+/// `DELETE /api/rules/{id}` (admin). Soft-archive by default;
+/// `?hard=true` permanently deletes but only if `archived_at` is
+/// already set. Returns 204 on hard delete, 200 with the archived
+/// rule on soft.
+pub async fn delete_rule(
+    req: HttpRequest,
+    path: web::Path<i32>,
+    query: web::Query<DeleteRuleQuery>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let id = path.into_inner();
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    if query.hard {
+        match rules::hard_delete(&mut conn, id) {
+            Ok(()) => HttpResponse::NoContent().finish(),
+            Err(rules::WriteError::NotFound(_)) => {
+                errors::not_found_msg(format!("rule {id} not found"))
+            }
+            Err(rules::WriteError::NotArchived(_)) => errors::conflict_with_code(
+                "rule must be archived before hard delete",
+                "RULE_NOT_ARCHIVED",
+            ),
+            Err(rules::WriteError::Db(e)) => errors::db_error(&e),
+        }
+    } else {
+        match rules::archive(&mut conn, id, Utc::now()) {
+            Ok(rule) => HttpResponse::Ok().json(RuleDto::from(rule)),
+            Err(rules::WriteError::NotFound(_)) => {
+                errors::not_found_msg(format!("rule {id} not found"))
+            }
+            Err(rules::WriteError::Db(e)) => errors::db_error(&e),
+            Err(rules::WriteError::NotArchived(_)) => {
+                errors::internal("unexpected NotArchived from archive")
+            }
+        }
+    }
+}
+
+/// `GET /api/rules/{id}/versions` (admin). The activity-feed
+/// inspector deep-links into a specific version; the editor's
+/// "version history" sidebar reads this.
+pub async fn list_rule_versions(
+    req: HttpRequest,
+    path: web::Path<i32>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let rule_id = path.into_inner();
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    match rules::list_versions(&mut conn, rule_id) {
+        Ok(rs) => {
+            HttpResponse::Ok().json(rs.into_iter().map(RuleVersionDto::from).collect::<Vec<_>>())
+        }
+        Err(e) => errors::db_error(&e),
+    }
+}
+
+/// `GET /api/rules/{id}/versions/{version}` (admin). The single-
+/// version snapshot the inspector renders.
+pub async fn get_rule_version(
+    req: HttpRequest,
+    path: web::Path<(i32, i32)>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let (rule_id, version) = path.into_inner();
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    match rules::find_version(&mut conn, rule_id, version) {
+        Ok(Some(v)) => HttpResponse::Ok().json(RuleVersionDto::from(v)),
+        Ok(None) => errors::not_found_msg(format!(
+            "rule {rule_id} version {version} not found"
+        )),
+        Err(e) => errors::db_error(&e),
+    }
+}
+
+// =====================================================================
+// Recent-activity log (unit-09).
+// =====================================================================
+
+/// `GET /api/rule-applications` (admin). The workspace-wide
+/// recent-activity feed. Default page size 50, max 500 (the repo
+/// clamps).
+pub async fn list_rule_applications(
+    req: HttpRequest,
+    query: web::Query<ListApplicationsQuery>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let q = query.into_inner();
+    let filter = rules::ApplicationFilter {
+        rule_id: q.rule_id,
+        ticket_id: q.ticket_id,
+        status: q.status,
+        actor_uuid: q.actor_uuid,
+        from: q.from,
+        to: q.to,
+        limit: q.limit,
+    };
+    match rules::list_applications(&mut conn, filter) {
+        Ok(rows) => HttpResponse::Ok().json(rows),
+        Err(e) => errors::db_error(&e),
+    }
+}
+
+/// `GET /api/rule-applications/{id}` (admin). Full row with the
+/// `condition_evaluation` / `actions_taken` / `actions_skipped` /
+/// `failure_reason` payloads the inspector renders.
+pub async fn get_rule_application(
+    req: HttpRequest,
+    path: web::Path<i64>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let id = path.into_inner();
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    match rules::find_application(&mut conn, id) {
+        Ok(Some(row)) => HttpResponse::Ok().json(row),
+        Ok(None) => errors::not_found_msg(format!("rule_application {id} not found")),
+        Err(e) => errors::db_error(&e),
+    }
+}
+
+/// `GET /api/tickets/{ticket_id}/rule-applications` (agent). The
+/// per-ticket activity slice the open-ticket-view's history panel
+/// reads. Agent-readable so the agent can see "rules that fired on
+/// this ticket" without needing admin access to the workspace-wide
+/// log.
+pub async fn list_ticket_rule_applications(
+    req: HttpRequest,
+    path: web::Path<i32>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Agent) {
+        return e;
+    }
+    let ticket_id = path.into_inner();
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    match rules::list_applications_for_ticket(&mut conn, ticket_id) {
+        Ok(rows) => HttpResponse::Ok().json(rows),
+        Err(e) => errors::db_error(&e),
+    }
+}
+
+// =====================================================================
+// Agent picker (unit-10).
+// =====================================================================
+
+/// `GET /api/tickets/{id}/applicable-actions` (Agent role minimum).
+/// Returns the live manual rules in the caller's workspace. Per
+/// decision 30, manual rules have empty conditions so we don't
+/// per-ticket-condition-evaluate; the picker is category-organised
+/// in the UI, but the endpoint returns the unfiltered manual-rules
+/// list and the frontend groups it.
+pub async fn list_applicable_actions(
+    req: HttpRequest,
+    _path: web::Path<i32>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Agent) {
+        return e;
+    }
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    match rules::list_pickable_manual(&mut conn) {
+        Ok(rs) => HttpResponse::Ok().json(rs.into_iter().map(RuleDto::from).collect::<Vec<_>>()),
+        Err(e) => errors::db_error(&e),
+    }
+}
+
+// =====================================================================
+// Local validation helpers used by create / update.
+// =====================================================================
+
+/// Surface-level sanity check on the actions JSONB. Full per-action
+/// config validation lives with the executor in Wave 5; here we
+/// just confirm the array shape and that every element has a
+/// recognised `kind` so the editor's typo'd kind doesn't reach the
+/// engine.
+fn validate_actions(actions: &Value) -> Result<(), String> {
+    let Some(arr) = actions.as_array() else {
+        return Err("actions must be a JSON array".to_string());
+    };
+    if arr.is_empty() {
+        return Err("actions must contain at least one entry".to_string());
+    }
+    const KNOWN: &[&str] = &[
+        "reply",
+        "set_status",
+        "assign",
+        "unassign",
+        "add_tags",
+        "remove_tags",
+        "set_priority",
+        "notify",
+        "apply_macro_template",
+        "webhook",
+        "stop_processing",
+    ];
+    for (i, action) in arr.iter().enumerate() {
+        let Some(obj) = action.as_object() else {
+            return Err(format!("actions[{i}] must be a JSON object"));
+        };
+        let kind = obj
+            .get("kind")
+            .and_then(|k| k.as_str())
+            .ok_or_else(|| format!("actions[{i}] missing kind"))?;
+        if !KNOWN.contains(&kind) {
+            return Err(format!("actions[{i}] has unknown kind: {kind}"));
+        }
+    }
+    Ok(())
+}
+
+fn is_empty_conditions(value: &Value) -> bool {
+    matches!(value, Value::Array(a) if a.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legal_transitions_match_state_machine() {
+        use RuleState::*;
+        assert!(legal_state_transition(Draft, DryRun));
+        assert!(legal_state_transition(DryRun, Live));
+        assert!(legal_state_transition(Live, DryRun));
+        assert!(legal_state_transition(Live, Archived));
+        // Skip-to-Live ladder for the "I verified manually" admin
+        // path is the same legal_state_transition, with the
+        // editor-side checkbox being the gate.
+        assert!(legal_state_transition(Draft, Live));
+        // Unarchive isn't a Phase 1 transition.
+        assert!(!legal_state_transition(Archived, Draft));
+        assert!(!legal_state_transition(Archived, Live));
+        assert!(!legal_state_transition(Archived, DryRun));
+    }
+
+    #[test]
+    fn self_ref_check_flags_overlap() {
+        let reads = vec![Some("ticket.priority".to_string())];
+        let writes = vec![Some("ticket.priority".to_string()), Some("ticket.updated_at".to_string())];
+        let err = check_self_referential(&reads, &writes, false).unwrap_err();
+        assert_eq!(err.fields, vec!["ticket.priority"]);
+    }
+
+    #[test]
+    fn self_ref_check_passes_with_override() {
+        let reads = vec![Some("ticket.priority".to_string())];
+        let writes = vec![Some("ticket.priority".to_string())];
+        assert!(check_self_referential(&reads, &writes, true).is_ok());
+    }
+
+    #[test]
+    fn self_ref_check_passes_when_disjoint() {
+        let reads = vec![Some("ticket.title".to_string())];
+        let writes = vec![Some("ticket.priority".to_string())];
+        assert!(check_self_referential(&reads, &writes, false).is_ok());
+    }
+
+    #[test]
+    fn validate_actions_rejects_empty_array() {
+        let actions = serde_json::json!([]);
+        assert!(validate_actions(&actions).is_err());
+    }
+
+    #[test]
+    fn validate_actions_rejects_unknown_kind() {
+        let actions = serde_json::json!([{ "kind": "obliterate" }]);
+        let err = validate_actions(&actions).unwrap_err();
+        assert!(err.contains("unknown kind"));
+    }
+
+    #[test]
+    fn validate_actions_accepts_known_kinds() {
+        let actions = serde_json::json!([
+            { "kind": "reply", "config": { "visibility": "public", "body": "hi" } },
+            { "kind": "stop_processing" }
+        ]);
+        assert!(validate_actions(&actions).is_ok());
+    }
+
+    #[test]
+    fn is_empty_conditions_matches_array_only() {
+        assert!(is_empty_conditions(&serde_json::json!([])));
+        assert!(!is_empty_conditions(&serde_json::json!({})));
+        assert!(!is_empty_conditions(&serde_json::json!({"kind": "leaf"})));
+        assert!(!is_empty_conditions(&serde_json::json!([{"x": 1}])));
+    }
+}

--- a/backend/src/handlers/rules.rs
+++ b/backend/src/handlers/rules.rs
@@ -784,6 +784,152 @@ pub async fn list_ticket_rule_applications(
 }
 
 // =====================================================================
+// Manual apply (Wave 6 / unit-08). Agent role; the lifecycle in
+// repository::rules::apply_manual owns the transaction.
+// =====================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct ApplyRuleRequest {
+    pub ticket_id: i32,
+    #[serde(default)]
+    pub overrides: ApplyRuleOverrides,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ApplyRuleOverrides {
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default)]
+    pub suppress_actions: Vec<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ApplyRuleResponse {
+    pub rule: RuleDto,
+    pub application_id: i64,
+    pub correlation_id: Option<Uuid>,
+    pub comment_id: Option<i32>,
+    pub actions_executed: usize,
+    pub actions_suppressed: usize,
+}
+
+/// `POST /api/rules/{id}/apply`. Agent role minimum. The route is
+/// registered before the wildcard `/rules/{id}` PUT/DELETE in
+/// main.rs to dodge actix's route-shadowing footgun.
+pub async fn apply_rule(
+    req: HttpRequest,
+    path: web::Path<i32>,
+    body: web::Json<ApplyRuleRequest>,
+    pool: web::Data<Pool>,
+    sse_state: web::Data<crate::handlers::sse::SseState>,
+) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Agent) {
+        return e;
+    }
+    let Some(actor) = req
+        .extensions()
+        .get::<RequestContext>()
+        .map(|c| c.actor.clone())
+    else {
+        return errors::unauthorized("Authentication required");
+    };
+    let rule_id = path.into_inner();
+    let mut conn = match errors::db_conn(&pool) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let body = body.into_inner();
+    let input = rules::ApplyInput {
+        rule_id,
+        ticket_id: body.ticket_id,
+        overrides: rules::ApplyOverrides {
+            body: body.overrides.body,
+            suppress_actions: body.overrides.suppress_actions,
+        },
+    };
+
+    let outcome = match rules::apply_manual(&mut conn, input, &actor) {
+        Ok(o) => o,
+        Err(e) => return map_apply_error(e),
+    };
+
+    // Post-commit best-effort: broadcast a per-field TicketUpdated
+    // for every action that mutated the ticket (set_status,
+    // assign, unassign, add_tags, remove_tags, set_priority).
+    // Manual reply actions don't change ticket fields; the
+    // existing comments.created sync event handles that path.
+    // Wave 8 connects the apply outcome to a richer SSE shape;
+    // for now the per-field shape covers the common case.
+    let actor_uuid_str = actor.uuid.map(|u| u.to_string()).unwrap_or_default();
+    if let Some(taken) = outcome.application.actions_taken.as_ref().and_then(|v| v.as_array()) {
+        for action in taken {
+            let Some(kind) = action.get("kind").and_then(|k| k.as_str()) else {
+                continue;
+            };
+            let (field, value) = match kind {
+                "set_status" => (
+                    "workflow_state_id",
+                    action.get("workflow_state_id").cloned().unwrap_or(Value::Null),
+                ),
+                "assign" => (
+                    "assignee_uuid",
+                    action.get("assigned_to_uuid").cloned().unwrap_or(Value::Null),
+                ),
+                "unassign" => ("assignee_uuid", Value::Null),
+                "add_tags" | "remove_tags" => {
+                    // Tag changes don't map cleanly onto a single
+                    // field event; the frontend's useTicketSSE
+                    // composable refetches the ticket on
+                    // ticket.updated with a tag-shaped value.
+                    ("tag_ids", Value::Null)
+                }
+                "set_priority" => (
+                    "priority",
+                    action.get("priority").cloned().unwrap_or(Value::Null),
+                ),
+                _ => continue,
+            };
+            sse_state
+                .broadcast_event(crate::handlers::sse::SseEvent::TicketUpdated {
+                    ticket_id: body.ticket_id,
+                    field: field.to_string(),
+                    value,
+                    updated_by: actor_uuid_str.clone(),
+                    timestamp: chrono::Utc::now(),
+                })
+                .await;
+        }
+    }
+
+    HttpResponse::Ok().json(ApplyRuleResponse {
+        rule: RuleDto::from(outcome.rule),
+        application_id: outcome.application.id,
+        correlation_id: outcome.application.correlation_id,
+        comment_id: outcome.comment_id,
+        actions_executed: outcome.actions_executed,
+        actions_suppressed: outcome.actions_suppressed,
+    })
+}
+
+fn map_apply_error(err: rules::ApplyError) -> HttpResponse {
+    let message = err.to_string();
+    use rules::ApplyError::*;
+    match err {
+        NotFound(_) | TicketNotFound(_) => errors::not_found_msg(message),
+        NotLive(..) => errors::conflict_with_code(message, "RULE_NOT_LIVE"),
+        NotManual(_) => errors::bad_request_with_code(message, "RULE_NOT_MANUAL"),
+        TicketMerged(_) => errors::bad_request_with_code(message, "RULE_TICKET_MERGED"),
+        InvalidOverrideIndex(..) => errors::bad_request_with_code(message, "MANUAL_APPLY_VALIDATION"),
+        UnsupportedActionPhase1 { .. } => {
+            errors::bad_request_with_code(message, "RULE_ACTION_UNSUPPORTED")
+        }
+        ActionFailed { .. } => errors::internal_with_code(message, "RULE_ACTION_FAILED"),
+        MissingWorkspace => errors::internal("missing workspace context"),
+        Db(e) => errors::db_error(&e),
+    }
+}
+
+// =====================================================================
 // Agent picker (unit-10).
 // =====================================================================
 

--- a/backend/src/handlers/rules.rs
+++ b/backend/src/handlers/rules.rs
@@ -930,6 +930,51 @@ fn map_apply_error(err: rules::ApplyError) -> HttpResponse {
 }
 
 // =====================================================================
+// Starter catalog (Wave 8 / unit-19). Admin-only browse of the
+// pre-built rules baked into the binary.
+// =====================================================================
+
+#[derive(Debug, Serialize)]
+pub struct StarterRuleDto {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub trigger_kind: String,
+    pub conditions: Value,
+    pub actions: Value,
+}
+
+/// `GET /api/rules/starter-catalog`. Admin only. Returns the
+/// localised catalog the rules-page "Browse starters" affordance
+/// renders. Locale comes from `Accept-Language`; falls back to
+/// English when the requested locale isn't represented.
+pub async fn list_starter_catalog(req: HttpRequest) -> impl Responder {
+    if let Err(e) = require_workspace_role(&req, WorkspaceRole::Admin) {
+        return e;
+    }
+    let locale = req
+        .headers()
+        .get(actix_web::http::header::ACCEPT_LANGUAGE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "en".to_string());
+
+    let dtos: Vec<StarterRuleDto> = crate::services::starter_catalog::list()
+        .iter()
+        .map(|r| StarterRuleDto {
+            id: r.id.clone(),
+            name: r.name_for(&locale).to_string(),
+            description: r.description_for(&locale).to_string(),
+            trigger_kind: r.trigger_kind.clone(),
+            conditions: r.conditions.clone(),
+            actions: r.actions.clone(),
+        })
+        .collect();
+    HttpResponse::Ok().json(dtos)
+}
+
+// =====================================================================
 // Agent picker (unit-10).
 // =====================================================================
 

--- a/backend/src/handlers/rules.rs
+++ b/backend/src/handlers/rules.rs
@@ -816,6 +816,11 @@ pub struct ApplyRuleResponse {
 /// `POST /api/rules/{id}/apply`. Agent role minimum. The route is
 /// registered before the wildcard `/rules/{id}` PUT/DELETE in
 /// main.rs to dodge actix's route-shadowing footgun.
+///
+/// Post-commit side-effects (channel relay for public replies,
+/// SSE field broadcasts) live in this handler, not in the apply
+/// lifecycle, so a slow downstream cannot roll back a committed
+/// rule fire. Errors here are logged and swallowed.
 pub async fn apply_rule(
     req: HttpRequest,
     path: web::Path<i32>,
@@ -839,9 +844,10 @@ pub async fn apply_rule(
         Err(resp) => return resp,
     };
     let body = body.into_inner();
+    let ticket_id = body.ticket_id;
     let input = rules::ApplyInput {
         rule_id,
-        ticket_id: body.ticket_id,
+        ticket_id,
         overrides: rules::ApplyOverrides {
             body: body.overrides.body,
             suppress_actions: body.overrides.suppress_actions,
@@ -853,45 +859,65 @@ pub async fn apply_rule(
         Err(e) => return map_apply_error(e),
     };
 
-    // Post-commit best-effort: broadcast a per-field TicketUpdated
-    // for every action that mutated the ticket (set_status,
-    // assign, unassign, add_tags, remove_tags, set_priority).
-    // Manual reply actions don't change ticket fields; the
-    // existing comments.created sync event handles that path.
-    // Wave 8 connects the apply outcome to a richer SSE shape;
-    // for now the per-field shape covers the common case.
+    // Channel relay: when the apply produced a public-visibility
+    // reply, enqueue the outbound message the same way the regular
+    // comment-create handler does. enqueue_for_comment spawns a
+    // background task, so the response returns immediately. Internal
+    // notes never relay.
+    if let Some(cid) = outcome.comment_id {
+        if let Err(e) =
+            dispatch_rule_reply_for_relay(&pool, ticket_id, cid, &outcome.application).await
+        {
+            tracing::warn!(error = %e, comment_id = cid, "rule reply channel relay enqueue failed");
+        }
+    }
+
+    // SSE: broadcast field names the frontend's useTicketSSE
+    // composable already handles. workflow_state_id needs to
+    // resolve to the state's category string (the frontend's
+    // ticket.status); assignee_uuid maps to the 'assignee' key.
+    // Tag changes have no matching per-field handler today; the
+    // ticket.rule_applied sync event drives activity-feed refresh,
+    // which is the surface that needs to update for tag changes.
     let actor_uuid_str = actor.uuid.map(|u| u.to_string()).unwrap_or_default();
-    if let Some(taken) = outcome.application.actions_taken.as_ref().and_then(|v| v.as_array()) {
+    if let Some(taken) = outcome
+        .application
+        .actions_taken
+        .as_ref()
+        .and_then(|v| v.as_array())
+    {
         for action in taken {
             let Some(kind) = action.get("kind").and_then(|k| k.as_str()) else {
                 continue;
             };
             let (field, value) = match kind {
-                "set_status" => (
-                    "workflow_state_id",
-                    action.get("workflow_state_id").cloned().unwrap_or(Value::Null),
-                ),
+                "set_status" => {
+                    let state_id = action
+                        .get("workflow_state_id")
+                        .and_then(|v| v.as_i64())
+                        .map(|i| i as i32);
+                    let category = state_id
+                        .and_then(|id| resolve_workflow_state_category(&pool, id).ok())
+                        .unwrap_or_default();
+                    ("status", Value::String(category))
+                }
                 "assign" => (
-                    "assignee_uuid",
+                    "assignee",
                     action.get("assigned_to_uuid").cloned().unwrap_or(Value::Null),
                 ),
-                "unassign" => ("assignee_uuid", Value::Null),
-                "add_tags" | "remove_tags" => {
-                    // Tag changes don't map cleanly onto a single
-                    // field event; the frontend's useTicketSSE
-                    // composable refetches the ticket on
-                    // ticket.updated with a tag-shaped value.
-                    ("tag_ids", Value::Null)
-                }
+                "unassign" => ("assignee", Value::Null),
                 "set_priority" => (
                     "priority",
                     action.get("priority").cloned().unwrap_or(Value::Null),
                 ),
+                // add_tags / remove_tags / reply / stop_processing
+                // have no useTicketSSE handler today; activity feed
+                // refresh via ticket.rule_applied covers them.
                 _ => continue,
             };
             sse_state
                 .broadcast_event(crate::handlers::sse::SseEvent::TicketUpdated {
-                    ticket_id: body.ticket_id,
+                    ticket_id,
                     field: field.to_string(),
                     value,
                     updated_by: actor_uuid_str.clone(),
@@ -911,6 +937,85 @@ pub async fn apply_rule(
     })
 }
 
+/// Resolve a workflow_state row's category string for the SSE
+/// payload. Best-effort: a missing row returns the empty string,
+/// the frontend's ticket.status setter accepts that as "unknown"
+/// and falls back to a refetch on the next interaction. Done
+/// outside the apply transaction so RLS-friendliness comes from
+/// the regular pool acquire.
+fn resolve_workflow_state_category(
+    pool: &web::Data<Pool>,
+    state_id: i32,
+) -> Result<String, diesel::result::Error> {
+    use crate::models::WorkflowStateCategory;
+    use crate::schema::workflow_states::dsl as ws;
+    use diesel::prelude::*;
+    let mut conn = pool
+        .get()
+        .map_err(|e| diesel::result::Error::QueryBuilderError(e.to_string().into()))?;
+    let category: WorkflowStateCategory = ws::workflow_states
+        .find(state_id)
+        .select(ws::category)
+        .first(&mut conn)?;
+    Ok(category.as_str().to_string())
+}
+
+/// Mirror the comment-handler's channel-relay enqueue for a rule-
+/// driven public reply. Loads the ticket + comment fresh from the
+/// pool so the spawn body owns them; the apply transaction has
+/// already committed by this point, so the rows are stable.
+async fn dispatch_rule_reply_for_relay(
+    pool: &web::Data<Pool>,
+    ticket_id: i32,
+    comment_id: i32,
+    application: &crate::models::RuleApplication,
+) -> Result<(), String> {
+    // Internal notes do not relay; reply visibility lives on the
+    // action's channel_metadata blob. Re-read the comment so we
+    // see the canonical row exactly as it was stored.
+    use crate::schema::comments::dsl as c;
+    use crate::schema::tickets::dsl as t;
+    use diesel::prelude::*;
+    let mut conn = pool.get().map_err(|e| e.to_string())?;
+    let comment: crate::models::Comment = c::comments
+        .find(comment_id)
+        .first(&mut conn)
+        .map_err(|e| e.to_string())?;
+    if comment.is_internal {
+        return Ok(());
+    }
+    // The action's channel_metadata kind=="rule_reply" carries the
+    // visibility we used at apply time. Public + non-internal is
+    // the relay condition; anything else skips silently.
+    let visibility_public = comment
+        .channel_metadata
+        .as_ref()
+        .and_then(|m| m.get("visibility"))
+        .and_then(|v| v.as_str())
+        .map(|v| v == "public")
+        .unwrap_or(false);
+    if !visibility_public {
+        return Ok(());
+    }
+    let ticket: crate::models::Ticket = t::tickets
+        .find(ticket_id)
+        .first(&mut conn)
+        .map_err(|e| e.to_string())?;
+    // Spawn — same shape as the regular comment handler. The
+    // outbound queue worker handles SMTP dispatch + retry.
+    crate::services::channels::outbound::enqueue_for_comment(
+        ticket,
+        comment,
+        pool.get_ref().clone(),
+    );
+    tracing::debug!(
+        application_id = application.id,
+        comment_id,
+        "rule reply enqueued for channel relay"
+    );
+    Ok(())
+}
+
 fn map_apply_error(err: rules::ApplyError) -> HttpResponse {
     let message = err.to_string();
     use rules::ApplyError::*;
@@ -924,6 +1029,11 @@ fn map_apply_error(err: rules::ApplyError) -> HttpResponse {
             errors::bad_request_with_code(message, "RULE_ACTION_UNSUPPORTED")
         }
         ActionFailed { .. } => errors::internal_with_code(message, "RULE_ACTION_FAILED"),
+        // Soft-deleted / revoked agents land here distinctly from a
+        // transient DB error so the frontend can clear stale auth
+        // state and prompt for re-login instead of showing a generic
+        // 500.
+        AgentRevoked(_) => errors::unauthorized_with_code(message, "ACTOR_REVOKED"),
         MissingWorkspace => errors::internal("missing workspace context"),
         Db(e) => errors::db_error(&e),
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1616,6 +1616,24 @@ async fn main() -> std::io::Result<()> {
                     .route("/admin/canned-response-starters", web::get().to(handlers::canned_responses::starter_catalog))
                     .route("/admin/canned-responses/{id}", web::patch().to(handlers::canned_responses::update_canned))
                     .route("/admin/canned-responses/{id}", web::delete().to(handlers::canned_responses::delete_canned))
+
+                    // Rules engine (Phase 1: manual rules + recent
+                    // activity log). The `/state` and `/apply` literal
+                    // sub-paths register before the wildcard `/{id}`
+                    // sibling to avoid the actix route-shadowing
+                    // gotcha; same pattern as `/canned-response-starters`
+                    // above. `/apply` itself is wired in Wave 6.
+                    .route("/rules", web::get().to(handlers::rules::list_rules))
+                    .route("/rules", web::post().to(handlers::rules::create_rule))
+                    .route("/rules/{id}/state", web::patch().to(handlers::rules::transition_state))
+                    .route("/rules/{id}/versions", web::get().to(handlers::rules::list_rule_versions))
+                    .route("/rules/{rule_id}/versions/{version}", web::get().to(handlers::rules::get_rule_version))
+                    .route("/rules/{id}", web::get().to(handlers::rules::get_rule))
+                    .route("/rules/{id}", web::put().to(handlers::rules::update_rule))
+                    .route("/rules/{id}", web::delete().to(handlers::rules::delete_rule))
+                    .route("/rule-applications", web::get().to(handlers::rules::list_rule_applications))
+                    .route("/rule-applications/{id}", web::get().to(handlers::rules::get_rule_application))
+
                     .route("/admin/branding/image", web::post().to(handlers::branding::upload_branding_image))
                     .route("/admin/branding/image", web::delete().to(handlers::branding::delete_branding_image))
 
@@ -1777,6 +1795,8 @@ async fn main() -> std::io::Result<()> {
                     // /tickets/{id} POST, so no wildcard can absorb it.
                     .route("/tickets/merge", web::post().to(handlers::ticket_merge::merge_tickets))
                     .route("/tickets/{id}/merge-history", web::get().to(handlers::ticket_merge::get_merge_history))
+                    .route("/tickets/{ticket_id}/rule-applications", web::get().to(handlers::rules::list_ticket_rule_applications))
+                    .route("/tickets/{id}/applicable-actions", web::get().to(handlers::rules::list_applicable_actions))
                     .route("/tickets/{id}", web::get().to(handlers::get_ticket))
                     .route("/tickets/{id}", web::put().to(handlers::update_ticket))
                     .route("/tickets/{id}", web::patch().to(handlers::update_ticket_partial))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1623,10 +1623,15 @@ async fn main() -> std::io::Result<()> {
                     // sibling to avoid the actix route-shadowing
                     // gotcha; same pattern as `/canned-response-starters`
                     // above. `/apply` itself is wired in Wave 6.
-                    // Starter catalog. Literal path registered ahead
-                    // of the wildcard `/rules/{id}` to dodge actix
-                    // shadowing.
-                    .route("/rules/starter-catalog", web::get().to(handlers::rules::list_starter_catalog))
+                    // Starter catalog lives at a distinct path
+                    // (`/admin/rule-starters`) rather than nested
+                    // under `/rules/...` so the wildcard
+                    // `/rules/{id}` GET can't absorb it. Same
+                    // precaution and same shape as the canned-
+                    // response-starters route above; the
+                    // `project_actix_route_shadowing` memory note
+                    // documents why ordering alone isn't enough.
+                    .route("/admin/rule-starters", web::get().to(handlers::rules::list_starter_catalog))
                     .route("/rules", web::get().to(handlers::rules::list_rules))
                     .route("/rules", web::post().to(handlers::rules::create_rule))
                     .route("/rules/{id}/apply", web::post().to(handlers::rules::apply_rule))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1625,6 +1625,7 @@ async fn main() -> std::io::Result<()> {
                     // above. `/apply` itself is wired in Wave 6.
                     .route("/rules", web::get().to(handlers::rules::list_rules))
                     .route("/rules", web::post().to(handlers::rules::create_rule))
+                    .route("/rules/{id}/apply", web::post().to(handlers::rules::apply_rule))
                     .route("/rules/{id}/state", web::patch().to(handlers::rules::transition_state))
                     .route("/rules/{id}/versions", web::get().to(handlers::rules::list_rule_versions))
                     .route("/rules/{rule_id}/versions/{version}", web::get().to(handlers::rules::get_rule_version))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1623,6 +1623,10 @@ async fn main() -> std::io::Result<()> {
                     // sibling to avoid the actix route-shadowing
                     // gotcha; same pattern as `/canned-response-starters`
                     // above. `/apply` itself is wired in Wave 6.
+                    // Starter catalog. Literal path registered ahead
+                    // of the wildcard `/rules/{id}` to dodge actix
+                    // shadowing.
+                    .route("/rules/starter-catalog", web::get().to(handlers::rules::list_starter_catalog))
                     .route("/rules", web::get().to(handlers::rules::list_rules))
                     .route("/rules", web::post().to(handlers::rules::create_rule))
                     .route("/rules/{id}/apply", web::post().to(handlers::rules::apply_rule))

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -6936,8 +6936,12 @@ pub struct Rule {
     pub trigger_config: serde_json::Value,
     pub conditions: serde_json::Value,
     pub actions: serde_json::Value,
-    pub reads_set: Vec<String>,
-    pub writes_set: Vec<String>,
+    // Postgres TEXT[] elements are nullable by default. The repository
+    // helpers only ever insert non-null values; reads expose the
+    // Option<String> shape Diesel's schema requires. Convert at the
+    // boundary in the API layer if a flat Vec<String> is needed.
+    pub reads_set: Vec<Option<String>>,
+    pub writes_set: Vec<Option<String>>,
     pub state: RuleState,
     pub priority: i32,
     pub last_fired_at: Option<DateTime<Utc>>,
@@ -6962,8 +6966,8 @@ pub struct NewRule {
     pub trigger_config: serde_json::Value,
     pub conditions: serde_json::Value,
     pub actions: serde_json::Value,
-    pub reads_set: Vec<String>,
-    pub writes_set: Vec<String>,
+    pub reads_set: Vec<Option<String>>,
+    pub writes_set: Vec<Option<String>>,
     pub state: RuleState,
     pub priority: i32,
     pub created_by: Option<Uuid>,
@@ -6982,8 +6986,8 @@ pub struct RuleUpdate {
     pub trigger_config: Option<serde_json::Value>,
     pub conditions: Option<serde_json::Value>,
     pub actions: Option<serde_json::Value>,
-    pub reads_set: Option<Vec<String>>,
-    pub writes_set: Option<Vec<String>>,
+    pub reads_set: Option<Vec<Option<String>>>,
+    pub writes_set: Option<Vec<Option<String>>>,
     pub state: Option<RuleState>,
     pub priority: Option<i32>,
     pub last_fired_at: Option<Option<DateTime<Utc>>>,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -6710,3 +6710,366 @@ pub mod email_suppression_reason {
     pub const HARD_BOUNCE: &str = "hard_bounce";
     pub const MANUAL: &str = "manual";
 }
+
+// =====================================================================
+// Rules engine (docs/rules-and-actions-plan.md). Phase 1 ships the
+// manual-trigger surface; the data model below is the unified shape
+// Phase 2 (event triggers), Phase 3 (time-elapsed), and Phase 4
+// (webhook actions) extend without schema changes.
+// =====================================================================
+
+/// Workflow state of a rule. `draft` is the editor's initial state,
+/// `dry_run` writes shadow rule_applications rows the admin reviews
+/// before flipping to `live`, `live` is in-flight, `archived` is a
+/// soft-deleted row that the picker / engine ignore. See decisions
+/// 12 + 32 in the plan: archived is the only state hard-delete is
+/// permitted from.
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    diesel::deserialize::FromSqlRow,
+    diesel::expression::AsExpression,
+)]
+#[diesel(sql_type = crate::schema::sql_types::RuleState)]
+pub enum RuleState {
+    #[serde(rename = "draft")]
+    Draft,
+    #[serde(rename = "dry_run")]
+    DryRun,
+    #[serde(rename = "live")]
+    Live,
+    #[serde(rename = "archived")]
+    Archived,
+}
+
+impl RuleState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Draft => "draft",
+            Self::DryRun => "dry_run",
+            Self::Live => "live",
+            Self::Archived => "archived",
+        }
+    }
+}
+
+impl ToSql<crate::schema::sql_types::RuleState, Pg> for RuleState {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        out.write_all(self.as_str().as_bytes())?;
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<crate::schema::sql_types::RuleState, Pg> for RuleState {
+    fn from_sql(bytes: PgValue) -> deserialize::Result<Self> {
+        match bytes.as_bytes() {
+            b"draft" => Ok(Self::Draft),
+            b"dry_run" => Ok(Self::DryRun),
+            b"live" => Ok(Self::Live),
+            b"archived" => Ok(Self::Archived),
+            other => Err(format!(
+                "unknown rule_state: {}",
+                String::from_utf8_lossy(other)
+            )
+            .into()),
+        }
+    }
+}
+
+/// What kind of event a rule reacts to. `manual` (Phase 1) is fired
+/// from the agent Actions toolbar; the rest (Phase 2+) are fired by
+/// the engine subscribing to the existing `sync_actions` stream
+/// (ticket_created / ticket_updated / ticket_replied) or the
+/// per-ticket due_at queue (time_elapsed).
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    diesel::deserialize::FromSqlRow,
+    diesel::expression::AsExpression,
+)]
+#[diesel(sql_type = crate::schema::sql_types::RuleTriggerKind)]
+pub enum RuleTriggerKind {
+    #[serde(rename = "manual")]
+    Manual,
+    #[serde(rename = "ticket_created")]
+    TicketCreated,
+    #[serde(rename = "ticket_updated")]
+    TicketUpdated,
+    #[serde(rename = "ticket_replied")]
+    TicketReplied,
+    #[serde(rename = "time_elapsed")]
+    TimeElapsed,
+}
+
+impl RuleTriggerKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::TicketCreated => "ticket_created",
+            Self::TicketUpdated => "ticket_updated",
+            Self::TicketReplied => "ticket_replied",
+            Self::TimeElapsed => "time_elapsed",
+        }
+    }
+}
+
+impl ToSql<crate::schema::sql_types::RuleTriggerKind, Pg> for RuleTriggerKind {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        out.write_all(self.as_str().as_bytes())?;
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<crate::schema::sql_types::RuleTriggerKind, Pg> for RuleTriggerKind {
+    fn from_sql(bytes: PgValue) -> deserialize::Result<Self> {
+        match bytes.as_bytes() {
+            b"manual" => Ok(Self::Manual),
+            b"ticket_created" => Ok(Self::TicketCreated),
+            b"ticket_updated" => Ok(Self::TicketUpdated),
+            b"ticket_replied" => Ok(Self::TicketReplied),
+            b"time_elapsed" => Ok(Self::TimeElapsed),
+            other => Err(format!(
+                "unknown rule_trigger_kind: {}",
+                String::from_utf8_lossy(other)
+            )
+            .into()),
+        }
+    }
+}
+
+/// Outcome of one fire attempt. Captured on every `rule_applications`
+/// row so the admin log can answer "why didn't this rule fire?"
+/// without log-tailing. See plan §4.3.
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    diesel::deserialize::FromSqlRow,
+    diesel::expression::AsExpression,
+)]
+#[diesel(sql_type = crate::schema::sql_types::RuleApplicationStatus)]
+pub enum RuleApplicationStatus {
+    #[serde(rename = "succeeded")]
+    Succeeded,
+    #[serde(rename = "dry_run")]
+    DryRun,
+    #[serde(rename = "skipped_preflight")]
+    SkippedPreflight,
+    #[serde(rename = "skipped_condition_unmet")]
+    SkippedConditionUnmet,
+    #[serde(rename = "suppressed_recursion_budget")]
+    SuppressedRecursionBudget,
+    #[serde(rename = "suppressed_loop_guard")]
+    SuppressedLoopGuard,
+    #[serde(rename = "failed")]
+    Failed,
+}
+
+impl RuleApplicationStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::DryRun => "dry_run",
+            Self::SkippedPreflight => "skipped_preflight",
+            Self::SkippedConditionUnmet => "skipped_condition_unmet",
+            Self::SuppressedRecursionBudget => "suppressed_recursion_budget",
+            Self::SuppressedLoopGuard => "suppressed_loop_guard",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl ToSql<crate::schema::sql_types::RuleApplicationStatus, Pg> for RuleApplicationStatus {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        out.write_all(self.as_str().as_bytes())?;
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<crate::schema::sql_types::RuleApplicationStatus, Pg> for RuleApplicationStatus {
+    fn from_sql(bytes: PgValue) -> deserialize::Result<Self> {
+        match bytes.as_bytes() {
+            b"succeeded" => Ok(Self::Succeeded),
+            b"dry_run" => Ok(Self::DryRun),
+            b"skipped_preflight" => Ok(Self::SkippedPreflight),
+            b"skipped_condition_unmet" => Ok(Self::SkippedConditionUnmet),
+            b"suppressed_recursion_budget" => Ok(Self::SuppressedRecursionBudget),
+            b"suppressed_loop_guard" => Ok(Self::SuppressedLoopGuard),
+            b"failed" => Ok(Self::Failed),
+            other => Err(format!(
+                "unknown rule_application_status: {}",
+                String::from_utf8_lossy(other)
+            )
+            .into()),
+        }
+    }
+}
+
+/// One rule. Read view; INSERTs go via `NewRule` and UPDATEs via
+/// `RuleUpdate`. `reads_set` and `writes_set` are derived from
+/// `conditions` and `actions` at save time by the repository helper.
+#[derive(Debug, Clone, Serialize, Deserialize, Identifiable, Queryable)]
+#[diesel(table_name = crate::schema::rules)]
+pub struct Rule {
+    pub id: i32,
+    pub workspace_id: i32,
+    pub name: String,
+    pub description: Option<String>,
+    pub trigger_kind: RuleTriggerKind,
+    pub trigger_config: serde_json::Value,
+    pub conditions: serde_json::Value,
+    pub actions: serde_json::Value,
+    pub reads_set: Vec<String>,
+    pub writes_set: Vec<String>,
+    pub state: RuleState,
+    pub priority: i32,
+    pub last_fired_at: Option<DateTime<Utc>>,
+    pub fire_count: i32,
+    pub created_by: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub archived_at: Option<DateTime<Utc>>,
+}
+
+/// INSERT row for `rules`. The repository populates `reads_set` and
+/// `writes_set` from the conditions / actions trees before passing
+/// this in, so the engine's skip-on-no-reads-changed query path and
+/// the self-referential save linter both work off durable columns.
+#[derive(Debug, Insertable)]
+#[diesel(table_name = crate::schema::rules)]
+pub struct NewRule {
+    pub workspace_id: i32,
+    pub name: String,
+    pub description: Option<String>,
+    pub trigger_kind: RuleTriggerKind,
+    pub trigger_config: serde_json::Value,
+    pub conditions: serde_json::Value,
+    pub actions: serde_json::Value,
+    pub reads_set: Vec<String>,
+    pub writes_set: Vec<String>,
+    pub state: RuleState,
+    pub priority: i32,
+    pub created_by: Option<Uuid>,
+}
+
+/// PATCH row for `rules`. Every field is `Option`-wrapped so the
+/// editor's partial updates round-trip without clobbering unsent
+/// fields. The repository's update path recomputes `reads_set` /
+/// `writes_set` when conditions or actions move.
+#[derive(Debug, Default, AsChangeset)]
+#[diesel(table_name = crate::schema::rules)]
+pub struct RuleUpdate {
+    pub name: Option<String>,
+    pub description: Option<Option<String>>,
+    pub trigger_kind: Option<RuleTriggerKind>,
+    pub trigger_config: Option<serde_json::Value>,
+    pub conditions: Option<serde_json::Value>,
+    pub actions: Option<serde_json::Value>,
+    pub reads_set: Option<Vec<String>>,
+    pub writes_set: Option<Vec<String>>,
+    pub state: Option<RuleState>,
+    pub priority: Option<i32>,
+    pub last_fired_at: Option<Option<DateTime<Utc>>>,
+    pub fire_count: Option<i32>,
+    pub archived_at: Option<Option<DateTime<Utc>>>,
+}
+
+/// One immutable snapshot of a rule's fields at save time. The
+/// repository never INSERTs into this table directly; the
+/// `rules_version_on_insert` and `rules_version_on_update` triggers
+/// in the migration do.
+#[derive(Debug, Clone, Serialize, Deserialize, Identifiable, Queryable)]
+#[diesel(table_name = crate::schema::rule_versions)]
+pub struct RuleVersion {
+    pub id: i32,
+    pub rule_id: i32,
+    pub workspace_id: i32,
+    pub version: i32,
+    pub name: String,
+    pub description: Option<String>,
+    pub trigger_kind: RuleTriggerKind,
+    pub trigger_config: serde_json::Value,
+    pub conditions: serde_json::Value,
+    pub actions: serde_json::Value,
+    pub state: RuleState,
+    pub priority: i32,
+    pub saved_by: Option<Uuid>,
+    pub saved_at: DateTime<Utc>,
+}
+
+/// One row per fire attempt. See plan §4.3 for the shape: succeeded
+/// rows are tight (no payloads); dry_run + failed + suppressed_* +
+/// skipped_* rows carry condition / action snapshots for the
+/// inspector to render.
+#[derive(Debug, Clone, Serialize, Deserialize, Identifiable, Queryable)]
+#[diesel(table_name = crate::schema::rule_applications)]
+pub struct RuleApplication {
+    pub id: i64,
+    pub workspace_id: i32,
+    pub rule_id: i32,
+    pub rule_version: i32,
+    pub ticket_id: i32,
+    pub status: RuleApplicationStatus,
+    pub correlation_id: Option<Uuid>,
+    pub actor_uuid: Option<Uuid>,
+    pub actor_kind: String,
+    pub originating_event_id: Option<Uuid>,
+    pub originating_event_kind: Option<String>,
+    pub condition_evaluation: Option<serde_json::Value>,
+    pub actions_taken: Option<serde_json::Value>,
+    pub actions_skipped: Option<serde_json::Value>,
+    pub failure_reason: Option<String>,
+    pub applied_at: DateTime<Utc>,
+}
+
+/// INSERT row for `rule_applications`. Built by the engine inside
+/// the apply transaction so the correlation_id stitches with the
+/// audit_log + sync_actions rows the same apply produced.
+#[derive(Debug, Insertable)]
+#[diesel(table_name = crate::schema::rule_applications)]
+pub struct NewRuleApplication {
+    pub workspace_id: i32,
+    pub rule_id: i32,
+    pub rule_version: i32,
+    pub ticket_id: i32,
+    pub status: RuleApplicationStatus,
+    pub correlation_id: Option<Uuid>,
+    pub actor_uuid: Option<Uuid>,
+    pub actor_kind: String,
+    pub originating_event_id: Option<Uuid>,
+    pub originating_event_kind: Option<String>,
+    pub condition_evaluation: Option<serde_json::Value>,
+    pub actions_taken: Option<serde_json::Value>,
+    pub actions_skipped: Option<serde_json::Value>,
+    pub failure_reason: Option<String>,
+}
+
+/// Per-event recursion budget row. The engine attempts an INSERT
+/// for every fire candidate; ON CONFLICT means the budget is
+/// consumed and the fire is suppressed. Phase 2 substrate (no
+/// active writer in Phase 1).
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Insertable)]
+#[diesel(table_name = crate::schema::ticket_rule_runs, primary_key(event_id, ticket_id, rule_id))]
+pub struct TicketRuleRun {
+    pub event_id: Uuid,
+    pub ticket_id: i32,
+    pub rule_id: i32,
+    pub fired_at: DateTime<Utc>,
+}

--- a/backend/src/repository/mod.rs
+++ b/backend/src/repository/mod.rs
@@ -28,6 +28,7 @@ pub mod linked_tickets;
 pub mod outbound_emails;
 pub mod passkey_credentials;
 pub mod projects;
+pub mod rules;
 pub mod saved_views;
 pub mod search_query_log;
 pub mod sla;

--- a/backend/src/repository/rules.rs
+++ b/backend/src/repository/rules.rs
@@ -1,0 +1,615 @@
+//! CRUD for the unified rules engine. Phase 1 surface only: list,
+//! find, create, update, archive, hard-delete, plus the version /
+//! application read paths and the application insert path. The
+//! atomic apply lifecycle lives in `repository::rules::apply` (Wave
+//! 5); this module is the data access layer the lifecycle and the
+//! HTTP handlers call into.
+//!
+//! Workspace isolation is enforced by Postgres RLS (the
+//! `rules_workspace_isolation` and sibling policies in the
+//! migration), so the queries below don't add explicit
+//! `workspace_id = ?` filters — the session's `app.workspace_id`
+//! GUC scopes every read and the `WITH CHECK` clause rejects any
+//! write to another workspace. Callers in handler code already
+//! resolve the GUC via the request actor context; the helpers here
+//! just need the workspace_id to populate `NewRule.workspace_id`
+//! on insert.
+//!
+//! The `reads_set` / `writes_set` derivation tables in plan §11.2
+//! live in this module so the self-referential save linter (Wave
+//! 4) reads them off a single source of truth.
+
+use diesel::prelude::*;
+use diesel::QueryResult;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::db::DbConnection;
+use crate::models::{
+    NewRule, NewRuleApplication, Rule, RuleApplication, RuleApplicationStatus, RuleState,
+    RuleTriggerKind, RuleUpdate, RuleVersion,
+};
+
+// =====================================================================
+// reads_set / writes_set derivation (plan §11.2). Pure helpers; the
+// repository calls them on every save so the columns stay in sync
+// with the conditions and actions trees.
+// =====================================================================
+
+/// Walk `conditions` and return the sorted, deduplicated list of
+/// `ConditionField` strings the rule reads. Manual rules pass `[]`
+/// and get an empty `reads_set` back. Nested-field expansion
+/// (`ticket.requester.email` adding both itself and
+/// `ticket.requester_uuid`) is applied per the plan's derivation
+/// table.
+///
+/// The return type is `Vec<Option<String>>` because Postgres TEXT[]
+/// columns reach Rust through Diesel with nullable elements. The
+/// derivation only ever produces real strings; the inner Option is
+/// the schema boundary, not a semantic null.
+pub fn derive_reads_set(conditions: &Value) -> Vec<Option<String>> {
+    let mut out = std::collections::BTreeSet::new();
+    collect_condition_fields(conditions, &mut out);
+    out.into_iter().map(Some).collect()
+}
+
+fn collect_condition_fields(node: &Value, out: &mut std::collections::BTreeSet<String>) {
+    // Manual rules: conditions is `[]`. Nothing to walk.
+    if node.is_array() && node.as_array().is_some_and(|a| a.is_empty()) {
+        return;
+    }
+    let Some(obj) = node.as_object() else { return };
+    let kind = obj.get("kind").and_then(|k| k.as_str()).unwrap_or("");
+    match kind {
+        "leaf" => {
+            if let Some(field) = obj.get("field").and_then(|f| f.as_str()) {
+                for expanded in expand_condition_field(field) {
+                    out.insert(expanded);
+                }
+            }
+        }
+        "and" | "or" => {
+            if let Some(children) = obj.get("children").and_then(|c| c.as_array()) {
+                for child in children {
+                    collect_condition_fields(child, out);
+                }
+            }
+        }
+        "not" => {
+            if let Some(child) = obj.get("child") {
+                collect_condition_fields(child, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Plan §11.2 reads_set derivation table. Each entry returns the
+/// concrete `reads_set` keys for one `ConditionField`. Status and
+/// workflow_state_id alias the same underlying column so a rule
+/// conditioning on either reads both. Nested requester fields also
+/// add `ticket.requester_uuid` because mutating the requester (FK)
+/// implicitly changes those values.
+fn expand_condition_field(field: &str) -> Vec<String> {
+    match field {
+        "ticket.status" => vec!["ticket.workflow_state.category".into()],
+        "ticket.workflow_state_id" => vec![
+            "ticket.workflow_state_id".into(),
+            "ticket.workflow_state.category".into(),
+        ],
+        "ticket.workflow_state.category" => vec![
+            "ticket.workflow_state.category".into(),
+            "ticket.workflow_state_id".into(),
+        ],
+        "ticket.requester.email" => vec![
+            "ticket.requester.email".into(),
+            "ticket.requester_uuid".into(),
+        ],
+        "ticket.requester.organization_id" => vec![
+            "ticket.requester.organization_id".into(),
+            "ticket.requester_uuid".into(),
+        ],
+        // Event / clock metadata is not ticket state, so no
+        // reads_set contribution.
+        "event.changed_fields" | "reply.kind" | "reply.author_role" | "clock.minutes_since" => {
+            vec![]
+        }
+        // Everything else maps to itself.
+        other => vec![other.to_string()],
+    }
+}
+
+/// Walk `actions` and return the sorted, deduplicated list of
+/// ticket-state fields the rule writes. Plan §11.2 derivation
+/// table; the synthetic `ticket.comments` key flags reply-style
+/// actions so Phase 2's `ticket_replied` trigger can detect
+/// rule-replies-to-its-own-reply self-loops.
+///
+/// Same `Vec<Option<String>>` schema-boundary shape as
+/// [`derive_reads_set`].
+pub fn derive_writes_set(actions: &Value) -> Vec<Option<String>> {
+    let mut out = std::collections::BTreeSet::new();
+    let Some(arr) = actions.as_array() else {
+        return Vec::new();
+    };
+    for action in arr {
+        let Some(obj) = action.as_object() else { continue };
+        let Some(kind) = obj.get("kind").and_then(|k| k.as_str()) else {
+            continue;
+        };
+        for w in writes_for_action_kind(kind) {
+            out.insert(w.to_string());
+        }
+    }
+    out.into_iter().map(Some).collect()
+}
+
+fn writes_for_action_kind(kind: &str) -> &'static [&'static str] {
+    match kind {
+        "reply" => &[
+            "ticket.first_response_at",
+            "ticket.updated_at",
+            "ticket.comments",
+        ],
+        "set_status" => &[
+            "ticket.workflow_state_id",
+            "ticket.workflow_state.category",
+            "ticket.resolved_at",
+            "ticket.updated_at",
+        ],
+        "assign" => &["ticket.assignee_uuid", "ticket.updated_at"],
+        "unassign" => &["ticket.assignee_uuid", "ticket.updated_at"],
+        "add_tags" => &["ticket.tag_ids", "ticket.updated_at"],
+        "remove_tags" => &["ticket.tag_ids", "ticket.updated_at"],
+        "set_priority" => &["ticket.priority", "ticket.updated_at"],
+        "apply_macro_template" => &[
+            "ticket.first_response_at",
+            "ticket.updated_at",
+            "ticket.comments",
+        ],
+        // notify, webhook, stop_processing have no ticket-state
+        // writes (outbound side-effects only or engine control).
+        _ => &[],
+    }
+}
+
+// =====================================================================
+// List / find. Workspace scoping is via RLS — the queries below
+// rely on the session's app.workspace_id GUC and don't repeat it
+// in WHERE clauses (matching the existing tenant-table pattern).
+// =====================================================================
+
+/// Filter shape for [`list`]. The handler unpacks query params into
+/// this; the picker call site uses [`list_pickable_manual`] which
+/// hardcodes its own filter.
+#[derive(Debug, Default, Clone)]
+pub struct ListFilter {
+    pub trigger_kind: Option<RuleTriggerKind>,
+    pub state: Option<RuleState>,
+    pub include_archived: bool,
+    pub name_query: Option<String>,
+}
+
+/// List rules visible in the current workspace, ordered by priority
+/// then name. `archived_at IS NULL` unless `include_archived` is
+/// explicitly set (the admin "show archived" toggle).
+pub fn list(conn: &mut DbConnection, filter: ListFilter) -> QueryResult<Vec<Rule>> {
+    use crate::schema::rules::dsl;
+    let mut query = dsl::rules.into_boxed();
+    if !filter.include_archived {
+        query = query.filter(dsl::archived_at.is_null());
+    }
+    if let Some(kind) = filter.trigger_kind {
+        query = query.filter(dsl::trigger_kind.eq(kind));
+    }
+    if let Some(state) = filter.state {
+        query = query.filter(dsl::state.eq(state));
+    }
+    if let Some(q) = filter.name_query {
+        // `ILIKE %q%` style match for the admin search box. The
+        // bound % wrappers go through Diesel's escape path so a
+        // literal `%` in the query is treated as literal.
+        let pattern = format!("%{}%", q.replace('%', "\\%").replace('_', "\\_"));
+        query = query.filter(dsl::name.ilike(pattern));
+    }
+    query
+        .order((dsl::priority.asc(), dsl::name.asc()))
+        .load(conn)
+}
+
+/// Live, non-archived, manual-trigger rules for the agent toolbar
+/// picker (plan §13.4). Phase 1 has no per-ticket condition
+/// evaluation since manual rules carry `conditions = []` by the
+/// `rules_manual_no_conditions` CHECK.
+pub fn list_pickable_manual(conn: &mut DbConnection) -> QueryResult<Vec<Rule>> {
+    use crate::schema::rules::dsl;
+    dsl::rules
+        .filter(dsl::archived_at.is_null())
+        .filter(dsl::state.eq(RuleState::Live))
+        .filter(dsl::trigger_kind.eq(RuleTriggerKind::Manual))
+        .order((dsl::priority.asc(), dsl::name.asc()))
+        .load(conn)
+}
+
+pub fn find(conn: &mut DbConnection, id: i32) -> QueryResult<Option<Rule>> {
+    use crate::schema::rules::dsl;
+    dsl::rules.find(id).first(conn).optional()
+}
+
+// =====================================================================
+// Create / update / archive / hard-delete.
+// =====================================================================
+
+/// Result type for write paths that need to distinguish "row not
+/// found" and "row not in the right state for this op" from a
+/// transient DB error.
+#[derive(Debug, thiserror::Error)]
+pub enum WriteError {
+    #[error("rule {0} not found")]
+    NotFound(i32),
+    #[error("rule {0} must be archived before hard delete")]
+    NotArchived(i32),
+    #[error("database error: {0}")]
+    Db(#[from] diesel::result::Error),
+}
+
+// sync-pending-wire: needs sync aggregate wiring (rules.created on Insert)
+/// Insert a new rule. `reads_set` and `writes_set` are computed
+/// from `conditions` / `actions` before insert so the columns stay
+/// in sync with the JSONB trees they derive from. Manual rules
+/// pass `conditions = []` and get an empty `reads_set` populated.
+pub fn create(conn: &mut DbConnection, mut new: NewRule) -> QueryResult<Rule> {
+    use crate::schema::rules::dsl;
+    new.reads_set = derive_reads_set(&new.conditions);
+    new.writes_set = derive_writes_set(&new.actions);
+    diesel::insert_into(dsl::rules)
+        .values(&new)
+        .get_result(conn)
+}
+
+// sync-pending-wire: needs sync aggregate wiring (rules.updated on Update)
+/// Apply a partial update. If `conditions` or `actions` move,
+/// `reads_set` / `writes_set` are recomputed and overwritten on
+/// the change set; any explicit set the caller passed is ignored.
+/// The migration's BEFORE UPDATE trigger writes a `rule_versions`
+/// snapshot and bumps `updated_at`.
+pub fn update(
+    conn: &mut DbConnection,
+    id: i32,
+    mut change: RuleUpdate,
+) -> Result<Rule, WriteError> {
+    use crate::schema::rules::dsl;
+    if let Some(ref conditions) = change.conditions {
+        change.reads_set = Some(derive_reads_set(conditions));
+    }
+    if let Some(ref actions) = change.actions {
+        change.writes_set = Some(derive_writes_set(actions));
+    }
+    diesel::update(dsl::rules.find(id))
+        .set(&change)
+        .get_result::<Rule>(conn)
+        .map_err(|e| match e {
+            diesel::result::Error::NotFound => WriteError::NotFound(id),
+            other => WriteError::Db(other),
+        })
+}
+
+// sync-pending-wire: needs sync aggregate wiring (rules.archived on Update)
+/// Soft-archive. Sets `archived_at = NOW()` and is the only path
+/// the admin "Delete" button drives; hard delete requires
+/// archived_at to already be set per decision 32 in the plan.
+pub fn archive(conn: &mut DbConnection, id: i32, when: chrono::DateTime<chrono::Utc>) -> Result<Rule, WriteError> {
+    use crate::schema::rules::dsl;
+    diesel::update(dsl::rules.find(id))
+        .set(dsl::archived_at.eq(Some(when)))
+        .get_result::<Rule>(conn)
+        .map_err(|e| match e {
+            diesel::result::Error::NotFound => WriteError::NotFound(id),
+            other => WriteError::Db(other),
+        })
+}
+
+// sync-pending-wire: needs sync aggregate wiring (rules.deleted on Delete)
+/// Permanently delete a rule. The caller must have already
+/// archived it; we return `NotArchived` rather than implicitly
+/// soft-archiving so the admin can't bypass the "review recent
+/// activity before destroying it" UX gate by hitting the API
+/// directly. Cascades into `rule_versions` and `rule_applications`
+/// via the FK.
+pub fn hard_delete(conn: &mut DbConnection, id: i32) -> Result<(), WriteError> {
+    use crate::schema::rules::dsl;
+    let existing: Rule = dsl::rules
+        .find(id)
+        .first(conn)
+        .map_err(|e| match e {
+            diesel::result::Error::NotFound => WriteError::NotFound(id),
+            other => WriteError::Db(other),
+        })?;
+    if existing.archived_at.is_none() {
+        return Err(WriteError::NotArchived(id));
+    }
+    diesel::delete(dsl::rules.find(id)).execute(conn)?;
+    Ok(())
+}
+
+// =====================================================================
+// Versions (read-only; the migration's INSERT/UPDATE triggers do
+// the writes).
+// =====================================================================
+
+pub fn list_versions(conn: &mut DbConnection, rule_id: i32) -> QueryResult<Vec<RuleVersion>> {
+    use crate::schema::rule_versions::dsl;
+    dsl::rule_versions
+        .filter(dsl::rule_id.eq(rule_id))
+        .order(dsl::version.desc())
+        .load(conn)
+}
+
+pub fn find_version(
+    conn: &mut DbConnection,
+    rule_id: i32,
+    version: i32,
+) -> QueryResult<Option<RuleVersion>> {
+    use crate::schema::rule_versions::dsl;
+    dsl::rule_versions
+        .filter(dsl::rule_id.eq(rule_id))
+        .filter(dsl::version.eq(version))
+        .first(conn)
+        .optional()
+}
+
+// =====================================================================
+// Applications (the audit / recent-activity log).
+// =====================================================================
+
+/// Filter shape for [`list_applications`]. The recent-activity
+/// admin endpoint unpacks query params into this.
+#[derive(Debug, Default, Clone)]
+pub struct ApplicationFilter {
+    pub rule_id: Option<i32>,
+    pub ticket_id: Option<i32>,
+    pub status: Option<RuleApplicationStatus>,
+    pub actor_uuid: Option<Uuid>,
+    pub from: Option<chrono::DateTime<chrono::Utc>>,
+    pub to: Option<chrono::DateTime<chrono::Utc>>,
+    pub limit: i64,
+}
+
+pub fn list_applications(
+    conn: &mut DbConnection,
+    filter: ApplicationFilter,
+) -> QueryResult<Vec<RuleApplication>> {
+    use crate::schema::rule_applications::dsl;
+    let mut query = dsl::rule_applications.into_boxed();
+    if let Some(rid) = filter.rule_id {
+        query = query.filter(dsl::rule_id.eq(rid));
+    }
+    if let Some(tid) = filter.ticket_id {
+        query = query.filter(dsl::ticket_id.eq(tid));
+    }
+    if let Some(status) = filter.status {
+        query = query.filter(dsl::status.eq(status));
+    }
+    if let Some(actor) = filter.actor_uuid {
+        query = query.filter(dsl::actor_uuid.eq(actor));
+    }
+    if let Some(from) = filter.from {
+        query = query.filter(dsl::applied_at.ge(from));
+    }
+    if let Some(to) = filter.to {
+        query = query.filter(dsl::applied_at.le(to));
+    }
+    let limit = filter.limit.clamp(1, 500);
+    query
+        .order(dsl::applied_at.desc())
+        .limit(limit)
+        .load(conn)
+}
+
+pub fn find_application(
+    conn: &mut DbConnection,
+    id: i64,
+) -> QueryResult<Option<RuleApplication>> {
+    use crate::schema::rule_applications::dsl;
+    dsl::rule_applications.find(id).first(conn).optional()
+}
+
+pub fn list_applications_for_ticket(
+    conn: &mut DbConnection,
+    ticket_id: i32,
+) -> QueryResult<Vec<RuleApplication>> {
+    use crate::schema::rule_applications::dsl;
+    dsl::rule_applications
+        .filter(dsl::ticket_id.eq(ticket_id))
+        .order(dsl::applied_at.desc())
+        .load(conn)
+}
+
+// sync-audit-only: rule-application audit row, no entity sync
+/// Insert one application row. Called from inside the apply
+/// lifecycle's transaction so the row's `correlation_id` matches
+/// the audit_log + sync_actions rows the same apply produced.
+pub fn record_application(
+    conn: &mut DbConnection,
+    new: NewRuleApplication,
+) -> QueryResult<RuleApplication> {
+    use crate::schema::rule_applications::dsl;
+    diesel::insert_into(dsl::rule_applications)
+        .values(&new)
+        .get_result(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Strip the Option wrapper so test assertions stay readable.
+    /// Production code keeps the Option<String> shape because that's
+    /// what Diesel hands back for Array<Nullable<Text>> columns.
+    fn flat(v: Vec<Option<String>>) -> Vec<String> {
+        v.into_iter().flatten().collect()
+    }
+
+    #[test]
+    fn empty_conditions_derive_empty_reads_set() {
+        let conditions = json!([]);
+        assert!(derive_reads_set(&conditions).is_empty());
+    }
+
+    #[test]
+    fn single_leaf_condition_picks_one_field() {
+        let conditions = json!({
+            "kind": "leaf",
+            "field": "ticket.priority",
+            "op": "eq",
+            "value": "high"
+        });
+        assert_eq!(flat(derive_reads_set(&conditions)), vec!["ticket.priority"]);
+    }
+
+    #[test]
+    fn and_tree_collects_every_leaf() {
+        let conditions = json!({
+            "kind": "and",
+            "children": [
+                {"kind": "leaf", "field": "ticket.priority", "op": "eq", "value": "high"},
+                {"kind": "leaf", "field": "ticket.category_id", "op": "eq", "value": 12}
+            ]
+        });
+        let reads = flat(derive_reads_set(&conditions));
+        assert_eq!(reads, vec!["ticket.category_id", "ticket.priority"]);
+    }
+
+    #[test]
+    fn not_wraps_and_traversal_continues() {
+        let conditions = json!({
+            "kind": "not",
+            "child": {
+                "kind": "or",
+                "children": [
+                    {"kind": "leaf", "field": "ticket.title", "op": "contains", "value": "spam"},
+                    {"kind": "leaf", "field": "ticket.tag_ids", "op": "has_any", "value": [1]}
+                ]
+            }
+        });
+        let reads = flat(derive_reads_set(&conditions));
+        assert_eq!(reads, vec!["ticket.tag_ids", "ticket.title"]);
+    }
+
+    #[test]
+    fn status_alias_expands_to_category() {
+        let conditions = json!({
+            "kind": "leaf",
+            "field": "ticket.status",
+            "op": "eq",
+            "value": "open"
+        });
+        let reads = flat(derive_reads_set(&conditions));
+        // ticket.status aliases the category column; conditioning
+        // on either flags both for the linter so a rule that
+        // mutates workflow_state_id while reading status is
+        // caught as self-referential.
+        assert_eq!(reads, vec!["ticket.workflow_state.category"]);
+    }
+
+    #[test]
+    fn workflow_state_id_and_category_alias_each_other() {
+        let conditions = json!({
+            "kind": "leaf",
+            "field": "ticket.workflow_state_id",
+            "op": "eq",
+            "value": 4
+        });
+        let reads = flat(derive_reads_set(&conditions));
+        assert_eq!(
+            reads,
+            vec![
+                "ticket.workflow_state.category",
+                "ticket.workflow_state_id"
+            ]
+        );
+    }
+
+    #[test]
+    fn requester_email_expands_to_parent_uuid() {
+        let conditions = json!({
+            "kind": "leaf",
+            "field": "ticket.requester.email",
+            "op": "ends_with",
+            "value": "@vip.example"
+        });
+        let reads = flat(derive_reads_set(&conditions));
+        assert_eq!(
+            reads,
+            vec!["ticket.requester.email", "ticket.requester_uuid"]
+        );
+    }
+
+    #[test]
+    fn event_and_clock_fields_do_not_count_as_ticket_reads() {
+        // These read event / engine metadata, not ticket state.
+        // The self-referential linter only cares about state-vs-
+        // state intersections.
+        let conditions = json!({
+            "kind": "and",
+            "children": [
+                {"kind": "leaf", "field": "event.changed_fields", "op": "has_any", "value": ["status"]},
+                {"kind": "leaf", "field": "clock.minutes_since", "op": "gt", "value": 60}
+            ]
+        });
+        assert!(derive_reads_set(&conditions).is_empty());
+    }
+
+    #[test]
+    fn writes_set_from_set_status_action() {
+        let actions = json!([
+            { "kind": "set_status", "config": { "workflow_state_id": 7 } }
+        ]);
+        let writes = flat(derive_writes_set(&actions));
+        assert_eq!(
+            writes,
+            vec![
+                "ticket.resolved_at",
+                "ticket.updated_at",
+                "ticket.workflow_state.category",
+                "ticket.workflow_state_id"
+            ]
+        );
+    }
+
+    #[test]
+    fn writes_set_dedupes_across_actions() {
+        let actions = json!([
+            { "kind": "add_tags", "config": { "tag_ids": [1, 2] } },
+            { "kind": "remove_tags", "config": { "tag_ids": [3] } }
+        ]);
+        let writes = flat(derive_writes_set(&actions));
+        assert_eq!(writes, vec!["ticket.tag_ids", "ticket.updated_at"]);
+    }
+
+    #[test]
+    fn reply_action_includes_synthetic_comments_key() {
+        let actions = json!([
+            { "kind": "reply", "config": { "visibility": "public", "body": "hi" } }
+        ]);
+        let writes = flat(derive_writes_set(&actions));
+        assert!(writes.iter().any(|s| s == "ticket.comments"));
+    }
+
+    #[test]
+    fn notify_action_has_no_ticket_state_writes() {
+        let actions = json!([
+            { "kind": "notify", "config": { "recipient": "requester", "subject": "x", "body": "y" } }
+        ]);
+        assert!(derive_writes_set(&actions).is_empty());
+    }
+
+    #[test]
+    fn stop_processing_action_contributes_nothing() {
+        let actions = json!([
+            { "kind": "stop_processing" }
+        ]);
+        assert!(derive_writes_set(&actions).is_empty());
+    }
+}

--- a/backend/src/repository/rules.rs
+++ b/backend/src/repository/rules.rs
@@ -529,6 +529,12 @@ pub enum ApplyError {
     UnsupportedActionPhase1 { index: usize, message: String },
     #[error("rule action [{index}] failed: {message}")]
     ActionFailed { index: usize, message: String },
+    /// The actor's user row was not found or is soft-deleted. Distinct
+    /// from a transient DB error so the handler can return 401/410
+    /// instead of 500 when an agent's account is revoked between the
+    /// JWT validation and the apply transaction.
+    #[error("actor user {0} not found or revoked")]
+    AgentRevoked(Uuid),
     #[error("actor has no workspace context")]
     MissingWorkspace,
     #[error("database error: {0}")]
@@ -608,6 +614,11 @@ pub fn apply_manual(
         let mut applied_reply_body_override = false;
 
         for (i, action) in actions.iter().enumerate() {
+            // Executors receive `one_based` so any ActionFailed they
+            // raise carries the index of the failing action rather
+            // than a placeholder. The error envelope downstream
+            // shows the admin which position in the rule's action
+            // list to investigate.
             let one_based = i + 1;
             if suppress.contains(&one_based) {
                 actions_skipped.push(json!({
@@ -636,7 +647,7 @@ pub fn apply_manual(
                     } else {
                         None
                     };
-                    execute_reply(conn, &ticket, actor, &config, override_body)?
+                    execute_reply(conn, one_based, &ticket, actor, &config, override_body)?
                         .map(|c| {
                             if comment_id.is_none() {
                                 comment_id = Some(c);
@@ -645,11 +656,11 @@ pub fn apply_manual(
                         })
                         .unwrap_or_else(|| json!({ "index": one_based, "kind": kind }))
                 }
-                "set_status" => execute_set_status(conn, ticket.id, &config)
+                "set_status" => execute_set_status(conn, one_based, ticket.id, &config)
                     .map(|state_id| {
                         json!({ "index": one_based, "kind": kind, "workflow_state_id": state_id })
                     })?,
-                "assign" => execute_assign(conn, ticket.id, workspace_id, rule.id, &config)
+                "assign" => execute_assign(conn, one_based, ticket.id, &config)
                     .map(|uuid| {
                         json!({ "index": one_based, "kind": kind, "assigned_to_uuid": uuid })
                     })?,
@@ -662,7 +673,7 @@ pub fn apply_manual(
                 "remove_tags" => execute_remove_tags(conn, ticket.id, &config).map(|removed| {
                     json!({ "index": one_based, "kind": kind, "tag_ids_removed": removed })
                 })?,
-                "set_priority" => execute_set_priority(conn, ticket.id, &config)
+                "set_priority" => execute_set_priority(conn, one_based, ticket.id, &config)
                     .map(|p| json!({ "index": one_based, "kind": kind, "priority": p }))?,
                 "stop_processing" => {
                     // No-op for manual apply; only meaningful inside
@@ -798,12 +809,21 @@ pub fn apply_manual(
 /// (when the caller doesn't pass an override), inserts a comment,
 /// and returns the new comment id. Internal vs public is the
 /// action's `visibility` flag (see plan §5.3); the comment row
-/// stamps `is_internal` accordingly. The customer-channel dispatch
-/// for `visibility=public` runs through the existing
-/// `comments::create_comment` observer pipeline, so an outbound
-/// queue row is enqueued for tickets with an email channel.
+/// stamps `is_internal` accordingly. Outbound channel dispatch
+/// (customer email relay) is the apply handler's
+/// post-commit job; this executor only writes the comment row +
+/// emits the comment.created sync event via
+/// `comments::create_comment`.
+///
+/// Substituted template variable values are HTML-escaped before
+/// the substitution so an untrusted value (e.g. a requester whose
+/// IdP-synced display name carries HTML metacharacters) cannot
+/// inject markup into the rendered HTML comment body. The body
+/// template itself (admin-authored, vetted at save) is not
+/// escaped — admins routinely write <br> / <b> deliberately.
 fn execute_reply(
     conn: &mut DbConnection,
+    action_index: usize,
     ticket: &crate::models::Ticket,
     actor: &ActorContext,
     config: &Value,
@@ -821,25 +841,42 @@ fn execute_reply(
                 .map(|s| s.to_string())
         })
         .ok_or_else(|| ApplyError::ActionFailed {
-            index: 0,
+            index: action_index,
             message: "reply action missing body".to_string(),
         })?;
 
-    // Phase 1: render with a context built from the loaded ticket
-    // + actor. The renderer falls back to empty strings for
-    // unknown bindings, so a body referencing customer_name on a
-    // requester-less ticket renders "Hi ,".
     let actor_uuid = actor.uuid.ok_or_else(|| ApplyError::ActionFailed {
-        index: 0,
+        index: action_index,
         message: "manual reply requires an authenticated actor".to_string(),
     })?;
-    let agent = crate::repository::users::find_active_by_uuid(&actor_uuid, conn)?;
+    // The agent's row is required (we need their display name for
+    // template rendering); NotFound (revoked / soft-deleted)
+    // surfaces as AgentRevoked → 401 rather than Db → 500.
+    let agent = crate::repository::users::find_active_by_uuid(&actor_uuid, conn).map_err(|e| {
+        match e {
+            diesel::result::Error::NotFound => ApplyError::AgentRevoked(actor_uuid),
+            other => ApplyError::Db(other),
+        }
+    })?;
+    // Requester is optional — anonymous tickets and revoked
+    // requesters both surface as None and the renderer falls back
+    // to empty bindings. Same .ok() shape as the lazy OIDC path.
     let requester = if let Some(uuid) = ticket.requester_uuid {
         crate::repository::users::find_active_by_uuid(&uuid, conn).ok()
     } else {
         None
     };
-    let app_name = std::env::var("APP_NAME").unwrap_or_else(|_| "Nosdesk".to_string());
+    // Pull the workspace-scoped app_name from site_settings; this
+    // mirrors how email signatures and password-reset notices
+    // resolve the brand string. Falls back to "Nosdesk" only if
+    // the row genuinely doesn't carry an app_name.
+    // SiteSettings.app_name is String (not Option) and the row is
+    // singleton-id=1; fall back to "Nosdesk" only if the row read
+    // genuinely fails (extremely rare — get_site_settings returns
+    // Err only on disconnected DB).
+    let app_name = crate::repository::site_settings::get_site_settings(conn)
+        .map(|s| s.app_name)
+        .unwrap_or_else(|_| "Nosdesk".to_string());
     let rendered = crate::services::template_vars::render(
         &raw_body,
         &crate::services::template_vars::TemplateContext {
@@ -874,6 +911,7 @@ fn execute_reply(
 /// `closed_at` stamping for terminal categories.
 fn execute_set_status(
     conn: &mut DbConnection,
+    action_index: usize,
     ticket_id: i32,
     config: &Value,
 ) -> Result<i32, ApplyError> {
@@ -882,7 +920,7 @@ fn execute_set_status(
         .get("workflow_state_id")
         .and_then(|v| v.as_i64())
         .ok_or_else(|| ApplyError::ActionFailed {
-            index: 0,
+            index: action_index,
             message: "set_status missing workflow_state_id".to_string(),
         })? as i32;
     diesel::update(dsl::tickets.find(ticket_id))
@@ -896,9 +934,8 @@ fn execute_set_status(
 /// here and the historical apply rows feed the stateless picker.
 fn execute_assign(
     conn: &mut DbConnection,
+    action_index: usize,
     ticket_id: i32,
-    _workspace_id: i32,
-    _rule_id: i32,
     config: &Value,
 ) -> Result<Uuid, ApplyError> {
     use crate::schema::tickets::dsl;
@@ -912,12 +949,12 @@ fn execute_assign(
             .and_then(|v| v.as_str())
             .and_then(|s| Uuid::parse_str(s).ok())
             .ok_or_else(|| ApplyError::ActionFailed {
-                index: 0,
+                index: action_index,
                 message: "assign(method=direct) missing valid user_uuid".to_string(),
             })?,
         other => {
             return Err(ApplyError::UnsupportedActionPhase1 {
-                index: 0,
+                index: action_index,
                 message: format!(
                     "assign method '{other}' lands in Phase 2 when assignment_rules absorbs here"
                 ),
@@ -997,6 +1034,7 @@ fn execute_remove_tags(
 
 fn execute_set_priority(
     conn: &mut DbConnection,
+    action_index: usize,
     ticket_id: i32,
     config: &Value,
 ) -> Result<String, ApplyError> {
@@ -1005,7 +1043,7 @@ fn execute_set_priority(
         .get("priority")
         .and_then(|v| v.as_str())
         .ok_or_else(|| ApplyError::ActionFailed {
-            index: 0,
+            index: action_index,
             message: "set_priority missing priority".to_string(),
         })?;
     // The codebase's TicketPriority enum is Low / Medium / High;
@@ -1020,7 +1058,7 @@ fn execute_set_priority(
         "high" | "urgent" => TicketPriority::High,
         other => {
             return Err(ApplyError::ActionFailed {
-                index: 0,
+                index: action_index,
                 message: format!("unknown priority: {other}"),
             })
         }

--- a/backend/src/repository/rules.rs
+++ b/backend/src/repository/rules.rs
@@ -32,7 +32,10 @@ use crate::models::{
 };
 use crate::repository::comments;
 use crate::sync::actor::ActorContext;
+use crate::sync::emit::{self, SyncEmit};
+use crate::sync::groups;
 use crate::sync::session::with_actor_context;
+use crate::models::{SyncAggregate, SyncOp};
 
 // =====================================================================
 // reads_set / writes_set derivation (plan §11.2). Pure helpers; the
@@ -744,9 +747,35 @@ pub fn apply_manual(
                 originating_event_id: None,
                 originating_event_kind: None,
                 condition_evaluation: None,
-                actions_taken: actions_taken_value,
+                actions_taken: actions_taken_value.clone(),
                 actions_skipped: actions_skipped_value,
                 failure_reason: None,
+            },
+        )?;
+
+        // Emit ticket.rule_applied so the activity feed surfaces the
+        // fire alongside ticket.merged + manual events. correlation_id
+        // is set via the actor session GUC; the audit_log + sync_actions
+        // rows for this transaction all share it.
+        let sync_groups = groups::for_ticket(conn, &ticket)?;
+        emit::record(
+            conn,
+            SyncEmit {
+                aggregate: SyncAggregate::Ticket,
+                aggregate_id: ticket.id.to_string(),
+                op: SyncOp::Update,
+                event_type: "ticket.rule_applied",
+                data: json!({
+                    "rule_id": rule.id,
+                    "rule_version": rule_version,
+                    "rule_name": updated_rule.name,
+                    "actor_uuid": actor.uuid,
+                    "comment_id": comment_id,
+                    "actions_taken": actions_taken_value,
+                    "was_dry_run": status == RuleApplicationStatus::DryRun,
+                }),
+                groups: sync_groups,
+                causation_id: None,
             },
         )?;
 

--- a/backend/src/repository/rules.rs
+++ b/backend/src/repository/rules.rs
@@ -20,15 +20,19 @@
 //! 4) reads them off a single source of truth.
 
 use diesel::prelude::*;
+use diesel::sql_types::BigInt;
 use diesel::QueryResult;
-use serde_json::Value;
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::db::DbConnection;
 use crate::models::{
-    NewRule, NewRuleApplication, Rule, RuleApplication, RuleApplicationStatus, RuleState,
-    RuleTriggerKind, RuleUpdate, RuleVersion,
+    NewComment, NewRule, NewRuleApplication, Rule, RuleApplication, RuleApplicationStatus,
+    RuleState, RuleTriggerKind, RuleUpdate, RuleVersion, TicketPriority,
 };
+use crate::repository::comments;
+use crate::sync::actor::ActorContext;
+use crate::sync::session::with_actor_context;
 
 // =====================================================================
 // reads_set / writes_set derivation (plan §11.2). Pure helpers; the
@@ -437,6 +441,611 @@ pub fn record_application(
     diesel::insert_into(dsl::rule_applications)
         .values(&new)
         .get_result(conn)
+}
+
+// =====================================================================
+// Manual apply lifecycle (Wave 5). Mirrors execute_merge's shape: one
+// `with_actor_context` transaction, advisory lock on the ticket, pre-
+// flight under the lock, then run the action executors in order. Any
+// preflight failure or executor error rolls the whole apply back; the
+// rule_applications row records what happened.
+//
+// Phase 1 only supports manual rules so the "evaluate conditions"
+// step is skipped (manual rules carry conditions = [] by the
+// rules_manual_no_conditions CHECK). Phase 2 plugs in condition
+// evaluation at the same pre-flight point.
+// =====================================================================
+
+/// Pack `(workspace_id, ticket_id)` into a collision-free int64
+/// advisory-lock key. Same formula as
+/// `repository::ticket_merge::advisory_key`; the helper there is
+/// private. We redefine locally rather than expose another crate's
+/// private helper through a pub(crate) escape hatch — single
+/// expression, no behavioural drift risk.
+fn advisory_key(workspace_id: i32, ticket_id: i32) -> i64 {
+    ((workspace_id as i64) << 32) | (ticket_id as i64 & 0xffff_ffff)
+}
+
+/// One-indexed action position the agent dialog ticks off to skip.
+/// `Vec<usize>` of positions, validated against the rule's action
+/// list length at the API boundary.
+#[derive(Debug, Clone, Default)]
+pub struct ApplyOverrides {
+    /// Replaces the first `reply` action's body verbatim if Some.
+    /// The agent edited it in the dialog after seeing the rendered
+    /// preview; the engine substitutes no further template tokens.
+    pub body: Option<String>,
+    /// Action positions to skip (1-indexed per decision 33).
+    pub suppress_actions: Vec<usize>,
+}
+
+/// Input to [`apply_manual`]. Built by the handler from the
+/// request body + the resolved actor.
+#[derive(Debug, Clone)]
+pub struct ApplyInput {
+    pub rule_id: i32,
+    pub ticket_id: i32,
+    pub overrides: ApplyOverrides,
+}
+
+/// Counts the apply endpoint returns to the agent dialog.
+#[derive(Debug, Clone)]
+pub struct ApplyOutcome {
+    /// Updated rule row (with the bumped `fire_count`).
+    pub rule: Rule,
+    /// The application audit row inserted at the end of the txn.
+    pub application: RuleApplication,
+    /// The `comments.id` of the reply action's row, when the rule
+    /// had a reply action and it wasn't suppressed. `None`
+    /// otherwise.
+    pub comment_id: Option<i32>,
+    /// How many actions ran (skip / failure subtracts).
+    pub actions_executed: usize,
+    /// How many actions were skipped via `overrides.suppress_actions`.
+    pub actions_suppressed: usize,
+}
+
+/// Errors specific to the apply lifecycle. Distinct from
+/// [`WriteError`] because handler callers map these to user-facing
+/// 400/404/409 codes.
+#[derive(Debug, thiserror::Error)]
+pub enum ApplyError {
+    #[error("rule {0} not found")]
+    NotFound(i32),
+    #[error("rule {0} is not live (current state: {1})")]
+    NotLive(i32, &'static str),
+    #[error("rule {0} is not a manual-trigger rule")]
+    NotManual(i32),
+    #[error("ticket {0} not found")]
+    TicketNotFound(i32),
+    #[error("ticket {0} is merged into another ticket and cannot be modified")]
+    TicketMerged(i32),
+    #[error("override index {0} is out of range (rule has {1} actions)")]
+    InvalidOverrideIndex(usize, usize),
+    #[error("rule action [{index}] is not valid for Phase 1: {message}")]
+    UnsupportedActionPhase1 { index: usize, message: String },
+    #[error("rule action [{index}] failed: {message}")]
+    ActionFailed { index: usize, message: String },
+    #[error("actor has no workspace context")]
+    MissingWorkspace,
+    #[error("database error: {0}")]
+    Db(#[from] diesel::result::Error),
+}
+
+// sync-pending-wire: emits ticket.rule_applied + ticket.updated via sync::emit inside the txn
+/// Apply one manual rule to one ticket. Atomic: every action runs
+/// inside one `with_actor_context` transaction. Pre-flight checks
+/// the rule + ticket under the advisory lock so a racing archive
+/// or merge can't slip past. On any executor error the whole apply
+/// rolls back and the `rule_applications` row is never written
+/// (which is the audit-correct behaviour: the failed apply didn't
+/// happen).
+pub fn apply_manual(
+    conn: &mut DbConnection,
+    input: ApplyInput,
+    actor: &ActorContext,
+) -> Result<ApplyOutcome, ApplyError> {
+    use crate::schema::rules::dsl as r;
+    use crate::schema::tickets::dsl as t;
+
+    let workspace_id = actor.workspace_id.ok_or(ApplyError::MissingWorkspace)?;
+
+    with_actor_context(conn, actor, |conn| -> Result<ApplyOutcome, ApplyError> {
+        diesel::sql_query("SELECT pg_advisory_xact_lock($1)")
+            .bind::<BigInt, _>(advisory_key(workspace_id, input.ticket_id))
+            .execute(conn)?;
+
+        // Re-read rule + ticket under the lock so racing edits
+        // (archive, state change, merge) are caught.
+        let rule: Rule = r::rules
+            .find(input.rule_id)
+            .first(conn)
+            .optional()?
+            .ok_or(ApplyError::NotFound(input.rule_id))?;
+        if rule.archived_at.is_some() {
+            return Err(ApplyError::NotLive(rule.id, rule.state.as_str()));
+        }
+        if rule.state != RuleState::Live && rule.state != RuleState::DryRun {
+            return Err(ApplyError::NotLive(rule.id, rule.state.as_str()));
+        }
+        if rule.trigger_kind != RuleTriggerKind::Manual {
+            return Err(ApplyError::NotManual(rule.id));
+        }
+
+        let ticket: crate::models::Ticket = t::tickets
+            .find(input.ticket_id)
+            .first(conn)
+            .optional()?
+            .ok_or(ApplyError::TicketNotFound(input.ticket_id))?;
+        if ticket.merged_into_ticket_id.is_some() {
+            return Err(ApplyError::TicketMerged(ticket.id));
+        }
+
+        let Some(actions) = rule.actions.as_array() else {
+            return Err(ApplyError::ActionFailed {
+                index: 0,
+                message: "rule.actions is not a JSON array (DB CHECK should have caught this)"
+                    .into(),
+            });
+        };
+        // Validate override indices up front so we don't run half
+        // the action list before bailing.
+        for idx in &input.overrides.suppress_actions {
+            if *idx == 0 || *idx > actions.len() {
+                return Err(ApplyError::InvalidOverrideIndex(*idx, actions.len()));
+            }
+        }
+        let suppress: std::collections::HashSet<usize> =
+            input.overrides.suppress_actions.iter().copied().collect();
+
+        let mut comment_id: Option<i32> = None;
+        let mut actions_executed = 0usize;
+        let mut actions_taken: Vec<Value> = Vec::with_capacity(actions.len());
+        let mut actions_skipped: Vec<Value> = Vec::with_capacity(suppress.len());
+        let mut applied_reply_body_override = false;
+
+        for (i, action) in actions.iter().enumerate() {
+            let one_based = i + 1;
+            if suppress.contains(&one_based) {
+                actions_skipped.push(json!({
+                    "index": one_based,
+                    "reason": "suppressed_by_override"
+                }));
+                continue;
+            }
+            let kind = action
+                .get("kind")
+                .and_then(|k| k.as_str())
+                .ok_or_else(|| ApplyError::ActionFailed {
+                    index: one_based,
+                    message: "missing kind".to_string(),
+                })?;
+            let config = action.get("config").cloned().unwrap_or(Value::Null);
+
+            let outcome = match kind {
+                "reply" => {
+                    let override_body = if !applied_reply_body_override {
+                        let b = input.overrides.body.clone();
+                        if b.is_some() {
+                            applied_reply_body_override = true;
+                        }
+                        b
+                    } else {
+                        None
+                    };
+                    execute_reply(conn, &ticket, actor, &config, override_body)?
+                        .map(|c| {
+                            if comment_id.is_none() {
+                                comment_id = Some(c);
+                            }
+                            json!({ "index": one_based, "kind": kind, "comment_id": c })
+                        })
+                        .unwrap_or_else(|| json!({ "index": one_based, "kind": kind }))
+                }
+                "set_status" => execute_set_status(conn, ticket.id, &config)
+                    .map(|state_id| {
+                        json!({ "index": one_based, "kind": kind, "workflow_state_id": state_id })
+                    })?,
+                "assign" => execute_assign(conn, ticket.id, workspace_id, rule.id, &config)
+                    .map(|uuid| {
+                        json!({ "index": one_based, "kind": kind, "assigned_to_uuid": uuid })
+                    })?,
+                "unassign" => execute_unassign(conn, ticket.id)
+                    .map(|_| json!({ "index": one_based, "kind": kind }))?,
+                "add_tags" => execute_add_tags(conn, ticket.id, workspace_id, &config, actor)
+                    .map(|added| {
+                        json!({ "index": one_based, "kind": kind, "tag_ids_added": added })
+                    })?,
+                "remove_tags" => execute_remove_tags(conn, ticket.id, &config).map(|removed| {
+                    json!({ "index": one_based, "kind": kind, "tag_ids_removed": removed })
+                })?,
+                "set_priority" => execute_set_priority(conn, ticket.id, &config)
+                    .map(|p| json!({ "index": one_based, "kind": kind, "priority": p }))?,
+                "stop_processing" => {
+                    // No-op for manual apply; only meaningful inside
+                    // an event-chain run loop in Phase 2.
+                    json!({ "index": one_based, "kind": kind, "note": "no-op for manual apply" })
+                }
+                "notify" | "apply_macro_template" | "webhook" => {
+                    return Err(ApplyError::UnsupportedActionPhase1 {
+                        index: one_based,
+                        message: format!(
+                            "{kind} action is scheduled for a later phase; admin should archive this rule or remove the action"
+                        ),
+                    });
+                }
+                other => {
+                    return Err(ApplyError::ActionFailed {
+                        index: one_based,
+                        message: format!("unknown action kind: {other}"),
+                    });
+                }
+            };
+            actions_taken.push(outcome);
+            actions_executed += 1;
+        }
+
+        // Bump fire_count + last_fired_at on the rule. Use sql::now
+        // so the timestamp comes from the same transaction's clock
+        // as the rule_applications.applied_at row below.
+        let updated_rule: Rule = diesel::update(r::rules.find(rule.id))
+            .set((
+                r::fire_count.eq(r::fire_count + 1),
+                r::last_fired_at.eq(Some(chrono::Utc::now())),
+            ))
+            .get_result(conn)?;
+
+        // dry_run state writes a shadow rule_applications row so the
+        // admin can preview without touching production data. The
+        // action writes above still hit the DB in the txn, but the
+        // outer transaction will be COMMITTED — dry-run rows live in
+        // the audit log alongside successful ones, distinguished by
+        // status. That matches the plan §4.3 contract.
+        let status = if updated_rule.state == RuleState::DryRun {
+            RuleApplicationStatus::DryRun
+        } else {
+            RuleApplicationStatus::Succeeded
+        };
+
+        let actions_taken_value = if actions_taken.is_empty() {
+            None
+        } else {
+            Some(Value::Array(actions_taken))
+        };
+        let actions_skipped_value = if actions_skipped.is_empty() {
+            None
+        } else {
+            Some(Value::Array(actions_skipped))
+        };
+
+        // rule_version is the current version after the last save;
+        // pull from rule_versions max(version) for this rule. The
+        // migration trigger guarantees a v1 row at minimum.
+        let rule_version: i32 = {
+            use crate::schema::rule_versions::dsl;
+            dsl::rule_versions
+                .filter(dsl::rule_id.eq(rule.id))
+                .select(diesel::dsl::max(dsl::version))
+                .first::<Option<i32>>(conn)?
+                .unwrap_or(1)
+        };
+
+        let application = record_application(
+            conn,
+            NewRuleApplication {
+                workspace_id,
+                rule_id: rule.id,
+                rule_version,
+                ticket_id: ticket.id,
+                status,
+                correlation_id: actor.correlation_id,
+                actor_uuid: actor.uuid,
+                actor_kind: "user".to_string(),
+                originating_event_id: None,
+                originating_event_kind: None,
+                condition_evaluation: None,
+                actions_taken: actions_taken_value,
+                actions_skipped: actions_skipped_value,
+                failure_reason: None,
+            },
+        )?;
+
+        Ok(ApplyOutcome {
+            rule: updated_rule,
+            application,
+            comment_id,
+            actions_executed,
+            actions_suppressed: suppress.len(),
+        })
+    })
+}
+
+// =====================================================================
+// Action executors (Wave 5 / unit-06). Each returns the relevant
+// detail the caller folds into the actions_taken JSONB blob.
+// =====================================================================
+
+/// `reply` action. Renders the body via services::template_vars
+/// (when the caller doesn't pass an override), inserts a comment,
+/// and returns the new comment id. Internal vs public is the
+/// action's `visibility` flag (see plan §5.3); the comment row
+/// stamps `is_internal` accordingly. The customer-channel dispatch
+/// for `visibility=public` runs through the existing
+/// `comments::create_comment` observer pipeline, so an outbound
+/// queue row is enqueued for tickets with an email channel.
+fn execute_reply(
+    conn: &mut DbConnection,
+    ticket: &crate::models::Ticket,
+    actor: &ActorContext,
+    config: &Value,
+    override_body: Option<String>,
+) -> Result<Option<i32>, ApplyError> {
+    let visibility = config
+        .get("visibility")
+        .and_then(|v| v.as_str())
+        .unwrap_or("public");
+    let raw_body = override_body
+        .or_else(|| {
+            config
+                .get("body")
+                .and_then(|b| b.as_str())
+                .map(|s| s.to_string())
+        })
+        .ok_or_else(|| ApplyError::ActionFailed {
+            index: 0,
+            message: "reply action missing body".to_string(),
+        })?;
+
+    // Phase 1: render with a context built from the loaded ticket
+    // + actor. The renderer falls back to empty strings for
+    // unknown bindings, so a body referencing customer_name on a
+    // requester-less ticket renders "Hi ,".
+    let actor_uuid = actor.uuid.ok_or_else(|| ApplyError::ActionFailed {
+        index: 0,
+        message: "manual reply requires an authenticated actor".to_string(),
+    })?;
+    let agent = crate::repository::users::find_active_by_uuid(&actor_uuid, conn)?;
+    let requester = if let Some(uuid) = ticket.requester_uuid {
+        crate::repository::users::find_active_by_uuid(&uuid, conn).ok()
+    } else {
+        None
+    };
+    let app_name = std::env::var("APP_NAME").unwrap_or_else(|_| "Nosdesk".to_string());
+    let rendered = crate::services::template_vars::render(
+        &raw_body,
+        &crate::services::template_vars::TemplateContext {
+            ticket,
+            requester: requester.as_ref(),
+            agent: &agent,
+            app_name: &app_name,
+            event: None,
+            reply: None,
+        },
+    );
+
+    let is_internal = visibility == "internal";
+    let new_comment = NewComment {
+        content: rendered,
+        ticket_id: ticket.id,
+        user_uuid: actor_uuid,
+        channel_metadata: Some(json!({
+            "kind": "rule_reply",
+            "visibility": visibility,
+        })),
+        is_internal,
+        content_format: crate::models::ContentFormat::Html,
+        ..NewComment::default()
+    };
+    let comment = comments::create_comment(conn, new_comment, None)?;
+    Ok(Some(comment.id))
+}
+
+/// `set_status` action. Updates `tickets.workflow_state_id`; the
+/// existing tickets-table trigger handles `resolved_at` /
+/// `closed_at` stamping for terminal categories.
+fn execute_set_status(
+    conn: &mut DbConnection,
+    ticket_id: i32,
+    config: &Value,
+) -> Result<i32, ApplyError> {
+    use crate::schema::tickets::dsl;
+    let state_id = config
+        .get("workflow_state_id")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| ApplyError::ActionFailed {
+            index: 0,
+            message: "set_status missing workflow_state_id".to_string(),
+        })? as i32;
+    diesel::update(dsl::tickets.find(ticket_id))
+        .set(dsl::workflow_state_id.eq(state_id))
+        .execute(conn)?;
+    Ok(state_id)
+}
+
+/// `assign` action. Direct user assignment for Phase 1; round-robin
+/// and group queue land in Phase 2 when assignment_rules absorbs
+/// here and the historical apply rows feed the stateless picker.
+fn execute_assign(
+    conn: &mut DbConnection,
+    ticket_id: i32,
+    _workspace_id: i32,
+    _rule_id: i32,
+    config: &Value,
+) -> Result<Uuid, ApplyError> {
+    use crate::schema::tickets::dsl;
+    let method = config
+        .get("method")
+        .and_then(|v| v.as_str())
+        .unwrap_or("direct");
+    let assignee = match method {
+        "direct" => config
+            .get("user_uuid")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+            .ok_or_else(|| ApplyError::ActionFailed {
+                index: 0,
+                message: "assign(method=direct) missing valid user_uuid".to_string(),
+            })?,
+        other => {
+            return Err(ApplyError::UnsupportedActionPhase1 {
+                index: 0,
+                message: format!(
+                    "assign method '{other}' lands in Phase 2 when assignment_rules absorbs here"
+                ),
+            });
+        }
+    };
+    diesel::update(dsl::tickets.find(ticket_id))
+        .set(dsl::assignee_uuid.eq(Some(assignee)))
+        .execute(conn)?;
+    Ok(assignee)
+}
+
+fn execute_unassign(conn: &mut DbConnection, ticket_id: i32) -> Result<(), ApplyError> {
+    use crate::schema::tickets::dsl;
+    diesel::update(dsl::tickets.find(ticket_id))
+        .set(dsl::assignee_uuid.eq::<Option<Uuid>>(None))
+        .execute(conn)?;
+    Ok(())
+}
+
+fn execute_add_tags(
+    conn: &mut DbConnection,
+    ticket_id: i32,
+    workspace_id: i32,
+    config: &Value,
+    actor: &ActorContext,
+) -> Result<Vec<i32>, ApplyError> {
+    use crate::schema::ticket_tags::dsl;
+    let tag_ids: Vec<i32> = config
+        .get("tag_ids")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_i64()).map(|x| x as i32).collect())
+        .unwrap_or_default();
+    if tag_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows: Vec<_> = tag_ids
+        .iter()
+        .map(|tid| {
+            (
+                dsl::ticket_id.eq(ticket_id),
+                dsl::tag_id.eq(*tid),
+                dsl::created_by.eq(actor.uuid),
+                dsl::workspace_id.eq(workspace_id),
+            )
+        })
+        .collect();
+    diesel::insert_into(dsl::ticket_tags)
+        .values(&rows)
+        .on_conflict_do_nothing()
+        .execute(conn)?;
+    Ok(tag_ids)
+}
+
+fn execute_remove_tags(
+    conn: &mut DbConnection,
+    ticket_id: i32,
+    config: &Value,
+) -> Result<Vec<i32>, ApplyError> {
+    use crate::schema::ticket_tags::dsl;
+    let tag_ids: Vec<i32> = config
+        .get("tag_ids")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_i64()).map(|x| x as i32).collect())
+        .unwrap_or_default();
+    if tag_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    diesel::delete(
+        dsl::ticket_tags
+            .filter(dsl::ticket_id.eq(ticket_id))
+            .filter(dsl::tag_id.eq_any(&tag_ids)),
+    )
+    .execute(conn)?;
+    Ok(tag_ids)
+}
+
+fn execute_set_priority(
+    conn: &mut DbConnection,
+    ticket_id: i32,
+    config: &Value,
+) -> Result<String, ApplyError> {
+    use crate::schema::tickets::dsl;
+    let priority_str = config
+        .get("priority")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ApplyError::ActionFailed {
+            index: 0,
+            message: "set_priority missing priority".to_string(),
+        })?;
+    // The codebase's TicketPriority enum is Low / Medium / High;
+    // the plan's "urgent" maps onto High since there's no taller
+    // tier. The save linter in the rule editor should validate
+    // against this restricted set; we error here as defence-in-
+    // depth so an editor mismatch surfaces with a clear message
+    // rather than a silent demotion.
+    let priority = match priority_str {
+        "low" => TicketPriority::Low,
+        "normal" | "medium" => TicketPriority::Medium,
+        "high" | "urgent" => TicketPriority::High,
+        other => {
+            return Err(ApplyError::ActionFailed {
+                index: 0,
+                message: format!("unknown priority: {other}"),
+            })
+        }
+    };
+    diesel::update(dsl::tickets.find(ticket_id))
+        .set(dsl::priority.eq(priority))
+        .execute(conn)?;
+    Ok(priority_str.to_string())
+}
+
+// =====================================================================
+// Preview-match save-time check (Wave 5 / unit-12). Phase 1
+// scaffolding: manual rules carry conditions = [] so the match is
+// trivially every ticket. The endpoint returns the count + sample
+// IDs of recent tickets so the editor can render the "matches N of
+// N tickets" banner uniformly with future event-rule previews.
+// Phase 2 plugs the typed condition evaluator in here.
+// =====================================================================
+
+/// Result of a preview-match against recent tickets.
+#[derive(Debug, Clone)]
+pub struct PreviewMatch {
+    pub matched: i64,
+    pub scanned: i64,
+    pub sample_ticket_ids: Vec<i32>,
+}
+
+/// Run `conditions` against the last `scan_limit` tickets in the
+/// workspace (capped at 1000) and return how many matched. Phase 1
+/// always returns matched = scanned because manual rules have no
+/// conditions; the shape is in place so Phase 2 can drop in the
+/// condition evaluator without changing the caller surface.
+pub fn preview_match(
+    conn: &mut DbConnection,
+    _conditions: &Value,
+    scan_limit: i64,
+) -> QueryResult<PreviewMatch> {
+    use crate::schema::tickets::dsl;
+    let limit = scan_limit.clamp(50, 1000);
+    let rows: Vec<i32> = dsl::tickets
+        .order(dsl::created_at.desc())
+        .limit(limit)
+        .select(dsl::id)
+        .load(conn)?;
+    let scanned = rows.len() as i64;
+    let sample_ticket_ids = rows.into_iter().take(5).collect();
+    Ok(PreviewMatch {
+        // Phase 1: every recent ticket matches a manual rule
+        // (manual rules carry conditions = [] and the picker
+        // returns them unfiltered, see plan §13.4).
+        matched: scanned,
+        scanned,
+        sample_ticket_ids,
+    })
 }
 
 #[cfg(test)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -14,6 +14,18 @@ pub mod sql_types {
     pub struct ProjectStatus;
 
     #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "rule_application_status"))]
+    pub struct RuleApplicationStatus;
+
+    #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "rule_state"))]
+    pub struct RuleState;
+
+    #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "rule_trigger_kind"))]
+    pub struct RuleTriggerKind;
+
+    #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "sync_aggregate"))]
     pub struct SyncAggregate;
 
@@ -1096,6 +1108,84 @@ diesel::table! {
 }
 
 diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::RuleApplicationStatus;
+
+    rule_applications (id) {
+        id -> Int8,
+        workspace_id -> Int4,
+        rule_id -> Int4,
+        rule_version -> Int4,
+        ticket_id -> Int4,
+        status -> RuleApplicationStatus,
+        correlation_id -> Nullable<Uuid>,
+        actor_uuid -> Nullable<Uuid>,
+        #[max_length = 16]
+        actor_kind -> Varchar,
+        originating_event_id -> Nullable<Uuid>,
+        #[max_length = 64]
+        originating_event_kind -> Nullable<Varchar>,
+        condition_evaluation -> Nullable<Jsonb>,
+        actions_taken -> Nullable<Jsonb>,
+        actions_skipped -> Nullable<Jsonb>,
+        failure_reason -> Nullable<Text>,
+        applied_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::RuleTriggerKind;
+    use super::sql_types::RuleState;
+
+    rule_versions (id) {
+        id -> Int4,
+        rule_id -> Int4,
+        workspace_id -> Int4,
+        version -> Int4,
+        #[max_length = 255]
+        name -> Varchar,
+        description -> Nullable<Text>,
+        trigger_kind -> RuleTriggerKind,
+        trigger_config -> Jsonb,
+        conditions -> Jsonb,
+        actions -> Jsonb,
+        state -> RuleState,
+        priority -> Int4,
+        saved_by -> Nullable<Uuid>,
+        saved_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::RuleTriggerKind;
+    use super::sql_types::RuleState;
+
+    rules (id) {
+        id -> Int4,
+        workspace_id -> Int4,
+        #[max_length = 255]
+        name -> Varchar,
+        description -> Nullable<Text>,
+        trigger_kind -> RuleTriggerKind,
+        trigger_config -> Jsonb,
+        conditions -> Jsonb,
+        actions -> Jsonb,
+        reads_set -> Array<Nullable<Text>>,
+        writes_set -> Array<Nullable<Text>>,
+        state -> RuleState,
+        priority -> Int4,
+        last_fired_at -> Nullable<Timestamptz>,
+        fire_count -> Int4,
+        created_by -> Nullable<Uuid>,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+        archived_at -> Nullable<Timestamptz>,
+    }
+}
+
+diesel::table! {
     saved_views (id) {
         id -> Int4,
         uuid -> Uuid,
@@ -1360,6 +1450,15 @@ diesel::table! {
         updated_at -> Timestamptz,
         created_by -> Nullable<Uuid>,
         workspace_id -> Int4,
+    }
+}
+
+diesel::table! {
+    ticket_rule_runs (event_id, ticket_id, rule_id) {
+        event_id -> Uuid,
+        ticket_id -> Int4,
+        rule_id -> Int4,
+        fired_at -> Timestamptz,
     }
 }
 
@@ -1809,6 +1908,15 @@ diesel::joinable!(project_tickets -> workspaces (workspace_id));
 diesel::joinable!(projects -> workspaces (workspace_id));
 diesel::joinable!(refresh_tokens -> users (user_uuid));
 diesel::joinable!(reset_tokens -> users (user_uuid));
+diesel::joinable!(rule_applications -> rules (rule_id));
+diesel::joinable!(rule_applications -> tickets (ticket_id));
+diesel::joinable!(rule_applications -> users (actor_uuid));
+diesel::joinable!(rule_applications -> workspaces (workspace_id));
+diesel::joinable!(rule_versions -> rules (rule_id));
+diesel::joinable!(rule_versions -> users (saved_by));
+diesel::joinable!(rule_versions -> workspaces (workspace_id));
+diesel::joinable!(rules -> users (created_by));
+diesel::joinable!(rules -> workspaces (workspace_id));
 diesel::joinable!(saved_views -> users (created_by));
 diesel::joinable!(saved_views -> workspaces (workspace_id));
 diesel::joinable!(search_query_log -> workspaces (workspace_id));
@@ -1928,6 +2036,9 @@ diesel::allow_tables_to_appear_in_same_query!(
     projects,
     refresh_tokens,
     reset_tokens,
+    rule_applications,
+    rule_versions,
+    rules,
     saved_views,
     search_index_state,
     search_query_log,
@@ -1942,6 +2053,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     tags,
     ticket_assets,
     ticket_categories,
+    ticket_rule_runs,
     ticket_tags,
     ticket_watchers,
     tickets,

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -16,6 +16,7 @@ pub mod scheduler;
 pub mod search;
 pub mod seed;
 pub mod sla;
+pub mod starter_catalog;
 pub mod sync_outbox;
 pub mod template_vars;
 pub mod transactional_email;

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -17,5 +17,6 @@ pub mod search;
 pub mod seed;
 pub mod sla;
 pub mod sync_outbox;
+pub mod template_vars;
 pub mod transactional_email;
 pub mod webhooks;

--- a/backend/src/services/starter_catalog.rs
+++ b/backend/src/services/starter_catalog.rs
@@ -1,0 +1,130 @@
+//! Rules engine starter catalog (Phase 1 / Wave 8).
+//!
+//! Ships ~half a dozen ready-made manual rules baked into the
+//! repo as a JSON file (`backend/data/starter-rules.json`). The
+//! admin Settings → Rules page lets admins browse the catalog and
+//! copy any entry as a new Draft rule in their workspace; per
+//! decision 35 in the plan, we never bulk-insert these on
+//! workspace creation. The catalog is in-memory, loaded once at
+//! startup; the JSON is checked into the repo so changes go
+//! through PR review like any other config.
+
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// One catalog entry. Names + descriptions are pre-translated for
+/// every supported locale; the rest is locale-independent (actions
+/// reference template tokens via the renderer, not localised
+/// strings).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StarterRule {
+    pub id: String,
+    pub name_en: String,
+    pub name_fr: String,
+    pub name_nl: String,
+    pub description_en: String,
+    pub description_fr: String,
+    pub description_nl: String,
+    pub trigger_kind: String,
+    pub conditions: Value,
+    pub actions: Value,
+}
+
+impl StarterRule {
+    /// Returns the localised name for `locale` (BCP-47 prefix
+    /// match, falls back to en).
+    pub fn name_for(&self, locale: &str) -> &str {
+        match locale_prefix(locale) {
+            "fr" => &self.name_fr,
+            "nl" => &self.name_nl,
+            _ => &self.name_en,
+        }
+    }
+
+    /// Returns the localised description for `locale` (BCP-47
+    /// prefix match, falls back to en).
+    pub fn description_for(&self, locale: &str) -> &str {
+        match locale_prefix(locale) {
+            "fr" => &self.description_fr,
+            "nl" => &self.description_nl,
+            _ => &self.description_en,
+        }
+    }
+}
+
+fn locale_prefix(locale: &str) -> &str {
+    locale.split('-').next().unwrap_or(locale)
+}
+
+/// Embedded at compile time so the binary has the catalog with
+/// no filesystem dependency at runtime. `include_str!` walks up
+/// from `services/starter_catalog.rs` to `data/starter-rules.json`.
+static RAW_CATALOG: &str = include_str!("../../data/starter-rules.json");
+
+/// Parsed-once view of the catalog. Lazy so a malformed file
+/// surfaces with a clear panic at first access (test or boot)
+/// rather than blowing up serde inside every endpoint call.
+static CATALOG: Lazy<Vec<StarterRule>> = Lazy::new(|| {
+    serde_json::from_str(RAW_CATALOG).expect(
+        "backend/data/starter-rules.json failed to parse; \
+         the catalog ships in the binary and a malformed file \
+         is a build-time bug, not a runtime one",
+    )
+});
+
+/// Return every catalog entry. The admin browse endpoint maps
+/// them through `StarterRule::name_for` / `description_for` for
+/// the caller's locale before sending.
+pub fn list() -> &'static [StarterRule] {
+    CATALOG.as_slice()
+}
+
+/// Find a catalog entry by id. Used by the
+/// `POST /api/rules?from_catalog_id=X` copy-as-new-rule path.
+pub fn find(id: &str) -> Option<&'static StarterRule> {
+    CATALOG.iter().find(|r| r.id == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_parses_at_startup() {
+        // Touching CATALOG forces the Lazy to evaluate; a
+        // malformed file panics here rather than the first
+        // production hit.
+        let entries = list();
+        assert!(!entries.is_empty(), "catalog ships with at least one entry");
+    }
+
+    #[test]
+    fn every_entry_carries_required_localisations() {
+        for rule in list() {
+            assert!(!rule.id.is_empty(), "id missing on {:?}", rule);
+            assert!(!rule.name_en.is_empty(), "name_en missing on {}", rule.id);
+            assert!(!rule.name_fr.is_empty(), "name_fr missing on {}", rule.id);
+            assert!(!rule.name_nl.is_empty(), "name_nl missing on {}", rule.id);
+        }
+    }
+
+    #[test]
+    fn find_returns_expected_entry() {
+        let rule = find("ack-and-acknowledge").expect("entry exists");
+        assert_eq!(rule.trigger_kind, "manual");
+    }
+
+    #[test]
+    fn locale_picker_falls_back_to_english() {
+        let rule = list()
+            .first()
+            .expect("catalog has at least one entry");
+        assert_eq!(rule.name_for("en-US"), rule.name_en);
+        assert_eq!(rule.name_for("en-GB"), rule.name_en);
+        assert_eq!(rule.name_for("fr-FR"), rule.name_fr);
+        assert_eq!(rule.name_for("nl-NL"), rule.name_nl);
+        // Unknown locale falls back to English.
+        assert_eq!(rule.name_for("de-DE"), rule.name_en);
+    }
+}

--- a/backend/src/services/template_vars.rs
+++ b/backend/src/services/template_vars.rs
@@ -53,9 +53,17 @@ pub struct ReplyContext<'a> {
     pub author_role: &'a str,
 }
 
-/// Render `template` against `ctx`. Unknown tokens pass through
-/// verbatim per [`substitute`]'s contract; the editor catches typos
-/// at save time via
+/// Render `template` against `ctx` for an HTML comment body.
+/// Substituted values are HTML-escaped before insertion so an
+/// untrusted binding (a requester whose IdP-synced display name
+/// contains HTML metacharacters, say) cannot inject script /
+/// markup into the rendered comment. The body template itself is
+/// admin-authored and vetted at save, so it passes through
+/// unescaped; admins can keep using deliberate `<br>` / `<b>`
+/// markup.
+///
+/// Unknown tokens pass through verbatim per [`substitute`]'s
+/// contract; the editor catches typos at save time via
 /// [`utils::template_variables::unknown_variables`] with the
 /// `RULE_REPLY_VARIABLES` allow-list.
 pub fn render(template: &str, ctx: &TemplateContext<'_>) -> String {
@@ -64,28 +72,50 @@ pub fn render(template: &str, ctx: &TemplateContext<'_>) -> String {
     let customer_name = ctx.requester.map(|r| r.name.as_str()).unwrap_or("");
     let customer_first = first_name(customer_name);
 
-    let mut pairs: Vec<(&str, &str)> = vec![
-        ("ticket_id", ticket_id.as_str()),
-        ("ticket_title", ctx.ticket.title.as_str()),
-        ("customer_name", customer_name),
-        ("customer_first_name", customer_first.as_str()),
-        ("tech_name", ctx.agent.name.as_str()),
-        ("tech_first_name", agent_first.as_str()),
-        ("agent_name", ctx.agent.name.as_str()),
-        ("agent_first_name", agent_first.as_str()),
-        ("app_name", ctx.app_name),
+    // HTML-escape every binding before substitution. The unsafe
+    // shapes (`<`, `>`, `&`, `'`, `"`) all matter for the HTML
+    // comment view; `encode_safe` is the same helper the email
+    // pipeline uses for outbound quoting.
+    let escaped: Vec<(&str, String)> = vec![
+        ("ticket_id", html_escape::encode_safe(&ticket_id).into_owned()),
+        ("ticket_title", html_escape::encode_safe(&ctx.ticket.title).into_owned()),
+        ("customer_name", html_escape::encode_safe(customer_name).into_owned()),
+        ("customer_first_name", html_escape::encode_safe(&customer_first).into_owned()),
+        ("tech_name", html_escape::encode_safe(&ctx.agent.name).into_owned()),
+        ("tech_first_name", html_escape::encode_safe(&agent_first).into_owned()),
+        ("agent_name", html_escape::encode_safe(&ctx.agent.name).into_owned()),
+        ("agent_first_name", html_escape::encode_safe(&agent_first).into_owned()),
+        ("app_name", html_escape::encode_safe(ctx.app_name).into_owned()),
     ];
+    let mut pairs: Vec<(&str, &str)> =
+        escaped.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
     // Phase 2 hooks: event and reply bindings stay outside the
-    // Phase 1 allow-list. Append them when present so a Phase-2
-    // template that references them resolves, while a Phase-1
-    // template that never mentions them is unaffected.
-    if let Some(event) = &ctx.event {
-        pairs.push(("event_kind", event.kind));
+    // Phase 1 allow-list. Pre-escape into owned strings whose
+    // lifetimes outlive the pairs vec; absent contexts produce
+    // empty placeholders that the substituter never references
+    // because the template doesn't mention those tokens.
+    let event_kind = ctx
+        .event
+        .as_ref()
+        .map(|e| html_escape::encode_safe(e.kind).into_owned())
+        .unwrap_or_default();
+    let reply_kind = ctx
+        .reply
+        .as_ref()
+        .map(|r| html_escape::encode_safe(r.kind).into_owned())
+        .unwrap_or_default();
+    let reply_author_role = ctx
+        .reply
+        .as_ref()
+        .map(|r| html_escape::encode_safe(r.author_role).into_owned())
+        .unwrap_or_default();
+    if ctx.event.is_some() {
+        pairs.push(("event_kind", event_kind.as_str()));
     }
-    if let Some(reply) = &ctx.reply {
-        pairs.push(("reply_kind", reply.kind));
-        pairs.push(("reply_author_role", reply.author_role));
+    if ctx.reply.is_some() {
+        pairs.push(("reply_kind", reply_kind.as_str()));
+        pairs.push(("reply_author_role", reply_author_role.as_str()));
     }
 
     substitute(template, &pairs)
@@ -173,9 +203,44 @@ mod tests {
             "Hi {{customer_name}}, ticket {{ticket_id}} ({{ticket_title}}) is being looked at by {{agent_name}}. Cheers, {{agent_first_name}} from {{app_name}}.",
             &ctx,
         );
+        // Output is HTML-safe; ASCII-only inputs survive verbatim
+        // through html_escape::encode_safe.
         assert_eq!(
             out,
             "Hi , ticket 42 (Wi-Fi outage) is being looked at by Kyle Phillips. Cheers, Kyle from Nosdesk."
+        );
+    }
+
+    #[test]
+    fn html_metacharacters_in_substituted_values_are_escaped() {
+        // The hostile-name case: a requester whose display name
+        // carries an HTML payload (e.g. from an unsanitised OIDC
+        // attribute). The body template's literal HTML
+        // (`<strong>...</strong>`) is admin-authored and stays
+        // intact; only the substituted value gets escaped.
+        let ticket = stub_ticket(7, "Login broken");
+        let agent = stub_user("Agent");
+        let requester = stub_user("<img src=x onerror=alert(1)>");
+        let ctx = TemplateContext {
+            ticket: &ticket,
+            requester: Some(&requester),
+            agent: &agent,
+            app_name: "Nosdesk",
+            event: None,
+            reply: None,
+        };
+        let out = render(
+            "<strong>Hi {{customer_name}}</strong>, we see ticket {{ticket_id}}.",
+            &ctx,
+        );
+        assert!(out.contains("<strong>Hi"), "body template HTML survives");
+        assert!(
+            !out.contains("<img src=x"),
+            "substituted value's raw HTML must be escaped, not rendered: {out}"
+        );
+        assert!(
+            out.contains("&lt;img src=x"),
+            "substituted value should appear in escaped form: {out}"
         );
     }
 

--- a/backend/src/services/template_vars.rs
+++ b/backend/src/services/template_vars.rs
@@ -1,0 +1,241 @@
+//! Context-driven template rendering for the rules engine's `reply`
+//! action.
+//!
+//! Wraps `utils::template_variables` (which owns the `{{name}}`
+//! regex and the flat `&str` substituter) and adds the typed
+//! `TemplateContext` the rule lifecycle passes in. The context is
+//! structured so Phase 2's event-triggered and Phase 3's
+//! time-elapsed fires extend the binding set without changing the
+//! function signature (decision 34 in
+//! `docs/rules-and-actions-plan.md`): `event` and `reply` are
+//! optional and stay `None` for Phase 1's manual apply path.
+//!
+//! Canned responses keep their existing path through
+//! `utils::template_variables::substitute` directly; they don't need
+//! the User / Ticket plumbing because the frontend builds the
+//! variable map at insert time. The two paths share the same regex
+//! and allow-list, so a body authored for a canned response renders
+//! identically when it ends up inside a rule's reply action.
+
+use crate::models::{Ticket, User};
+use crate::utils::template_variables::{first_name, substitute};
+
+/// Inputs to [`render`]. The lifecycle builds one of these and hands
+/// it off; the renderer pulls variable bindings from it without
+/// touching the database.
+///
+/// `event` and `reply` are present so Phase 2 can stamp event- and
+/// reply-scoped bindings without breaking Phase 1 callers; the
+/// renderer reads them but Phase 1 templates won't reference them so
+/// the bindings stay unused for now.
+pub struct TemplateContext<'a> {
+    pub ticket: &'a Ticket,
+    pub requester: Option<&'a User>,
+    pub agent: &'a User,
+    pub app_name: &'a str,
+    pub event: Option<EventContext<'a>>,
+    pub reply: Option<ReplyContext<'a>>,
+}
+
+/// Event-scoped bindings populated by Phase 2's event-triggered fire
+/// path. Phase 1's manual apply path leaves the parent field as
+/// `None`.
+pub struct EventContext<'a> {
+    pub kind: &'a str,
+    pub changed_fields: &'a [String],
+}
+
+/// Reply-scoped bindings populated by Phase 2's `ticket_replied`
+/// trigger. Phase 1's manual apply path leaves the parent field as
+/// `None`.
+pub struct ReplyContext<'a> {
+    pub kind: &'a str,
+    pub author_role: &'a str,
+}
+
+/// Render `template` against `ctx`. Unknown tokens pass through
+/// verbatim per [`substitute`]'s contract; the editor catches typos
+/// at save time via
+/// [`utils::template_variables::unknown_variables`] with the
+/// `RULE_REPLY_VARIABLES` allow-list.
+pub fn render(template: &str, ctx: &TemplateContext<'_>) -> String {
+    let ticket_id = ctx.ticket.id.to_string();
+    let agent_first = first_name(&ctx.agent.name);
+    let customer_name = ctx.requester.map(|r| r.name.as_str()).unwrap_or("");
+    let customer_first = first_name(customer_name);
+
+    let mut pairs: Vec<(&str, &str)> = vec![
+        ("ticket_id", ticket_id.as_str()),
+        ("ticket_title", ctx.ticket.title.as_str()),
+        ("customer_name", customer_name),
+        ("customer_first_name", customer_first.as_str()),
+        ("tech_name", ctx.agent.name.as_str()),
+        ("tech_first_name", agent_first.as_str()),
+        ("agent_name", ctx.agent.name.as_str()),
+        ("agent_first_name", agent_first.as_str()),
+        ("app_name", ctx.app_name),
+    ];
+
+    // Phase 2 hooks: event and reply bindings stay outside the
+    // Phase 1 allow-list. Append them when present so a Phase-2
+    // template that references them resolves, while a Phase-1
+    // template that never mentions them is unaffected.
+    if let Some(event) = &ctx.event {
+        pairs.push(("event_kind", event.kind));
+    }
+    if let Some(reply) = &ctx.reply {
+        pairs.push(("reply_kind", reply.kind));
+        pairs.push(("reply_author_role", reply.author_role));
+    }
+
+    substitute(template, &pairs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::TicketPriority;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn stub_ticket(id: i32, title: &str) -> Ticket {
+        let now = Utc::now().naive_utc();
+        Ticket {
+            id,
+            title: title.to_string(),
+            priority: TicketPriority::Medium,
+            requester_uuid: None,
+            assignee_uuid: None,
+            created_at: now,
+            updated_at: now,
+            created_by: None,
+            closed_at: None,
+            closed_by: None,
+            category_id: None,
+            submitted_via: None,
+            guest_lookup_token: None,
+            verification_state: None,
+            origin_channel_id: None,
+            triage_state: None,
+            due_date: None,
+            recurrence_rule: None,
+            recurrence_template_id: None,
+            resolution_notes: None,
+            workspace_id: 1,
+            workflow_state_id: 2,
+            first_response_at: None,
+            sla_response_target_at: None,
+            sla_response_breached_at: None,
+            sla_resolution_target_at: None,
+            sla_resolution_breached_at: None,
+            merged_into_ticket_id: None,
+            merged_at: None,
+            merged_by_user_uuid: None,
+            merge_reason: None,
+        }
+    }
+
+    fn stub_user(name: &str) -> User {
+        let now = Utc::now().naive_utc();
+        User {
+            uuid: Uuid::nil(),
+            name: name.to_string(),
+            created_at: now,
+            updated_at: now,
+            password_changed_at: None,
+            pronouns: None,
+            avatar_url: None,
+            banner_url: None,
+            avatar_thumb: None,
+            microsoft_uuid: None,
+            mfa_enabled: false,
+            feature_flag_overrides: serde_json::Value::Null,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_secret_kek_id: None,
+            platform_role: "user".to_string(),
+        }
+    }
+
+    #[test]
+    fn renders_ticket_and_agent_bindings() {
+        let ticket = stub_ticket(42, "Wi-Fi outage");
+        let agent = stub_user("Kyle Phillips");
+        let ctx = TemplateContext {
+            ticket: &ticket,
+            requester: None,
+            agent: &agent,
+            app_name: "Nosdesk",
+            event: None,
+            reply: None,
+        };
+        let out = render(
+            "Hi {{customer_name}}, ticket {{ticket_id}} ({{ticket_title}}) is being looked at by {{agent_name}}. Cheers, {{agent_first_name}} from {{app_name}}.",
+            &ctx,
+        );
+        assert_eq!(
+            out,
+            "Hi , ticket 42 (Wi-Fi outage) is being looked at by Kyle Phillips. Cheers, Kyle from Nosdesk."
+        );
+    }
+
+    #[test]
+    fn renders_customer_bindings_when_requester_present() {
+        let ticket = stub_ticket(7, "Login broken");
+        let agent = stub_user("Alex Chen");
+        let requester = stub_user("Jordan Lee");
+        let ctx = TemplateContext {
+            ticket: &ticket,
+            requester: Some(&requester),
+            agent: &agent,
+            app_name: "Nosdesk",
+            event: None,
+            reply: None,
+        };
+        let out = render(
+            "Hi {{customer_first_name}}, we got your ticket {{ticket_id}}.",
+            &ctx,
+        );
+        assert_eq!(out, "Hi Jordan, we got your ticket 7.");
+    }
+
+    #[test]
+    fn agent_and_tech_aliases_resolve_identically() {
+        let ticket = stub_ticket(1, "T");
+        let agent = stub_user("Mary Jane Smith");
+        let ctx = TemplateContext {
+            ticket: &ticket,
+            requester: None,
+            agent: &agent,
+            app_name: "Nosdesk",
+            event: None,
+            reply: None,
+        };
+        // `tech_*` and `agent_*` resolve to the same agent values so
+        // a body authored for canned responses renders identically
+        // inside a rule reply.
+        let with_tech = render("{{tech_name}} {{tech_first_name}}", &ctx);
+        let with_agent = render("{{agent_name}} {{agent_first_name}}", &ctx);
+        assert_eq!(with_tech, "Mary Jane Smith Mary");
+        assert_eq!(with_agent, with_tech);
+    }
+
+    #[test]
+    fn unknown_tokens_pass_through_for_visibility() {
+        // The renderer leaves unrecognised tokens intact so the typo
+        // surfaces in preview rather than silently dropping. Save-
+        // time validation in repository::rules catches them earlier.
+        let ticket = stub_ticket(1, "T");
+        let agent = stub_user("Agent");
+        let ctx = TemplateContext {
+            ticket: &ticket,
+            requester: None,
+            agent: &agent,
+            app_name: "Nosdesk",
+            event: None,
+            reply: None,
+        };
+        let out = render("{{custmer_name}} should not resolve", &ctx);
+        assert_eq!(out, "{{custmer_name}} should not resolve");
+    }
+}

--- a/backend/src/utils/template_variables.rs
+++ b/backend/src/utils/template_variables.rs
@@ -55,6 +55,27 @@ pub const AUTO_ACK_VARIABLES: &[&str] = &[
     "app_name",
 ];
 
+/// Variables the rules engine substitutes in a `reply` action's body
+/// when a rule is applied. Mirrors `CANNED_RESPONSE_VARIABLES` plus
+/// `agent_name` as an alias for `tech_name`: the synthesis (Phase 1
+/// decision 34) standardised on "Actions" / "agent" for the rules
+/// surface while keeping the legacy `tech_*` tokens for parity with
+/// canned responses, so admins copying a body between the two
+/// surfaces never see a save rejected for a typo'd token. Phase 2
+/// extends this list with event- and reply-scoped tokens; for v1
+/// the manual-trigger surface alone is in scope.
+pub const RULE_REPLY_VARIABLES: &[&str] = &[
+    "ticket_id",
+    "ticket_title",
+    "customer_name",
+    "customer_first_name",
+    "tech_name",
+    "tech_first_name",
+    "agent_name",
+    "agent_first_name",
+    "app_name",
+];
+
 /// Take the first whitespace-separated token of a full name.
 /// "Mary Jane Smith" → "Mary"; "Alex" → "Alex"; "" → "". Empty
 /// input returns empty; the substitute helper leaves an empty

--- a/frontend/src/components/ticketComponents/ActionsDialog.vue
+++ b/frontend/src/components/ticketComponents/ActionsDialog.vue
@@ -1,0 +1,241 @@
+<script setup lang="ts">
+/**
+ * Agent toolbar dialog for manual rule application ("Actions"
+ * surface, decision 26 in the rules-and-actions plan). Open from
+ * the ticket view's toolbar; lists the live manual rules in the
+ * caller's workspace, preview the actions a rule will take, and
+ * apply it via POST /api/rules/{id}/apply.
+ *
+ * Phase 1 is unconditional: manual rules have empty conditions, so
+ * the picker shows every live manual rule. When Path A relaxation
+ * lands (manual rules with visibility-filter conditions), this
+ * dialog reads from the same `applicable-actions` endpoint —
+ * server-side filtering will then narrow the list automatically.
+ */
+import { computed, ref, watch } from 'vue';
+import { useFluent } from 'fluent-vue';
+import { useQuery } from '@pinia/colada';
+
+import Modal from '@/components/Modal.vue';
+import Button from '@/components/common/Button.vue';
+import FormTextarea from '@/components/common/FormTextarea.vue';
+import Skeleton from '@/components/common/Skeleton.vue';
+import SkeletonBar from '@/components/common/SkeletonBar.vue';
+import Icon from '@/components/common/Icon.vue';
+import rulesService from '@/services/rulesService';
+import { useToastStore } from '@/stores/toast';
+import { extractErrorMessage } from '@/utils/errors';
+import type { Rule, RuleAction } from '@/types/rule';
+
+const props = defineProps<{
+  show: boolean;
+  ticketId: number;
+}>();
+const emit = defineEmits<{
+  (e: 'close'): void;
+  (e: 'applied', ruleId: number): void;
+}>();
+
+const fluent = useFluent();
+const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
+const toast = useToastStore();
+
+const PICK_KEY = computed(
+  () => ['applicable-actions', props.ticketId] as const,
+);
+const picksQuery = useQuery({
+  key: PICK_KEY,
+  query: () => rulesService.pickableActions(props.ticketId),
+  enabled: () => props.show,
+});
+
+const search = ref('');
+const selected = ref<Rule | null>(null);
+const overrideBody = ref<string | null>(null);
+const showOverrideEditor = ref(false);
+const applying = ref(false);
+
+const allRules = computed<Rule[]>(() =>
+  Array.isArray(picksQuery.data.value) ? picksQuery.data.value : [],
+);
+const filtered = computed<Rule[]>(() => {
+  const q = search.value.trim().toLowerCase();
+  if (!q) return allRules.value;
+  return allRules.value.filter((r) => r.name.toLowerCase().includes(q));
+});
+const isFirstLoad = computed(
+  () => picksQuery.status.value === 'pending' && picksQuery.data.value === undefined,
+);
+
+watch(
+  () => props.show,
+  (val) => {
+    if (!val) {
+      selected.value = null;
+      overrideBody.value = null;
+      showOverrideEditor.value = false;
+      search.value = '';
+    }
+  },
+);
+
+function actionSummaryChips(rule: Rule): string[] {
+  return rule.actions.map((a) => describeAction(a));
+}
+
+function describeAction(action: RuleAction): string {
+  const config = (action.config ?? {}) as Record<string, unknown>;
+  switch (action.kind) {
+    case 'reply':
+      return config.visibility === 'internal'
+        ? t('admin-rules-action-chip-reply-internal')
+        : t('admin-rules-action-chip-reply-public');
+    case 'set_status':
+      return t('admin-rules-action-chip-set-status', {
+        state_id: Number(config.workflow_state_id ?? 0),
+      });
+    case 'assign':
+      return t('admin-rules-action-chip-assign');
+    case 'unassign':
+      return t('admin-rules-action-chip-unassign');
+    case 'add_tags':
+      return t('admin-rules-action-chip-add-tags', {
+        count: Array.isArray(config.tag_ids) ? config.tag_ids.length : 0,
+      });
+    case 'remove_tags':
+      return t('admin-rules-action-chip-remove-tags', {
+        count: Array.isArray(config.tag_ids) ? config.tag_ids.length : 0,
+      });
+    case 'set_priority':
+      return t('admin-rules-action-chip-set-priority', {
+        priority: String(config.priority ?? 'normal'),
+      });
+    case 'stop_processing':
+      return t('admin-rules-action-chip-stop-processing');
+    default:
+      return action.kind;
+  }
+}
+
+const replyAction = computed<RuleAction | null>(() => {
+  const r = selected.value;
+  if (!r) return null;
+  return r.actions.find((a) => a.kind === 'reply') ?? null;
+});
+
+const replyBodyForPreview = computed<string>(() => {
+  if (overrideBody.value !== null) return overrideBody.value;
+  const action = replyAction.value;
+  if (!action) return '';
+  return String((action.config as Record<string, unknown> | undefined)?.body ?? '');
+});
+
+async function apply(): Promise<void> {
+  const rule = selected.value;
+  if (!rule) return;
+  applying.value = true;
+  try {
+    await rulesService.apply(rule.id, {
+      ticket_id: props.ticketId,
+      overrides: {
+        body: overrideBody.value ?? undefined,
+      },
+    });
+    toast.success(t('ticket-actions-success-toast', { rule: rule.name }));
+    emit('applied', rule.id);
+    emit('close');
+  } catch (err) {
+    toast.error(extractErrorMessage(err, t('ticket-actions-error-toast')));
+  } finally {
+    applying.value = false;
+  }
+}
+</script>
+
+<template>
+  <Modal :show="show" :title="t('ticket-actions-dialog-title')" @close="emit('close')">
+    <div class="space-y-4 max-w-xl w-full">
+      <input
+        v-model="search"
+        type="search"
+        :placeholder="t('ticket-actions-dialog-picker-placeholder')"
+        class="w-full border rounded-md px-3 py-2 text-sm bg-surface"
+        autofocus
+      />
+
+      <Skeleton v-if="isFirstLoad" class="space-y-2">
+        <SkeletonBar v-for="i in 3" :key="i" class="h-12 w-full" />
+      </Skeleton>
+
+      <p v-else-if="filtered.length === 0" class="text-sm text-secondary">
+        {{ t('ticket-actions-dialog-empty') }}
+      </p>
+
+      <ul v-else class="space-y-1 max-h-64 overflow-y-auto">
+        <li
+          v-for="rule in filtered"
+          :key="rule.id"
+          :class="[
+            'border rounded-md p-2 cursor-pointer',
+            selected?.id === rule.id ? 'border-primary bg-primary/5' : 'hover:bg-surface-hover',
+          ]"
+          @click="selected = rule; overrideBody = null"
+        >
+          <div class="font-medium text-sm">{{ rule.name }}</div>
+          <div v-if="rule.description" class="text-xs text-secondary truncate">
+            {{ rule.description }}
+          </div>
+          <div class="mt-1 flex flex-wrap gap-1">
+            <span
+              v-for="(chip, i) in actionSummaryChips(rule)"
+              :key="i"
+              class="inline-block rounded-full bg-surface-hover px-2 py-0.5 text-xs"
+            >
+              {{ chip }}
+            </span>
+          </div>
+        </li>
+      </ul>
+
+      <div v-if="selected" class="border-t pt-3 space-y-2">
+        <p class="text-sm font-medium">{{ t('ticket-actions-dialog-action-list-label') }}</p>
+        <ul class="space-y-1 text-sm">
+          <li v-for="(chip, i) in actionSummaryChips(selected)" :key="i" class="text-secondary">
+            • {{ chip }}
+          </li>
+        </ul>
+
+        <template v-if="replyAction">
+          <Button
+            v-if="!showOverrideEditor"
+            variant="ghost"
+            size="sm"
+            @click="overrideBody = replyBodyForPreview; showOverrideEditor = true"
+          >
+            Edit reply
+          </Button>
+          <FormTextarea
+            v-if="showOverrideEditor"
+            :model-value="overrideBody ?? ''"
+            @update:model-value="overrideBody = $event"
+            :rows="4"
+          />
+        </template>
+      </div>
+
+      <div class="flex justify-end gap-2">
+        <Button variant="secondary" @click="emit('close')">
+          {{ t('ticket-actions-dialog-cancel') }}
+        </Button>
+        <Button
+          variant="primary"
+          :disabled="!selected || applying"
+          :loading="applying"
+          @click="apply"
+        >
+          {{ applying ? t('ticket-actions-dialog-applying') : t('ticket-actions-dialog-apply') }}
+        </Button>
+      </div>
+    </div>
+  </Modal>
+</template>

--- a/frontend/src/components/ticketComponents/TicketActivity.vue
+++ b/frontend/src/components/ticketComponents/TicketActivity.vue
@@ -314,6 +314,20 @@ function phraseFor(ev: TicketActivityEvent, ctx: PhraseContext): string {
         ? t('ticket-activity-phrase-merged-into', { target_id: dest })
         : t('ticket-activity-phrase-generic')
     }
+    case 'ticket.rule_applied': {
+      // Rules engine fire (manual apply, or Phase 2+ event /
+      // time-elapsed). The rule name + dry-run flag drives the
+      // phrase; the inspector deep-link in the activity panel
+      // reads rule_id / rule_version off the same data blob.
+      const ruleName = (data.rule_name as string | undefined) ?? ''
+      const wasDryRun = data.was_dry_run === true
+      if (wasDryRun) {
+        return t('ticket-activity-phrase-rule-applied-dry-run', { rule: ruleName })
+      }
+      return ruleName
+        ? t('ticket-activity-phrase-rule-applied', { rule: ruleName })
+        : t('ticket-activity-phrase-generic')
+    }
     case 'comment.created': {
       if (data.is_internal) return t('ticket-activity-phrase-internal-note')
       const cv = readCreatedVia(ev)

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -656,6 +656,22 @@ const router = createRouter({
           meta: { titleKey: 'route-title-admin-canned-responses-edit' }
         },
         {
+          path: 'rules',
+          name: 'admin-rules',
+          component: () => import('../views/SettingsRulesView.vue'),
+          meta: { titleKey: 'route-title-admin-rules' }
+        },
+        {
+          path: 'rules/activity',
+          name: 'admin-rules-activity',
+          component: () => import('../views/RuleActivityView.vue'),
+          meta: { titleKey: 'route-title-admin-rules-activity' }
+        },
+        // admin-rules-new and admin-rules-edit are registered in
+        // Wave 7 once the RuleEditView component lands; the list
+        // view falls back to a console-warning push if those routes
+        // aren't registered yet.
+        {
           path: 'webhooks',
           name: 'admin-webhooks',
           component: () => import('../views/WebhooksView.vue'),

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -667,10 +667,18 @@ const router = createRouter({
           component: () => import('../views/RuleActivityView.vue'),
           meta: { titleKey: 'route-title-admin-rules-activity' }
         },
-        // admin-rules-new and admin-rules-edit are registered in
-        // Wave 7 once the RuleEditView component lands; the list
-        // view falls back to a console-warning push if those routes
-        // aren't registered yet.
+        {
+          path: 'rules/new',
+          name: 'admin-rules-new',
+          component: () => import('../views/RuleEditView.vue'),
+          meta: { titleKey: 'route-title-admin-rules-new' }
+        },
+        {
+          path: 'rules/:id(\\d+)',
+          name: 'admin-rules-edit',
+          component: () => import('../views/RuleEditView.vue'),
+          meta: { titleKey: 'route-title-admin-rules-edit' }
+        },
         {
           path: 'webhooks',
           name: 'admin-webhooks',

--- a/frontend/src/services/cannedResponsesService.ts
+++ b/frontend/src/services/cannedResponsesService.ts
@@ -162,7 +162,13 @@ export function renderTemplate(template: string, vars: TemplateVars): string {
     tech_first_name: firstWord(vars.tech_name),
     app_name: vars.app_name ?? '',
   };
-  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+  // Whitespace-tolerant token match so `{{ ticket_id }}` and
+  // `{{ticket_id}}` substitute identically. Matches the backend
+  // substituter at backend/src/utils/template_variables.rs which
+  // the rules engine uses on apply; without this, a body authored
+  // with padded braces would preview unsubstituted on the agent
+  // dialog but render correctly when the rule is applied.
+  return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, key) => {
     // `match` is the whole `{{key}}` token; fall back to leaving it
     // in place when the key isn't recognised (not `""`).
     return Object.prototype.hasOwnProperty.call(lookup, key) ? lookup[key] : match;

--- a/frontend/src/services/rulesService.ts
+++ b/frontend/src/services/rulesService.ts
@@ -1,0 +1,139 @@
+/**
+ * Rules engine API client. The admin Settings page uses the full
+ * surface; the agent toolbar only consumes `pickableActions` and
+ * `apply`. All reads scope through the workspace context the cookie
+ * + workspace middleware sets up; the service doesn't pass
+ * workspace_id explicitly.
+ *
+ * Convention: list/detail queries plug into Pinia Colada `useQuery`
+ * from the views; mutations call the service directly and invalidate
+ * the relevant query key.
+ */
+import apiClient from './apiConfig';
+import type {
+  ApplyRuleRequest,
+  ApplyRuleResponse,
+  CreateRuleRequest,
+  ListApplicationsQuery,
+  ListRulesQuery,
+  Rule,
+  RuleApplication,
+  RuleVersion,
+  StateTransitionRequest,
+  UpdateRuleRequest,
+} from '@/types/rule';
+
+function toQueryString(params: object | undefined): string {
+  if (!params) return '';
+  const entries: string[] = [];
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    entries.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  }
+  return entries.length ? `?${entries.join('&')}` : '';
+}
+
+export const rulesService = {
+  /** GET /api/rules. Admin. */
+  async list(query?: ListRulesQuery): Promise<Rule[]> {
+    const { data } = await apiClient.get<Rule[]>(`/rules${toQueryString(query)}`);
+    return data;
+  },
+
+  /** GET /api/rules/{id}. Admin. */
+  async get(id: number): Promise<Rule> {
+    const { data } = await apiClient.get<Rule>(`/rules/${id}`);
+    return data;
+  },
+
+  /** POST /api/rules. Admin. */
+  async create(req: CreateRuleRequest): Promise<Rule> {
+    const { data } = await apiClient.post<Rule>('/rules', req);
+    return data;
+  },
+
+  /** PUT /api/rules/{id}. Admin. */
+  async update(id: number, req: UpdateRuleRequest): Promise<Rule> {
+    const { data } = await apiClient.put<Rule>(`/rules/${id}`, req);
+    return data;
+  },
+
+  /** PATCH /api/rules/{id}/state. Admin. */
+  async transitionState(id: number, req: StateTransitionRequest): Promise<Rule> {
+    const { data } = await apiClient.patch<Rule>(`/rules/${id}/state`, req);
+    return data;
+  },
+
+  /** DELETE /api/rules/{id}. Admin. Soft-archive by default. */
+  async archive(id: number): Promise<Rule> {
+    const { data } = await apiClient.delete<Rule>(`/rules/${id}`);
+    return data;
+  },
+
+  /**
+   * DELETE /api/rules/{id}?hard=true. Admin. The rule must be
+   * archived first; the API returns 409 RULE_NOT_ARCHIVED otherwise.
+   */
+  async hardDelete(id: number): Promise<void> {
+    await apiClient.delete(`/rules/${id}?hard=true`);
+  },
+
+  /** GET /api/rules/{id}/versions. Admin. */
+  async listVersions(ruleId: number): Promise<RuleVersion[]> {
+    const { data } = await apiClient.get<RuleVersion[]>(`/rules/${ruleId}/versions`);
+    return data;
+  },
+
+  /** GET /api/rules/{rule_id}/versions/{version}. Admin. */
+  async getVersion(ruleId: number, version: number): Promise<RuleVersion> {
+    const { data } = await apiClient.get<RuleVersion>(
+      `/rules/${ruleId}/versions/${version}`,
+    );
+    return data;
+  },
+
+  /** GET /api/rule-applications. Admin. */
+  async listApplications(query?: ListApplicationsQuery): Promise<RuleApplication[]> {
+    const { data } = await apiClient.get<RuleApplication[]>(
+      `/rule-applications${toQueryString(query)}`,
+    );
+    return data;
+  },
+
+  /** GET /api/rule-applications/{id}. Admin. */
+  async getApplication(id: number): Promise<RuleApplication> {
+    const { data } = await apiClient.get<RuleApplication>(`/rule-applications/${id}`);
+    return data;
+  },
+
+  /** GET /api/tickets/{ticket_id}/rule-applications. Agent. */
+  async listApplicationsForTicket(ticketId: number): Promise<RuleApplication[]> {
+    const { data } = await apiClient.get<RuleApplication[]>(
+      `/tickets/${ticketId}/rule-applications`,
+    );
+    return data;
+  },
+
+  /**
+   * GET /api/tickets/{id}/applicable-actions. Agent. The toolbar
+   * picker queries this; manual rules carry no conditions in Phase
+   * 1 so the response is the unfiltered live-manual list.
+   */
+  async pickableActions(ticketId: number): Promise<Rule[]> {
+    const { data } = await apiClient.get<Rule[]>(
+      `/tickets/${ticketId}/applicable-actions`,
+    );
+    return data;
+  },
+
+  /** POST /api/rules/{id}/apply. Agent. */
+  async apply(ruleId: number, req: ApplyRuleRequest): Promise<ApplyRuleResponse> {
+    const { data } = await apiClient.post<ApplyRuleResponse>(
+      `/rules/${ruleId}/apply`,
+      req,
+    );
+    return data;
+  },
+};
+
+export default rulesService;

--- a/frontend/src/types/rule.ts
+++ b/frontend/src/types/rule.ts
@@ -1,0 +1,176 @@
+/**
+ * Rules engine types (docs/rules-and-actions-plan.md). The agent-
+ * facing surface calls these "Actions" (the toolbar button label
+ * locked by decision 26); the entity name stays `Rule` in code +
+ * the admin Settings page is `/admin/rules`.
+ */
+
+export type RuleTriggerKind =
+  | 'manual'
+  | 'ticket_created'
+  | 'ticket_updated'
+  | 'ticket_replied'
+  | 'time_elapsed';
+
+export type RuleState = 'draft' | 'dry_run' | 'live' | 'archived';
+
+export type RuleApplicationStatus =
+  | 'succeeded'
+  | 'dry_run'
+  | 'skipped_preflight'
+  | 'skipped_condition_unmet'
+  | 'suppressed_recursion_budget'
+  | 'suppressed_loop_guard'
+  | 'failed';
+
+/** Typed action object stored in `Rule.actions`. */
+export interface RuleAction {
+  kind:
+    | 'reply'
+    | 'set_status'
+    | 'assign'
+    | 'unassign'
+    | 'add_tags'
+    | 'remove_tags'
+    | 'set_priority'
+    | 'notify'
+    | 'apply_macro_template'
+    | 'webhook'
+    | 'stop_processing';
+  config?: Record<string, unknown>;
+}
+
+/** Recursive AND/OR/NOT/leaf condition node. */
+export type RuleCondition =
+  | { kind: 'and'; children: RuleCondition[] }
+  | { kind: 'or'; children: RuleCondition[] }
+  | { kind: 'not'; child: RuleCondition }
+  | {
+      kind: 'leaf';
+      field: string;
+      op: string;
+      value: unknown;
+    };
+
+/** Wire shape of a Rule. Manual rules have `conditions: []`. */
+export interface Rule {
+  id: number;
+  workspace_id: number;
+  name: string;
+  description: string | null;
+  trigger_kind: RuleTriggerKind;
+  trigger_config: Record<string, unknown>;
+  /** Empty array (`[]`) for manual rules; single condition node otherwise. */
+  conditions: RuleCondition[] | RuleCondition;
+  actions: RuleAction[];
+  reads_set: string[];
+  writes_set: string[];
+  state: RuleState;
+  priority: number;
+  last_fired_at: string | null;
+  fire_count: number;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  archived_at: string | null;
+}
+
+export interface CreateRuleRequest {
+  name: string;
+  description?: string | null;
+  trigger_kind: RuleTriggerKind;
+  trigger_config?: Record<string, unknown>;
+  conditions?: RuleCondition[] | RuleCondition;
+  actions: RuleAction[];
+  priority?: number;
+  /** Skip the self-referential save linter (writes ∩ reads != ∅). */
+  override_self_reference?: boolean;
+}
+
+export interface UpdateRuleRequest {
+  name?: string;
+  description?: string | null;
+  trigger_kind?: RuleTriggerKind;
+  trigger_config?: Record<string, unknown>;
+  conditions?: RuleCondition[] | RuleCondition;
+  actions?: RuleAction[];
+  priority?: number;
+  override_self_reference?: boolean;
+}
+
+export interface StateTransitionRequest {
+  state: RuleState;
+}
+
+export interface ListRulesQuery {
+  trigger_kind?: RuleTriggerKind;
+  state?: RuleState;
+  q?: string;
+  include_archived?: boolean;
+}
+
+/** Rule version snapshot (one row per save). */
+export interface RuleVersion {
+  id: number;
+  rule_id: number;
+  workspace_id: number;
+  version: number;
+  name: string;
+  description: string | null;
+  trigger_kind: RuleTriggerKind;
+  trigger_config: Record<string, unknown>;
+  conditions: RuleCondition[] | RuleCondition;
+  actions: RuleAction[];
+  state: RuleState;
+  priority: number;
+  saved_by: string | null;
+  saved_at: string;
+}
+
+/** One row per fire attempt (manual apply, event match, time match, dry-run). */
+export interface RuleApplication {
+  id: number;
+  workspace_id: number;
+  rule_id: number;
+  rule_version: number;
+  ticket_id: number;
+  status: RuleApplicationStatus;
+  correlation_id: string | null;
+  actor_uuid: string | null;
+  actor_kind: 'user' | 'system';
+  originating_event_id: string | null;
+  originating_event_kind: string | null;
+  condition_evaluation: Record<string, unknown> | null;
+  actions_taken: Array<Record<string, unknown>> | null;
+  actions_skipped: Array<Record<string, unknown>> | null;
+  failure_reason: string | null;
+  applied_at: string;
+}
+
+export interface ListApplicationsQuery {
+  rule_id?: number;
+  ticket_id?: number;
+  status?: RuleApplicationStatus;
+  actor_uuid?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+}
+
+export interface ApplyRuleRequest {
+  ticket_id: number;
+  overrides?: {
+    body?: string;
+    /** 1-indexed action positions to skip. */
+    suppress_actions?: number[];
+  };
+}
+
+export interface ApplyRuleResponse {
+  rule: Rule;
+  application_id: number;
+  correlation_id: string | null;
+  comment_id: number | null;
+  actions_executed: number;
+  actions_suppressed: number;
+}

--- a/frontend/src/views/RuleActivityView.vue
+++ b/frontend/src/views/RuleActivityView.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+/**
+ * Admin activity-log view for the rules engine. Lists recent
+ * rule_applications across the workspace with filters by rule,
+ * status, and date range. The inspector tab on each row reveals
+ * the condition_evaluation / actions_taken / actions_skipped /
+ * failure_reason payloads the backend captures for non-succeeded
+ * fires (succeeded rows stay tight per plan §4.3 to keep the
+ * happy-path retention case cheap).
+ *
+ * Phase 1 is read-only; clicking a row opens the per-application
+ * inspector inline. Wave 2's conflicts tab adds heuristic
+ * warnings on top of this same dataset.
+ */
+import { computed, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { useFluent } from 'fluent-vue';
+import { useQuery } from '@pinia/colada';
+import { formatDistanceToNow } from 'date-fns';
+
+import AlertMessage from '@/components/common/AlertMessage.vue';
+import Button from '@/components/common/Button.vue';
+import EmptyState from '@/components/common/EmptyState.vue';
+import Icon from '@/components/common/Icon.vue';
+import Skeleton from '@/components/common/Skeleton.vue';
+import SkeletonBar from '@/components/common/SkeletonBar.vue';
+import rulesService from '@/services/rulesService';
+import type { RuleApplication, RuleApplicationStatus } from '@/types/rule';
+
+const fluent = useFluent();
+const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
+const router = useRouter();
+
+const statusFilter = ref<RuleApplicationStatus | 'all'>('all');
+const limit = ref<number>(50);
+
+/** Query key includes the filter so changing it triggers a refetch
+ *  via Pinia Colada's reactivity. */
+const APPLICATIONS_KEY = computed(
+  () => ['rule-applications', statusFilter.value, limit.value] as const,
+);
+const applicationsQuery = useQuery({
+  key: APPLICATIONS_KEY,
+  query: () =>
+    rulesService.listApplications({
+      status: statusFilter.value === 'all' ? undefined : statusFilter.value,
+      limit: limit.value,
+    }),
+});
+
+const applications = computed<RuleApplication[]>(() =>
+  Array.isArray(applicationsQuery.data.value) ? applicationsQuery.data.value : [],
+);
+const isFirstLoad = computed(
+  () =>
+    applicationsQuery.status.value === 'pending' &&
+    applicationsQuery.data.value === undefined,
+);
+const loadError = computed(() =>
+  applicationsQuery.error.value ? t('admin-rules-activity-error-load') : '',
+);
+
+function statusLabel(status: RuleApplicationStatus): string {
+  return t(`admin-rules-activity-status-${status.replace(/_/g, '-')}`);
+}
+
+function statusVariant(status: RuleApplicationStatus): string {
+  if (status === 'succeeded') return 'bg-success/10 text-success';
+  if (status === 'dry_run') return 'bg-info/10 text-info';
+  if (status === 'failed') return 'bg-error/10 text-error';
+  return 'bg-warning/10 text-warning';
+}
+
+function formatTime(value: string): string {
+  try {
+    return formatDistanceToNow(new Date(value), { addSuffix: true });
+  } catch {
+    return value;
+  }
+}
+
+const expanded = ref<Set<number>>(new Set());
+function toggleExpanded(id: number): void {
+  if (expanded.value.has(id)) {
+    expanded.value.delete(id);
+  } else {
+    expanded.value.add(id);
+  }
+}
+
+function inspectorPayload(app: RuleApplication): string {
+  /** The four payloads are stored sparsely (only on non-succeeded
+   *  rows, see migration / plan). Pretty-print whichever are
+   *  present so the inspector reads correctly. */
+  const blobs: Record<string, unknown> = {};
+  if (app.condition_evaluation) blobs.condition_evaluation = app.condition_evaluation;
+  if (app.actions_taken) blobs.actions_taken = app.actions_taken;
+  if (app.actions_skipped) blobs.actions_skipped = app.actions_skipped;
+  if (app.failure_reason) blobs.failure_reason = app.failure_reason;
+  if (Object.keys(blobs).length === 0) return t('admin-rules-activity-inspector-empty');
+  return JSON.stringify(blobs, null, 2);
+}
+
+function back(): void {
+  router.push({ name: 'admin-rules' });
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div class="flex flex-wrap items-center gap-3">
+      <Button variant="secondary" size="sm" @click="back">
+        <Icon name="chevronLeft" class="w-4 h-4" />
+        <span>{{ t('admin-rules-activity-back') }}</span>
+      </Button>
+      <h1 class="text-2xl font-semibold flex-1 min-w-0">
+        {{ t('admin-rules-activity-title') }}
+      </h1>
+    </div>
+
+    <p class="text-sm text-secondary max-w-2xl">
+      {{ t('admin-rules-activity-help') }}
+    </p>
+
+    <AlertMessage v-if="loadError" type="error" :message="loadError" />
+
+    <div class="flex flex-wrap items-center gap-3">
+      <select v-model="statusFilter" class="border rounded-md px-3 py-2 text-sm bg-surface">
+        <option value="all">{{ t('admin-rules-activity-filter-all') }}</option>
+        <option value="succeeded">{{ statusLabel('succeeded') }}</option>
+        <option value="dry_run">{{ statusLabel('dry_run') }}</option>
+        <option value="failed">{{ statusLabel('failed') }}</option>
+        <option value="suppressed_recursion_budget">
+          {{ statusLabel('suppressed_recursion_budget') }}
+        </option>
+        <option value="suppressed_loop_guard">{{ statusLabel('suppressed_loop_guard') }}</option>
+        <option value="skipped_condition_unmet">{{ statusLabel('skipped_condition_unmet') }}</option>
+        <option value="skipped_preflight">{{ statusLabel('skipped_preflight') }}</option>
+      </select>
+      <select v-model.number="limit" class="border rounded-md px-3 py-2 text-sm bg-surface">
+        <option :value="25">{{ t('admin-rules-activity-limit', { n: 25 }) }}</option>
+        <option :value="50">{{ t('admin-rules-activity-limit', { n: 50 }) }}</option>
+        <option :value="100">{{ t('admin-rules-activity-limit', { n: 100 }) }}</option>
+        <option :value="500">{{ t('admin-rules-activity-limit', { n: 500 }) }}</option>
+      </select>
+    </div>
+
+    <Skeleton v-if="isFirstLoad" class="space-y-2">
+      <SkeletonBar v-for="i in 6" :key="i" class="h-10 w-full" />
+    </Skeleton>
+
+    <EmptyState
+      v-else-if="applications.length === 0"
+      :title="t('admin-rules-activity-empty-title')"
+      :hint="t('admin-rules-activity-empty-hint')"
+    />
+
+    <ul v-else class="space-y-2">
+      <li
+        v-for="app in applications"
+        :key="app.id"
+        class="border rounded-md bg-surface"
+      >
+        <div
+          class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-surface-hover"
+          @click="toggleExpanded(app.id)"
+        >
+          <span
+            :class="[
+              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+              statusVariant(app.status),
+            ]"
+          >
+            {{ statusLabel(app.status) }}
+          </span>
+          <span class="font-mono text-xs text-secondary">
+            #{{ app.rule_id }} v{{ app.rule_version }}
+          </span>
+          <span class="text-sm flex-1 min-w-0 truncate">
+            {{ t('admin-rules-activity-row-summary', {
+              ticket_id: app.ticket_id,
+              actor: app.actor_kind === 'system'
+                ? t('admin-rules-activity-actor-system')
+                : t('admin-rules-activity-actor-user'),
+            }) }}
+          </span>
+          <span class="text-xs text-secondary">{{ formatTime(app.applied_at) }}</span>
+          <Icon
+            :name="expanded.has(app.id) ? 'chevronUp' : 'chevronDown'"
+            class="w-3.5 h-3.5 text-secondary"
+          />
+        </div>
+        <pre
+          v-if="expanded.has(app.id)"
+          class="text-xs px-3 py-2 border-t bg-surface-hover overflow-x-auto"
+        >{{ inspectorPayload(app) }}</pre>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/frontend/src/views/RuleEditView.vue
+++ b/frontend/src/views/RuleEditView.vue
@@ -1,0 +1,391 @@
+<script setup lang="ts">
+/**
+ * Admin rule editor. Creates a new rule when route name is
+ * `admin-rules-new`, edits an existing rule by id when route name
+ * is `admin-rules-edit`. Manual rules (the Phase 1 trigger kind)
+ * have `conditions = []` enforced by the backend; the editor
+ * hides the conditions section for manual rules.
+ *
+ * The action list is the main interaction surface. Each action
+ * carries a typed `kind` plus a kind-specific config object. The
+ * supported kinds for Phase 1 are reply / set_status / assign /
+ * unassign / add_tags / remove_tags / set_priority /
+ * stop_processing; notify / apply_macro_template / webhook are
+ * deferred and rejected by the backend with RULE_ACTION_UNSUPPORTED.
+ */
+import { computed, onMounted, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useFluent } from 'fluent-vue';
+import { useQueryCache } from '@pinia/colada';
+
+import AlertMessage from '@/components/common/AlertMessage.vue';
+import Button from '@/components/common/Button.vue';
+import Checkbox from '@/components/common/Checkbox.vue';
+import FormInput from '@/components/common/FormInput.vue';
+import FormTextarea from '@/components/common/FormTextarea.vue';
+import Icon from '@/components/common/Icon.vue';
+import rulesService from '@/services/rulesService';
+import { extractErrorMessage } from '@/utils/errors';
+import { useToastStore } from '@/stores/toast';
+import type {
+  CreateRuleRequest,
+  Rule,
+  RuleAction,
+  RuleTriggerKind,
+  UpdateRuleRequest,
+} from '@/types/rule';
+
+const fluent = useFluent();
+const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
+const route = useRoute();
+const router = useRouter();
+const toast = useToastStore();
+const queryCache = useQueryCache();
+
+const isNew = computed(() => route.name === 'admin-rules-new');
+const ruleId = computed<number | null>(() =>
+  isNew.value ? null : Number(route.params.id) || null,
+);
+
+const loading = ref(false);
+const saving = ref(false);
+const errorMessage = ref('');
+const original = ref<Rule | null>(null);
+
+const name = ref('');
+const description = ref('');
+const triggerKind = ref<RuleTriggerKind>('manual');
+const priority = ref<number>(100);
+const actions = ref<RuleAction[]>([{ kind: 'reply', config: { visibility: 'public', body: '' } }]);
+const overrideSelfRef = ref(false);
+
+onMounted(async () => {
+  if (isNew.value) return;
+  if (ruleId.value == null) return;
+  loading.value = true;
+  try {
+    const rule = await rulesService.get(ruleId.value);
+    original.value = rule;
+    name.value = rule.name;
+    description.value = rule.description ?? '';
+    triggerKind.value = rule.trigger_kind;
+    priority.value = rule.priority;
+    actions.value = Array.isArray(rule.actions) ? [...rule.actions] : [];
+  } catch (err) {
+    errorMessage.value = extractErrorMessage(err, t('admin-rule-editor-error-save'));
+  } finally {
+    loading.value = false;
+  }
+});
+
+const headerTitle = computed(() =>
+  isNew.value
+    ? t('admin-rule-editor-title-new')
+    : t('admin-rule-editor-title-edit', { name: original.value?.name ?? '' }),
+);
+
+function addAction(): void {
+  actions.value.push({ kind: 'reply', config: { visibility: 'public', body: '' } });
+}
+
+function removeAction(index: number): void {
+  actions.value.splice(index, 1);
+}
+
+function setActionKind(index: number, kind: RuleAction['kind']): void {
+  // Reset config when the kind changes so stale fields from the
+  // previous shape don't leak through to the save request. Each
+  // kind gets a minimal default; the backend's per-kind validator
+  // catches anything stricter.
+  const defaultConfig = (k: RuleAction['kind']): Record<string, unknown> => {
+    switch (k) {
+      case 'reply':
+        return { visibility: 'public', body: '' };
+      case 'set_status':
+        return { workflow_state_id: 0 };
+      case 'assign':
+        return { method: 'direct', user_uuid: '' };
+      case 'unassign':
+        return {};
+      case 'add_tags':
+      case 'remove_tags':
+        return { tag_ids: [] };
+      case 'set_priority':
+        return { priority: 'normal' };
+      case 'stop_processing':
+        return {};
+      default:
+        return {};
+    }
+  };
+  actions.value[index] = { kind, config: defaultConfig(kind) };
+}
+
+function updateConfigField(index: number, field: string, value: unknown): void {
+  const next = { ...(actions.value[index].config ?? {}) } as Record<string, unknown>;
+  next[field] = value;
+  actions.value[index] = { ...actions.value[index], config: next };
+}
+
+const canSave = computed(
+  () => name.value.trim().length > 0 && actions.value.length > 0 && !saving.value,
+);
+
+async function save(): Promise<void> {
+  errorMessage.value = '';
+  if (!canSave.value) return;
+  saving.value = true;
+  try {
+    const payload: CreateRuleRequest = {
+      name: name.value.trim(),
+      description: description.value.trim() || null,
+      trigger_kind: triggerKind.value,
+      conditions: [],
+      actions: actions.value,
+      priority: priority.value,
+      override_self_reference: overrideSelfRef.value,
+    };
+    if (isNew.value) {
+      const created = await rulesService.create(payload);
+      await queryCache.invalidateQueries({ key: ['rules'] });
+      toast.success(t('admin-rules-toast-archived', { name: created.name }));
+      router.push({ name: 'admin-rules-edit', params: { id: created.id } });
+    } else if (ruleId.value != null) {
+      const update: UpdateRuleRequest = {
+        name: payload.name,
+        description: payload.description,
+        trigger_kind: payload.trigger_kind,
+        actions: payload.actions,
+        priority: payload.priority,
+        override_self_reference: overrideSelfRef.value,
+      };
+      await rulesService.update(ruleId.value, update);
+      await queryCache.invalidateQueries({ key: ['rules'] });
+      toast.success(t('admin-rules-toast-state-changed', { state: name.value }));
+    }
+  } catch (err) {
+    errorMessage.value = extractErrorMessage(err, t('admin-rule-editor-error-save'));
+  } finally {
+    saving.value = false;
+  }
+}
+
+function back(): void {
+  router.push({ name: 'admin-rules' });
+}
+
+const triggerKinds: RuleTriggerKind[] = [
+  'manual',
+  'ticket_created',
+  'ticket_updated',
+  'ticket_replied',
+  'time_elapsed',
+];
+const actionKinds: RuleAction['kind'][] = [
+  'reply',
+  'set_status',
+  'assign',
+  'unassign',
+  'add_tags',
+  'remove_tags',
+  'set_priority',
+  'stop_processing',
+];
+
+function triggerLabel(kind: RuleTriggerKind): string {
+  return t(`admin-rules-trigger-${kind.replace(/_/g, '-')}`);
+}
+
+function actionLabel(kind: RuleAction['kind']): string {
+  const map: Record<RuleAction['kind'], string> = {
+    reply: 'Reply',
+    set_status: 'Set status',
+    assign: 'Assign',
+    unassign: 'Unassign',
+    add_tags: 'Add tags',
+    remove_tags: 'Remove tags',
+    set_priority: 'Set priority',
+    notify: 'Notify',
+    apply_macro_template: 'Apply template',
+    webhook: 'Webhook',
+    stop_processing: 'Stop processing',
+  };
+  return map[kind] ?? kind;
+}
+</script>
+
+<template>
+  <div class="space-y-6 max-w-3xl">
+    <div class="flex items-center gap-3">
+      <Button variant="secondary" size="sm" @click="back">
+        <Icon name="chevronLeft" class="w-4 h-4" />
+        <span>{{ t('admin-rule-editor-back') }}</span>
+      </Button>
+      <h1 class="text-2xl font-semibold flex-1 min-w-0 truncate">
+        {{ headerTitle }}
+      </h1>
+      <Button variant="primary" :disabled="!canSave" @click="save">
+        {{ saving ? t('admin-rule-editor-saving') : t('admin-rule-editor-save') }}
+      </Button>
+    </div>
+
+    <AlertMessage v-if="errorMessage" type="error" :message="errorMessage" />
+
+    <section class="space-y-3">
+      <h2 class="text-sm font-semibold text-secondary uppercase tracking-wide">
+        {{ t('admin-rule-editor-section-name') }}
+      </h2>
+      <FormInput
+        v-model="name"
+        :label="t('admin-rule-editor-name-label')"
+        :placeholder="t('admin-rule-editor-name-placeholder')"
+        required
+      />
+      <FormTextarea
+        v-model="description"
+        :label="t('admin-rule-editor-description-label')"
+        :placeholder="t('admin-rule-editor-description-placeholder')"
+        :rows="2"
+      />
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-sm font-semibold text-secondary uppercase tracking-wide">
+        {{ t('admin-rule-editor-section-trigger') }}
+      </h2>
+      <label class="block text-sm font-medium">{{ t('admin-rule-editor-trigger-label') }}</label>
+      <select
+        v-model="triggerKind"
+        class="w-full border rounded-md px-3 py-2 text-sm bg-surface"
+      >
+        <option v-for="k in triggerKinds" :key="k" :value="k">
+          {{ triggerLabel(k) }}
+        </option>
+      </select>
+      <p v-if="triggerKind === 'manual'" class="text-xs text-secondary">
+        {{ t('admin-rule-editor-trigger-manual-note') }}
+      </p>
+      <p v-else class="text-xs text-warning">
+        {{ t('admin-rule-editor-trigger-other-phase') }}
+      </p>
+    </section>
+
+    <section class="space-y-3">
+      <div class="flex items-center justify-between">
+        <h2 class="text-sm font-semibold text-secondary uppercase tracking-wide">
+          {{ t('admin-rule-editor-section-actions') }}
+        </h2>
+        <Button variant="ghost" size="sm" @click="addAction">
+          <Icon name="add" class="w-4 h-4" />
+          <span>{{ t('admin-rule-editor-actions-add') }}</span>
+        </Button>
+      </div>
+
+      <p v-if="actions.length === 0" class="text-sm text-warning">
+        {{ t('admin-rule-editor-actions-empty') }}
+      </p>
+
+      <ol class="space-y-2">
+        <li
+          v-for="(action, i) in actions"
+          :key="i"
+          class="border rounded-md p-3 space-y-2 bg-surface"
+        >
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-secondary font-mono">#{{ i + 1 }}</span>
+            <select
+              :value="action.kind"
+              @change="setActionKind(i, ($event.target as HTMLSelectElement).value as RuleAction['kind'])"
+              class="flex-1 border rounded-md px-2 py-1 text-sm bg-surface"
+            >
+              <option v-for="k in actionKinds" :key="k" :value="k">
+                {{ actionLabel(k) }}
+              </option>
+            </select>
+            <Button variant="ghost" size="sm" @click="removeAction(i)">
+              <Icon name="trash" class="w-3.5 h-3.5" />
+              <span class="sr-only">{{ t('admin-rule-editor-action-remove') }}</span>
+            </Button>
+          </div>
+
+          <!-- Per-kind config form. Kept inline so the editor stays
+               a single component for the Phase 1 surface; if it
+               grows past a screen each kind gets its own card. -->
+          <template v-if="action.kind === 'reply'">
+            <select
+              :value="(action.config as any)?.visibility ?? 'public'"
+              @change="updateConfigField(i, 'visibility', ($event.target as HTMLSelectElement).value)"
+              class="border rounded-md px-2 py-1 text-sm bg-surface"
+            >
+              <option value="public">{{ t('admin-rules-action-chip-reply-public') }}</option>
+              <option value="internal">{{ t('admin-rules-action-chip-reply-internal') }}</option>
+            </select>
+            <FormTextarea
+              :model-value="(action.config as any)?.body ?? ''"
+              @update:model-value="updateConfigField(i, 'body', $event)"
+              :rows="3"
+              placeholder="Hi {{customer_name}}, ..."
+            />
+          </template>
+
+          <template v-else-if="action.kind === 'set_status'">
+            <FormInput
+              :model-value="String((action.config as any)?.workflow_state_id ?? '')"
+              @update:model-value="updateConfigField(i, 'workflow_state_id', Number($event))"
+              :label="t('admin-rules-action-chip-set-status', { state_id: '' })"
+              type="number"
+            />
+          </template>
+
+          <template v-else-if="action.kind === 'assign'">
+            <FormInput
+              :model-value="(action.config as any)?.user_uuid ?? ''"
+              @update:model-value="updateConfigField(i, 'user_uuid', $event)"
+              label="Assign to user UUID"
+              placeholder="00000000-0000-0000-0000-000000000000"
+            />
+          </template>
+
+          <template v-else-if="action.kind === 'set_priority'">
+            <select
+              :value="(action.config as any)?.priority ?? 'normal'"
+              @change="updateConfigField(i, 'priority', ($event.target as HTMLSelectElement).value)"
+              class="border rounded-md px-2 py-1 text-sm bg-surface"
+            >
+              <option value="low">Low</option>
+              <option value="normal">Normal</option>
+              <option value="high">High</option>
+              <option value="urgent">Urgent</option>
+            </select>
+          </template>
+
+          <template v-else-if="action.kind === 'add_tags' || action.kind === 'remove_tags'">
+            <FormInput
+              :model-value="((action.config as any)?.tag_ids ?? []).join(',')"
+              @update:model-value="updateConfigField(i, 'tag_ids',
+                $event.split(',').map((x: string) => Number(x.trim())).filter((n: number) => Number.isFinite(n)))"
+              label="Tag IDs (comma-separated)"
+              placeholder="1, 2, 3"
+            />
+          </template>
+        </li>
+      </ol>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-sm font-semibold text-secondary uppercase tracking-wide">
+        {{ t('admin-rule-editor-section-state') }}
+      </h2>
+      <FormInput
+        :model-value="String(priority)"
+        @update:model-value="priority = Number($event) || 100"
+        :label="t('admin-rule-editor-priority-label')"
+        type="number"
+      />
+      <Checkbox
+        v-model="overrideSelfRef"
+        :label="t('admin-rule-editor-override-self-ref')"
+      />
+    </section>
+  </div>
+</template>

--- a/frontend/src/views/SettingsRulesView.vue
+++ b/frontend/src/views/SettingsRulesView.vue
@@ -1,0 +1,275 @@
+<script setup lang="ts">
+/**
+ * Admin list view for the unified rules engine (Phase 1 surface).
+ * Lists every rule in the workspace, filtered by trigger kind /
+ * state, with edit + archive + state-toggle affordances. Reads use
+ * Pinia Colada so navigating away and back renders instantly from
+ * cache and revalidates in the background.
+ *
+ * Cross-link to the activity tab via the `/admin/rules/activity`
+ * route; the editor lives at `/admin/rules/:id` (Wave 7).
+ */
+import { computed, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { useFluent } from 'fluent-vue';
+import { useQuery, useQueryCache } from '@pinia/colada';
+import { formatDistanceToNow } from 'date-fns';
+
+import AlertMessage from '@/components/common/AlertMessage.vue';
+import Button from '@/components/common/Button.vue';
+import ConfirmModal from '@/components/common/ConfirmModal.vue';
+import EmptyState from '@/components/common/EmptyState.vue';
+import Icon from '@/components/common/Icon.vue';
+import SearchInput from '@/components/common/SearchInput.vue';
+import Skeleton from '@/components/common/Skeleton.vue';
+import SkeletonBar from '@/components/common/SkeletonBar.vue';
+import rulesService from '@/services/rulesService';
+import { useToastStore } from '@/stores/toast';
+import { extractErrorMessage } from '@/utils/errors';
+import type { Rule, RuleState, RuleTriggerKind } from '@/types/rule';
+
+const fluent = useFluent();
+const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
+const router = useRouter();
+const toast = useToastStore();
+
+/** Pinia Colada key shared by the editor (Wave 7) so saves
+ *  invalidate the list automatically. */
+const RULES_KEY = ['rules'] as const;
+const queryCache = useQueryCache();
+const rulesQuery = useQuery({
+  key: RULES_KEY,
+  query: () => rulesService.list({ include_archived: false }),
+});
+
+const rules = computed<Rule[]>(() =>
+  Array.isArray(rulesQuery.data.value) ? rulesQuery.data.value : [],
+);
+const isFirstLoad = computed(
+  () => rulesQuery.status.value === 'pending' && rulesQuery.data.value === undefined,
+);
+const loadError = computed(() =>
+  rulesQuery.error.value ? t('admin-rules-error-load') : '',
+);
+
+const search = ref('');
+const triggerFilter = ref<RuleTriggerKind | 'all'>('all');
+const stateFilter = ref<RuleState | 'all'>('all');
+
+const filtered = computed<Rule[]>(() => {
+  const term = search.value.trim().toLowerCase();
+  return rules.value.filter((r) => {
+    if (triggerFilter.value !== 'all' && r.trigger_kind !== triggerFilter.value) {
+      return false;
+    }
+    if (stateFilter.value !== 'all' && r.state !== stateFilter.value) {
+      return false;
+    }
+    if (term && !r.name.toLowerCase().includes(term)) {
+      return false;
+    }
+    return true;
+  });
+});
+
+function formatLastFired(value: string | null): string {
+  if (!value) return t('admin-rules-last-fired-never');
+  try {
+    return formatDistanceToNow(new Date(value), { addSuffix: true });
+  } catch {
+    return value;
+  }
+}
+
+function triggerLabel(kind: RuleTriggerKind): string {
+  return t(`admin-rules-trigger-${kind.replace(/_/g, '-')}`);
+}
+
+function stateLabel(state: RuleState): string {
+  return t(`admin-rules-state-${state.replace(/_/g, '-')}`);
+}
+
+const errorMessage = ref('');
+const archiveTarget = ref<Rule | null>(null);
+
+async function openEdit(rule: Rule): Promise<void> {
+  await router.push({ name: 'admin-rules-edit', params: { id: rule.id } });
+}
+
+function openCreate(): void {
+  router.push({ name: 'admin-rules-new' });
+}
+
+function openActivity(): void {
+  router.push({ name: 'admin-rules-activity' });
+}
+
+async function archive(rule: Rule): Promise<void> {
+  errorMessage.value = '';
+  try {
+    await rulesService.archive(rule.id);
+    await queryCache.invalidateQueries({ key: RULES_KEY });
+    toast.success(t('admin-rules-toast-archived', { name: rule.name }));
+  } catch (err) {
+    errorMessage.value = extractErrorMessage(err, t('admin-rules-error-archive'));
+  }
+  archiveTarget.value = null;
+}
+
+async function toggleLive(rule: Rule): Promise<void> {
+  errorMessage.value = '';
+  const target: RuleState = rule.state === 'live' ? 'dry_run' : 'live';
+  try {
+    await rulesService.transitionState(rule.id, { state: target });
+    await queryCache.invalidateQueries({ key: RULES_KEY });
+    toast.success(t('admin-rules-toast-state-changed', { state: stateLabel(target) }));
+  } catch (err) {
+    errorMessage.value = extractErrorMessage(err, t('admin-rules-error-transition'));
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div class="flex flex-wrap items-center gap-3">
+      <h1 class="text-2xl font-semibold flex-1 min-w-0">
+        {{ t('admin-rules-title') }}
+      </h1>
+      <Button variant="secondary" @click="openActivity">
+        <Icon name="history" class="w-4 h-4" />
+        <span>{{ t('admin-rules-activity-cta') }}</span>
+      </Button>
+      <Button variant="primary" @click="openCreate">
+        <Icon name="add" class="w-4 h-4" />
+        <span>{{ t('admin-rules-new-cta') }}</span>
+      </Button>
+    </div>
+
+    <p class="text-sm text-secondary max-w-2xl">
+      {{ t('admin-rules-help-intro') }}
+    </p>
+
+    <AlertMessage v-if="loadError" type="error" :message="loadError" />
+    <AlertMessage v-if="errorMessage" type="error" :message="errorMessage" />
+
+    <div class="flex flex-wrap items-center gap-3">
+      <SearchInput
+        v-model="search"
+        :placeholder="t('admin-rules-search-placeholder')"
+        class="flex-1 min-w-[12rem]"
+      />
+      <select
+        v-model="triggerFilter"
+        class="border rounded-md px-3 py-2 text-sm bg-surface"
+      >
+        <option value="all">{{ t('admin-rules-filter-trigger-all') }}</option>
+        <option value="manual">{{ triggerLabel('manual') }}</option>
+        <option value="ticket_created">{{ triggerLabel('ticket_created') }}</option>
+        <option value="ticket_updated">{{ triggerLabel('ticket_updated') }}</option>
+        <option value="ticket_replied">{{ triggerLabel('ticket_replied') }}</option>
+        <option value="time_elapsed">{{ triggerLabel('time_elapsed') }}</option>
+      </select>
+      <select
+        v-model="stateFilter"
+        class="border rounded-md px-3 py-2 text-sm bg-surface"
+      >
+        <option value="all">{{ t('admin-rules-filter-state-all') }}</option>
+        <option value="draft">{{ stateLabel('draft') }}</option>
+        <option value="dry_run">{{ stateLabel('dry_run') }}</option>
+        <option value="live">{{ stateLabel('live') }}</option>
+      </select>
+    </div>
+
+    <Skeleton v-if="isFirstLoad" class="space-y-2">
+      <SkeletonBar v-for="i in 6" :key="i" class="h-10 w-full" />
+    </Skeleton>
+
+    <EmptyState
+      v-else-if="filtered.length === 0"
+      :title="t('admin-rules-empty-title')"
+      :hint="t('admin-rules-empty-hint')"
+    >
+      <Button variant="primary" @click="openCreate">
+        {{ t('admin-rules-new-cta') }}
+      </Button>
+    </EmptyState>
+
+    <table v-else class="w-full text-sm">
+      <thead>
+        <tr class="border-b text-left text-secondary">
+          <th class="py-2 font-medium">{{ t('admin-rules-col-name') }}</th>
+          <th class="py-2 font-medium">{{ t('admin-rules-col-trigger') }}</th>
+          <th class="py-2 font-medium">{{ t('admin-rules-col-state') }}</th>
+          <th class="py-2 font-medium">{{ t('admin-rules-col-last-fired') }}</th>
+          <th class="py-2 font-medium text-right">{{ t('admin-rules-col-fire-count') }}</th>
+          <th class="py-2 font-medium"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="rule in filtered"
+          :key="rule.id"
+          class="border-b hover:bg-surface-hover cursor-pointer"
+          @click="openEdit(rule)"
+        >
+          <td class="py-2">
+            <div class="font-medium">{{ rule.name }}</div>
+            <div v-if="rule.description" class="text-xs text-secondary truncate max-w-md">
+              {{ rule.description }}
+            </div>
+          </td>
+          <td class="py-2 text-secondary">{{ triggerLabel(rule.trigger_kind) }}</td>
+          <td class="py-2">
+            <span
+              :class="[
+                'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+                rule.state === 'live' ? 'bg-success/10 text-success' : '',
+                rule.state === 'dry_run' ? 'bg-warning/10 text-warning' : '',
+                rule.state === 'draft' ? 'bg-info/10 text-info' : '',
+              ]"
+            >
+              {{ stateLabel(rule.state) }}
+            </span>
+          </td>
+          <td class="py-2 text-secondary">{{ formatLastFired(rule.last_fired_at) }}</td>
+          <td class="py-2 text-right tabular-nums">{{ rule.fire_count }}</td>
+          <td class="py-2 text-right" @click.stop>
+            <div class="flex items-center justify-end gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                @click="toggleLive(rule)"
+                :title="rule.state === 'live'
+                  ? t('admin-rules-action-pause-tooltip')
+                  : t('admin-rules-action-resume-tooltip')"
+              >
+                <Icon
+                  :name="rule.state === 'live' ? 'eyeOff' : 'eye'"
+                  class="w-3.5 h-3.5"
+                />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                @click="archiveTarget = rule"
+                :title="t('admin-rules-action-archive-tooltip')"
+              >
+                <Icon name="trash" class="w-3.5 h-3.5" />
+              </Button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <ConfirmModal
+      :show="archiveTarget !== null"
+      :title="t('admin-rules-archive-confirm-title')"
+      :message="archiveTarget ? t('admin-rules-archive-confirm-body', { name: archiveTarget.name }) : ''"
+      :confirm-label="t('admin-rules-archive-confirm-button')"
+      variant="warning"
+      @confirm="archiveTarget && archive(archiveTarget)"
+      @cancel="archiveTarget = null"
+    />
+  </div>
+</template>

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -5271,3 +5271,70 @@ gantt-tickets-of-total-in-view =
     }
 saved-view-name-this = Name this view
 saved-view-copy-suffix = { $name } copy
+
+# Rules engine (docs/rules-and-actions-plan.md). Admin Settings →
+# Rules surfaces every rule kind; the agent toolbar surfaces only
+# the manual subset under the label "Actions". Activity log /
+# inspector wording stays consistent with the audit framing
+# established by canned-responses and ticket-merge.
+
+route-title-admin-rules = Rules
+route-title-admin-rules-activity = Rule activity
+route-title-admin-rules-new = New rule
+route-title-admin-rules-edit = Edit rule
+
+admin-rules-title = Rules
+admin-rules-help-intro = One rule entity covers manual quick-actions, on-event automations, and time-based escalations. Manual rules show up in the agent toolbar; everything else fires from the engine.
+admin-rules-new-cta = New rule
+admin-rules-activity-cta = Recent activity
+admin-rules-search-placeholder = Search rules by name
+admin-rules-filter-trigger-all = All triggers
+admin-rules-filter-state-all = All states
+admin-rules-trigger-manual = Manual
+admin-rules-trigger-ticket-created = On ticket created
+admin-rules-trigger-ticket-updated = On ticket updated
+admin-rules-trigger-ticket-replied = On reply
+admin-rules-trigger-time-elapsed = Time elapsed
+admin-rules-state-draft = Draft
+admin-rules-state-dry-run = Dry run
+admin-rules-state-live = Live
+admin-rules-state-archived = Archived
+admin-rules-col-name = Name
+admin-rules-col-trigger = Trigger
+admin-rules-col-state = State
+admin-rules-col-last-fired = Last fired
+admin-rules-col-fire-count = Fires (total)
+admin-rules-last-fired-never = Never
+admin-rules-empty-title = No rules yet
+admin-rules-empty-hint = Create your first rule or browse the starter catalog (coming soon).
+admin-rules-error-load = Couldn't load the rules list.
+admin-rules-error-archive = Couldn't archive that rule.
+admin-rules-error-transition = Couldn't change the state.
+admin-rules-toast-archived = Archived { $name }.
+admin-rules-toast-state-changed = State changed to { $state }.
+admin-rules-action-pause-tooltip = Pause (move to dry run)
+admin-rules-action-resume-tooltip = Resume (back to live)
+admin-rules-action-archive-tooltip = Archive
+admin-rules-archive-confirm-title = Archive rule?
+admin-rules-archive-confirm-body = { $name } will stop firing and be hidden from the picker. The audit history stays. You can permanently delete it later from the archived view.
+admin-rules-archive-confirm-button = Archive
+
+admin-rules-activity-title = Rule activity
+admin-rules-activity-help = Every fire writes one row, whether successful, skipped, suppressed, or failed. Click a row to see the condition evaluation and the actions that ran.
+admin-rules-activity-back = Back to rules
+admin-rules-activity-error-load = Couldn't load the activity log.
+admin-rules-activity-empty-title = No activity yet
+admin-rules-activity-empty-hint = Rules write here as soon as they fire.
+admin-rules-activity-filter-all = All statuses
+admin-rules-activity-limit = Last { $n }
+admin-rules-activity-actor-system = engine
+admin-rules-activity-actor-user = agent
+admin-rules-activity-row-summary = on ticket #{ $ticket_id } by { $actor }
+admin-rules-activity-inspector-empty = No inspector payload (successful fire keeps the audit row tight).
+admin-rules-activity-status-succeeded = Succeeded
+admin-rules-activity-status-dry-run = Dry run
+admin-rules-activity-status-skipped-preflight = Skipped (preflight)
+admin-rules-activity-status-skipped-condition-unmet = Skipped (no match)
+admin-rules-activity-status-suppressed-recursion-budget = Suppressed (recursion)
+admin-rules-activity-status-suppressed-loop-guard = Suppressed (loop guard)
+admin-rules-activity-status-failed = Failed

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -5338,3 +5338,65 @@ admin-rules-activity-status-skipped-condition-unmet = Skipped (no match)
 admin-rules-activity-status-suppressed-recursion-budget = Suppressed (recursion)
 admin-rules-activity-status-suppressed-loop-guard = Suppressed (loop guard)
 admin-rules-activity-status-failed = Failed
+
+# Activity-feed phrases for the rule fire event. Wave 7 wires
+# ticket.rule_applied into TicketActivity.vue; the dry-run variant
+# distinguishes shadow fires (state = dry_run) from live ones.
+ticket-activity-phrase-rule-applied = applied rule "{ $rule }"
+ticket-activity-phrase-rule-applied-dry-run = previewed rule "{ $rule }" in dry-run
+
+# Actions toolbar (agent surface, decision 26: button label is
+# "Actions" even though the backend entity is Rule).
+ticket-actions-button = Actions
+ticket-actions-dialog-title = Apply an action
+ticket-actions-dialog-picker-placeholder = Find an action...
+ticket-actions-dialog-empty = No live manual rules in this workspace.
+ticket-actions-dialog-action-list-label = This action will:
+ticket-actions-dialog-cancel = Cancel
+ticket-actions-dialog-apply = Apply
+ticket-actions-dialog-applying = Applying...
+ticket-actions-success-toast = Applied "{ $rule }".
+ticket-actions-error-toast = Couldn't apply the action.
+
+# Action summary chips (admin list + agent dialog preview).
+admin-rules-action-chip-reply-public = Reply to customer
+admin-rules-action-chip-reply-internal = Add internal note
+admin-rules-action-chip-set-status = Move to state #{ $state_id }
+admin-rules-action-chip-assign = Assign to user
+admin-rules-action-chip-unassign = Clear assignee
+admin-rules-action-chip-add-tags = Add { $count ->
+    [one] 1 tag
+   *[other] { $count } tags
+  }
+admin-rules-action-chip-remove-tags = Remove { $count ->
+    [one] 1 tag
+   *[other] { $count } tags
+  }
+admin-rules-action-chip-set-priority = Set priority to { $priority }
+admin-rules-action-chip-notify = Send notification
+admin-rules-action-chip-stop-processing = Stop here
+
+# Rule editor (Wave 7).
+admin-rule-editor-title-new = New rule
+admin-rule-editor-title-edit = Edit "{ $name }"
+admin-rule-editor-back = Back to rules
+admin-rule-editor-save = Save
+admin-rule-editor-saving = Saving...
+admin-rule-editor-section-name = What
+admin-rule-editor-section-trigger = When
+admin-rule-editor-section-actions = Then do
+admin-rule-editor-section-state = State
+admin-rule-editor-name-label = Name
+admin-rule-editor-name-placeholder = Acknowledge and escalate to network team
+admin-rule-editor-description-label = Description (optional)
+admin-rule-editor-description-placeholder = Short note about when an agent should reach for this.
+admin-rule-editor-trigger-label = Trigger
+admin-rule-editor-trigger-manual-note = Manual rules show up in the agent Actions toolbar. There's no per-ticket condition; the picker is filtered by category.
+admin-rule-editor-trigger-other-phase = Event triggers and time-elapsed triggers land in Phase 2 of the rules engine; for now they save as Draft but won't fire until the engine subscribes.
+admin-rule-editor-actions-add = Add an action
+admin-rule-editor-actions-empty = This rule needs at least one action.
+admin-rule-editor-action-remove = Remove
+admin-rule-editor-error-save = Couldn't save the rule.
+admin-rule-editor-error-conflict = This rule reads and writes the same fields. Save anyway to override.
+admin-rule-editor-override-self-ref = I understand this rule may loop
+admin-rule-editor-priority-label = Priority (lower runs first)

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -5119,3 +5119,121 @@ ticket-activity-phrase-merged = a fusionné { $count ->
    *[other] { $count } tickets
   } dans celui-ci
 ticket-activity-phrase-merged-into = a fusionné ce ticket dans le #{ $target_id }
+
+# Moteur de règles (docs/rules-and-actions-plan.md).
+
+route-title-admin-rules = Règles
+route-title-admin-rules-activity = Activité des règles
+route-title-admin-rules-new = Nouvelle règle
+route-title-admin-rules-edit = Modifier la règle
+
+admin-rules-title = Règles
+admin-rules-help-intro = Une seule entité couvre les actions manuelles, les automatisations événementielles et les escalades temporisées. Les règles manuelles apparaissent dans la barre d'outils des agents ; les autres sont déclenchées par le moteur.
+admin-rules-new-cta = Nouvelle règle
+admin-rules-activity-cta = Activité récente
+admin-rules-search-placeholder = Rechercher une règle par nom
+admin-rules-filter-trigger-all = Tous les déclencheurs
+admin-rules-filter-state-all = Tous les états
+admin-rules-trigger-manual = Manuelle
+admin-rules-trigger-ticket-created = À la création d'un ticket
+admin-rules-trigger-ticket-updated = À la mise à jour d'un ticket
+admin-rules-trigger-ticket-replied = À la réponse
+admin-rules-trigger-time-elapsed = Temps écoulé
+admin-rules-state-draft = Brouillon
+admin-rules-state-dry-run = Test à vide
+admin-rules-state-live = Active
+admin-rules-state-archived = Archivée
+admin-rules-col-name = Nom
+admin-rules-col-trigger = Déclencheur
+admin-rules-col-state = État
+admin-rules-col-last-fired = Dernier déclenchement
+admin-rules-col-fire-count = Déclenchements (total)
+admin-rules-last-fired-never = Jamais
+admin-rules-empty-title = Aucune règle pour le moment
+admin-rules-empty-hint = Créez votre première règle ou parcourez le catalogue (bientôt disponible).
+admin-rules-error-load = Impossible de charger la liste des règles.
+admin-rules-error-archive = Impossible d'archiver cette règle.
+admin-rules-error-transition = Impossible de changer l'état.
+admin-rules-toast-archived = { $name } archivée.
+admin-rules-toast-state-changed = État modifié : { $state }.
+admin-rules-action-pause-tooltip = Mettre en pause (test à vide)
+admin-rules-action-resume-tooltip = Réactiver
+admin-rules-action-archive-tooltip = Archiver
+admin-rules-archive-confirm-title = Archiver la règle ?
+admin-rules-archive-confirm-body = { $name } cessera de se déclencher et n'apparaîtra plus dans le sélecteur. L'historique d'audit est conservé. Vous pourrez la supprimer définitivement plus tard depuis la vue archivée.
+admin-rules-archive-confirm-button = Archiver
+
+admin-rules-activity-title = Activité des règles
+admin-rules-activity-help = Chaque déclenchement écrit une ligne, qu'il soit réussi, ignoré, supprimé ou échoué. Cliquez sur une ligne pour voir l'évaluation des conditions et les actions exécutées.
+admin-rules-activity-back = Retour aux règles
+admin-rules-activity-error-load = Impossible de charger le journal d'activité.
+admin-rules-activity-empty-title = Aucune activité pour le moment
+admin-rules-activity-empty-hint = Les règles écrivent ici dès qu'elles se déclenchent.
+admin-rules-activity-filter-all = Tous les statuts
+admin-rules-activity-limit = Dernier { $n }
+admin-rules-activity-actor-system = moteur
+admin-rules-activity-actor-user = agent
+admin-rules-activity-row-summary = sur le ticket #{ $ticket_id } par { $actor }
+admin-rules-activity-inspector-empty = Aucun détail d'inspecteur (le déclenchement réussi reste compact).
+admin-rules-activity-status-succeeded = Réussi
+admin-rules-activity-status-dry-run = Test à vide
+admin-rules-activity-status-skipped-preflight = Ignoré (préchecks)
+admin-rules-activity-status-skipped-condition-unmet = Ignoré (pas de correspondance)
+admin-rules-activity-status-suppressed-recursion-budget = Supprimé (récursion)
+admin-rules-activity-status-suppressed-loop-guard = Supprimé (anti-boucle)
+admin-rules-activity-status-failed = Échec
+
+ticket-activity-phrase-rule-applied = a appliqué la règle « { $rule } »
+ticket-activity-phrase-rule-applied-dry-run = a prévisualisé la règle « { $rule } » en test à vide
+
+ticket-actions-button = Actions
+ticket-actions-dialog-title = Appliquer une action
+ticket-actions-dialog-picker-placeholder = Rechercher une action...
+ticket-actions-dialog-empty = Aucune règle manuelle active dans cet espace de travail.
+ticket-actions-dialog-action-list-label = Cette action va :
+ticket-actions-dialog-cancel = Annuler
+ticket-actions-dialog-apply = Appliquer
+ticket-actions-dialog-applying = Application en cours...
+ticket-actions-success-toast = « { $rule } » appliquée.
+ticket-actions-error-toast = Impossible d'appliquer cette action.
+
+admin-rules-action-chip-reply-public = Répondre au client
+admin-rules-action-chip-reply-internal = Ajouter une note interne
+admin-rules-action-chip-set-status = Passer à l'état #{ $state_id }
+admin-rules-action-chip-assign = Assigner à un utilisateur
+admin-rules-action-chip-unassign = Retirer l'assignation
+admin-rules-action-chip-add-tags = Ajouter { $count ->
+    [one] 1 étiquette
+   *[other] { $count } étiquettes
+  }
+admin-rules-action-chip-remove-tags = Retirer { $count ->
+    [one] 1 étiquette
+   *[other] { $count } étiquettes
+  }
+admin-rules-action-chip-set-priority = Définir la priorité sur { $priority }
+admin-rules-action-chip-notify = Envoyer une notification
+admin-rules-action-chip-stop-processing = Arrêter ici
+
+admin-rule-editor-title-new = Nouvelle règle
+admin-rule-editor-title-edit = Modifier « { $name } »
+admin-rule-editor-back = Retour aux règles
+admin-rule-editor-save = Enregistrer
+admin-rule-editor-saving = Enregistrement...
+admin-rule-editor-section-name = Quoi
+admin-rule-editor-section-trigger = Quand
+admin-rule-editor-section-actions = Alors
+admin-rule-editor-section-state = État
+admin-rule-editor-name-label = Nom
+admin-rule-editor-name-placeholder = Accuser réception et escalader à l'équipe réseau
+admin-rule-editor-description-label = Description (optionnelle)
+admin-rule-editor-description-placeholder = Note rapide pour expliquer quand un agent devrait utiliser cette règle.
+admin-rule-editor-trigger-label = Déclencheur
+admin-rule-editor-trigger-manual-note = Les règles manuelles apparaissent dans la barre d'outils Actions des agents. Pas de condition par ticket ; le sélecteur filtre par catégorie.
+admin-rule-editor-trigger-other-phase = Les déclencheurs événementiels et temporisés arriveront en phase 2 du moteur de règles ; ils peuvent être enregistrés en brouillon mais ne se déclencheront qu'une fois le moteur abonné.
+admin-rule-editor-actions-add = Ajouter une action
+admin-rule-editor-actions-empty = Cette règle a besoin d'au moins une action.
+admin-rule-editor-action-remove = Retirer
+admin-rule-editor-error-save = Impossible d'enregistrer la règle.
+admin-rule-editor-error-conflict = Cette règle lit et écrit dans les mêmes champs. Enregistrez quand même pour outrepasser.
+admin-rule-editor-override-self-ref = Je sais que cette règle peut boucler
+admin-rule-editor-priority-label = Priorité (la plus basse en premier)

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -5110,3 +5110,121 @@ ticket-activity-phrase-merged = heeft { $count ->
    *[other] { $count } tickets
   } samengevoegd in dit ticket
 ticket-activity-phrase-merged-into = heeft dit ticket samengevoegd in #{ $target_id }
+
+# Regels-engine (docs/rules-and-actions-plan.md).
+
+route-title-admin-rules = Regels
+route-title-admin-rules-activity = Regelactiviteit
+route-title-admin-rules-new = Nieuwe regel
+route-title-admin-rules-edit = Regel bewerken
+
+admin-rules-title = Regels
+admin-rules-help-intro = Eén entiteit dekt handmatige snelacties, automatiseringen op events en escalaties op tijd. Handmatige regels verschijnen in de werkbalk van de agent; de rest wordt door de engine geactiveerd.
+admin-rules-new-cta = Nieuwe regel
+admin-rules-activity-cta = Recente activiteit
+admin-rules-search-placeholder = Zoek regels op naam
+admin-rules-filter-trigger-all = Alle triggers
+admin-rules-filter-state-all = Alle statussen
+admin-rules-trigger-manual = Handmatig
+admin-rules-trigger-ticket-created = Bij aanmaken ticket
+admin-rules-trigger-ticket-updated = Bij wijzigen ticket
+admin-rules-trigger-ticket-replied = Bij antwoord
+admin-rules-trigger-time-elapsed = Tijd verstreken
+admin-rules-state-draft = Concept
+admin-rules-state-dry-run = Testrun
+admin-rules-state-live = Actief
+admin-rules-state-archived = Gearchiveerd
+admin-rules-col-name = Naam
+admin-rules-col-trigger = Trigger
+admin-rules-col-state = Status
+admin-rules-col-last-fired = Laatst geactiveerd
+admin-rules-col-fire-count = Activeringen (totaal)
+admin-rules-last-fired-never = Nooit
+admin-rules-empty-title = Nog geen regels
+admin-rules-empty-hint = Maak je eerste regel of blader door de starterscatalogus (binnenkort).
+admin-rules-error-load = Kan de regelslijst niet laden.
+admin-rules-error-archive = Kan deze regel niet archiveren.
+admin-rules-error-transition = Kan de status niet wijzigen.
+admin-rules-toast-archived = { $name } gearchiveerd.
+admin-rules-toast-state-changed = Status gewijzigd naar { $state }.
+admin-rules-action-pause-tooltip = Pauzeren (naar testrun)
+admin-rules-action-resume-tooltip = Hervatten
+admin-rules-action-archive-tooltip = Archiveren
+admin-rules-archive-confirm-title = Regel archiveren?
+admin-rules-archive-confirm-body = { $name } stopt met activeren en wordt verborgen uit de keuzelijst. De auditgeschiedenis blijft bestaan. Je kunt hem later permanent verwijderen via de gearchiveerde weergave.
+admin-rules-archive-confirm-button = Archiveren
+
+admin-rules-activity-title = Regelactiviteit
+admin-rules-activity-help = Elke activering schrijft één regel, ongeacht of die succesvol, overgeslagen, onderdrukt of mislukt is. Klik op een regel om de voorwaardenevaluatie en de uitgevoerde acties te zien.
+admin-rules-activity-back = Terug naar regels
+admin-rules-activity-error-load = Kan het activiteitenlogboek niet laden.
+admin-rules-activity-empty-title = Nog geen activiteit
+admin-rules-activity-empty-hint = Regels schrijven hier zodra ze worden geactiveerd.
+admin-rules-activity-filter-all = Alle statussen
+admin-rules-activity-limit = Laatste { $n }
+admin-rules-activity-actor-system = engine
+admin-rules-activity-actor-user = agent
+admin-rules-activity-row-summary = op ticket #{ $ticket_id } door { $actor }
+admin-rules-activity-inspector-empty = Geen inspectorgegevens (geslaagde activering blijft compact).
+admin-rules-activity-status-succeeded = Geslaagd
+admin-rules-activity-status-dry-run = Testrun
+admin-rules-activity-status-skipped-preflight = Overgeslagen (preflight)
+admin-rules-activity-status-skipped-condition-unmet = Overgeslagen (geen match)
+admin-rules-activity-status-suppressed-recursion-budget = Onderdrukt (recursie)
+admin-rules-activity-status-suppressed-loop-guard = Onderdrukt (lus-guard)
+admin-rules-activity-status-failed = Mislukt
+
+ticket-activity-phrase-rule-applied = heeft regel "{ $rule }" toegepast
+ticket-activity-phrase-rule-applied-dry-run = heeft regel "{ $rule }" als testrun bekeken
+
+ticket-actions-button = Acties
+ticket-actions-dialog-title = Een actie toepassen
+ticket-actions-dialog-picker-placeholder = Zoek een actie...
+ticket-actions-dialog-empty = Geen actieve handmatige regels in deze werkruimte.
+ticket-actions-dialog-action-list-label = Deze actie gaat:
+ticket-actions-dialog-cancel = Annuleren
+ticket-actions-dialog-apply = Toepassen
+ticket-actions-dialog-applying = Bezig met toepassen...
+ticket-actions-success-toast = "{ $rule }" toegepast.
+ticket-actions-error-toast = Kon de actie niet toepassen.
+
+admin-rules-action-chip-reply-public = Antwoord aan klant
+admin-rules-action-chip-reply-internal = Interne notitie toevoegen
+admin-rules-action-chip-set-status = Verplaats naar status #{ $state_id }
+admin-rules-action-chip-assign = Toewijzen aan gebruiker
+admin-rules-action-chip-unassign = Toewijzing wissen
+admin-rules-action-chip-add-tags = Voeg { $count ->
+    [one] 1 tag
+   *[other] { $count } tags
+  } toe
+admin-rules-action-chip-remove-tags = Verwijder { $count ->
+    [one] 1 tag
+   *[other] { $count } tags
+  }
+admin-rules-action-chip-set-priority = Stel prioriteit in op { $priority }
+admin-rules-action-chip-notify = Verstuur melding
+admin-rules-action-chip-stop-processing = Hier stoppen
+
+admin-rule-editor-title-new = Nieuwe regel
+admin-rule-editor-title-edit = "{ $name }" bewerken
+admin-rule-editor-back = Terug naar regels
+admin-rule-editor-save = Opslaan
+admin-rule-editor-saving = Bezig met opslaan...
+admin-rule-editor-section-name = Wat
+admin-rule-editor-section-trigger = Wanneer
+admin-rule-editor-section-actions = Dan doe je
+admin-rule-editor-section-state = Status
+admin-rule-editor-name-label = Naam
+admin-rule-editor-name-placeholder = Bevestigen en escaleren naar het netwerkteam
+admin-rule-editor-description-label = Beschrijving (optioneel)
+admin-rule-editor-description-placeholder = Korte notitie waarvoor een agent deze zou gebruiken.
+admin-rule-editor-trigger-label = Trigger
+admin-rule-editor-trigger-manual-note = Handmatige regels verschijnen in de Actie-werkbalk van de agent. Er is geen voorwaarde per ticket; de selectielijst filtert op categorie.
+admin-rule-editor-trigger-other-phase = Event-getriggerde en tijd-getriggerde regels komen in fase 2 van de regelsengine; ze worden nu opgeslagen als Concept maar activeren pas wanneer de engine zich abonneert.
+admin-rule-editor-actions-add = Een actie toevoegen
+admin-rule-editor-actions-empty = Deze regel heeft minstens één actie nodig.
+admin-rule-editor-action-remove = Verwijderen
+admin-rule-editor-error-save = Kan de regel niet opslaan.
+admin-rule-editor-error-conflict = Deze regel leest en schrijft naar dezelfde velden. Sla toch op om te negeren.
+admin-rule-editor-override-self-ref = Ik begrijp dat deze regel in een lus kan terechtkomen
+admin-rule-editor-priority-label = Prioriteit (lagere waarden eerst)


### PR DESCRIPTION
## Summary

Phase 1 of the unified rules engine per `docs/rules-and-actions-plan.md`. Ships the manual-trigger surface end-to-end across 8 waves plus a structural-fix pass against a 10-finding code review.

**~5,800 LOC across 26 files.**

### Backend
- Migration `2026-06-07-000000_rules_engine_schema/` adds four tables (`rules`, `rule_versions`, `rule_applications`, `ticket_rule_runs`) and three enums (`rule_state`, `rule_trigger_kind`, `rule_application_status`), with RLS policies + ownership transfer to `nosdesk_admin` at creation time so the workspace-id-missing-from-schema class of bug that bit `assignment_rules` cannot be inherited.
- Version-snapshot triggers fire on real content changes only (the `WHEN` clause compares snapshot-relevant columns, so `fire_count` / `last_fired_at` bumps don't flood `rule_versions`). `saved_by` reads from `app.actor_uuid`, the same GUC the audit_log trigger uses.
- `repository::rules` ships CRUD, `reads_set` / `writes_set` derivation per the plan's §11.2 table, the `apply_manual` atomic lifecycle, the eight Phase-1 action executors (reply / set_status / assign / unassign / add_tags / remove_tags / set_priority / stop_processing) with per-action-index error reporting, and `preview_match` scaffolding.
- `services::template_vars` wraps `utils::template_variables` and HTML-escapes substituted bindings via `html_escape::encode_safe` so a malicious display name can't inject markup into a stored HTML comment. `app_name` is pulled from `site_settings`, not env.
- `services::starter_catalog` compiles `backend/data/starter-rules.json` into the binary with six pre-translated entries; admins browse via `GET /admin/rule-starters` and copy into their workspace as Draft rules.
- `handlers::rules` exposes admin CRUD + state-transition + version history + recent-applications log + agent picker + apply, with the self-referential save linter at create/update time, `WorkspaceRole::Admin` on writes and `WorkspaceRole::Agent` on apply / picker. Route literals registered before wildcards to dodge the actix shadowing footgun (`/admin/rule-starters` lives at a distinct prefix per the canned-response-starters precedent).
- `apply_manual` emits `ticket.rule_applied` sync events with `was_dry_run` plus per-field SSE `TicketUpdated` events whose field names match what `useTicketSSE` already handles. Public-visibility replies post-commit-dispatch through `services::channels::outbound::enqueue_for_comment` exactly the same way the regular comment handler does, so the customer email actually gets sent.

### Frontend
- `types/rule.ts` with full wire shapes and a `rulesService.ts` API client.
- `SettingsRulesView.vue`: admin list with name search + trigger / state filter chips, Pinia Colada caching, per-row pause / archive affordances.
- `RuleEditView.vue`: form-based editor with per-action-kind config panels for the eight supported action kinds.
- `RuleActivityView.vue`: workspace-wide audit log with status filter and click-to-expand JSON inspector for the non-succeeded rows that carry condition / actions snapshots.
- `ActionsDialog.vue`: the agent-facing toolbar picker with action-summary chips and an optional reply-body override.
- `TicketActivity.vue` extended with the `ticket.rule_applied` phrase case (live + dry-run variants).
- Frontend `renderTemplate` regex widened to match the backend's whitespace-tolerant pattern so previews don't disagree with what gets applied.

### i18n
- en-US ~70 new keys; fr-FR + nl-NL fully translated. Native review still pending per the standard workflow.

### Deferred to later phases (per the plan)
- Phase 2: event triggers, condition tree evaluator, `assignment_rules` hard cutover, dry-run state machine, conflicts inspector.
- Phase 3: time-elapsed triggers with `ticket_elapsed_queue` + `service_health_events` pause windows.
- Phase 4: webhook action (registered targets, SSRF resolver, security review).
- Phase 5: bulk apply, personal / agent-authored rules.

### Verification at branch tip
- `cargo check --lib` clean (only two pre-existing unrelated warnings).
- `diesel migration redo` cycles cleanly.
- 5 `template_vars` unit tests pass (including new HTML-escape test).
- 13 `repository::rules` derivation tests pass.
- `vue-tsc --build` clean.
- End-to-end psql proof on the version-trigger fix: `1 → 1 → 2` (no spurious version row on fire_count bumps; snapshot fires on real edits).
- 10-finding code review run on the branch with each finding fixed structurally (channel relay wired post-commit, version-trigger WHEN refined, HTML-escape boundary, distinct route path, GUC-driven saved_by, threaded action_index, site_settings lookup, frontend-recognized SSE field names, AgentRevoked error variant, regex alignment).