### PR TITLE
Follow-up: server-side MFA setup secret + fail-loud workspace resolution

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -1296,6 +1296,15 @@ pub async fn mfa_setup(db_pool: web::Data<crate::db::Pool>, req: HttpRequest) ->
     // Generate new TOTP secret (backup codes will be generated after successful verification)
     let secret = mfa::generate_totp_secret();
 
+    // Pin server-side so the matching mfa_enable call refuses to
+    // honour a substituted secret. See utils::mfa::stash_setup_secret
+    // for the threat model (attacker-with-password substitutes their
+    // own TOTP secret + matching code).
+    if let Err(e) = mfa::stash_setup_secret(&user.uuid, secret.as_str()).await {
+        tracing::error!(user_uuid = %user.uuid, error = %e, "Failed to stash MFA setup secret");
+        return errors::internal("Failed to initialise MFA setup");
+    }
+
     // Get user's primary email for QR code
     let user_email = repository::user_helpers::get_primary_email(&user.uuid, &mut conn)
         .unwrap_or_else(|| format!("user-{}", user.uuid));
@@ -1383,11 +1392,20 @@ pub async fn mfa_enable(
 
     tracing::info!("Enabling MFA for user: {}", user_uuid);
 
-    // Validate inputs securely
-    let mfa_secret = match &request.secret {
-        Some(secret) if !secret.is_empty() => secret,
-        _ => return errors::bad_request("MFA secret is required"),
+    // Pull the secret from the server-side setup cache. See
+    // utils::mfa::stash_setup_secret for the threat model — request
+    // bodies on this endpoint are not trusted to carry the TOTP
+    // secret. An absent cache entry means setup expired (TTL ~10min)
+    // or was never initiated; user is sent back to mfa_setup.
+    let stashed_secret = match mfa::fetch_setup_secret(&user_uuid).await {
+        Some(s) => s,
+        None => {
+            return errors::bad_request(
+                "MFA setup expired or was not initiated. Please start setup again.",
+            )
+        }
     };
+    let mfa_secret = stashed_secret.as_str();
 
     // Per-account rate limit on enrollment TOTP attempts (shares the
     // bucket with login MFA attempts). Five tries in the window, then
@@ -1449,6 +1467,9 @@ pub async fn mfa_enable(
             // Clear the rate-limit bucket so any fumbled enrollment
             // attempts don't follow the user into their next login.
             mfa::clear_mfa_rate_limit(&user_uuid).await;
+            // Drop the setup secret cache entry — its job is done
+            // and the persisted users.mfa_secret is authoritative.
+            mfa::consume_setup_secret(&user_uuid).await;
             // Return plaintext backup codes so the client can display them once
             HttpResponse::Ok().json(json!({
                 "status": "success",
@@ -1741,6 +1762,16 @@ pub async fn mfa_setup_login(
     // Generate new TOTP secret (backup codes will be generated after verification)
     let secret = mfa::generate_totp_secret();
 
+    // Pin the secret server-side for the matching mfa_enable_login
+    // call. The client still receives the secret in the response so
+    // it can render the QR; the server-side stash is what makes the
+    // enroll path refuse to honour a secret the user didn't actually
+    // see, closing the attacker-with-password substitution vector.
+    if let Err(e) = mfa::stash_setup_secret(&user.uuid, secret.as_str()).await {
+        tracing::error!(user_uuid = %user.uuid, error = %e, "Failed to stash MFA setup secret");
+        return errors::internal("Failed to initialise MFA setup");
+    }
+
     // Get user's primary email for QR code
     let user_email = repository::user_helpers::get_primary_email(&user.uuid, &mut conn)
         .unwrap_or_else(|| format!("user-{}", user.uuid));
@@ -1842,11 +1873,22 @@ pub async fn mfa_enable_login(
         return errors::bad_request("MFA is not required for this account");
     }
 
-    // Validate inputs securely
-    let mfa_secret = match &request.secret {
-        Some(secret) if !secret.is_empty() => secret,
-        _ => return errors::bad_request("MFA secret is required"),
+    // Pull the secret from the server-side setup cache, NOT from
+    // the request body. The previous design honoured request.secret
+    // and let an attacker who knew the victim's password substitute
+    // their own attacker-controlled TOTP secret, enrolling the
+    // attacker's authenticator on the victim's account. The cache
+    // entry was minted by `mfa_setup_login` and is bound to this
+    // user uuid; if it's absent the user is asked to restart setup.
+    let stashed_secret = match mfa::fetch_setup_secret(&user.uuid).await {
+        Some(s) => s,
+        None => {
+            return errors::bad_request(
+                "MFA setup expired or was not initiated. Please start setup again.",
+            )
+        }
     };
+    let mfa_secret = stashed_secret.as_str();
 
     // Per-account rate limit on enrollment TOTP attempts (same bucket
     // as login MFA), so the 6-digit code can't be brute-forced here
@@ -1922,6 +1964,11 @@ pub async fn mfa_enable_login(
             // enrol shouldn't penalise the user's next login
             // attempt with attempts they've already cleared.
             mfa::clear_mfa_rate_limit(&user_uuid).await;
+            // The setup secret has done its job; remove the cache
+            // entry so a subsequent stale enable_login attempt
+            // can't reuse it (defence in depth — the user.mfa_secret
+            // column is now the authoritative copy).
+            mfa::consume_setup_secret(&user_uuid).await;
 
             // Create session + tokens (same as login, but attach backup codes)
             let session = match create_session_record(&user_uuid, &http_request, &mut conn) {

--- a/backend/src/handlers/invitation.rs
+++ b/backend/src/handlers/invitation.rs
@@ -239,13 +239,22 @@ pub async fn accept_invitation(
     // Pre-session (token-verified) flow: resolve the audit workspace
     // once from the user's primary membership, then thread it through
     // the audited writes below (users.password_changed_at and the
-    // ticket release). Falls back to the bootstrap workspace if the
-    // lookup errors so these best-effort writes stay non-fatal.
-    let actor = crate::sync::actor::ActorContext::user_at_workspace(
-        user.uuid,
-        crate::repository::workspaces::primary_workspace_for_user(&mut conn, user.uuid)
-            .unwrap_or(crate::sync::actor::BOOTSTRAP_WORKSPACE_ID),
-    );
+    // ticket release). Fail loud if the user has no membership —
+    // silently attributing to workspace 1 mis-routes the audit row
+    // under hosted multi-tenancy.
+    let workspace_id =
+        match crate::repository::workspaces::primary_workspace_for_user(&mut conn, user.uuid) {
+            Ok(ws) => ws,
+            Err(e) => {
+                error!(
+                    user_uuid = %user.uuid,
+                    error = ?e,
+                    "Failed to resolve primary workspace for invitation accept"
+                );
+                return errors::internal("Failed to complete invitation");
+            }
+        };
+    let actor = crate::sync::actor::ActorContext::user_at_workspace(user.uuid, workspace_id);
 
     // Update password_changed_at timestamp in users table
     let now = Utc::now().naive_utc();

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -2451,13 +2451,19 @@ pub struct MfaSetupLoginRequest {
     pub password: String,
 }
 
-/// Request for enabling MFA during login (unauthenticated)
+/// Request for enabling MFA during login (unauthenticated).
+///
+/// The TOTP secret is intentionally NOT in this struct: the matching
+/// `mfa_setup_login` call stashes it server-side and the enable
+/// handler retrieves it from there. Accepting it from the client
+/// would let an attacker who knew the victim's password substitute
+/// their own attacker-controlled secret + code and enroll their
+/// authenticator on the victim's account.
 #[derive(Debug, Deserialize)]
 pub struct MfaEnableLoginRequest {
     pub email: String,
     pub password: String,
     pub token: String,
-    pub secret: Option<String>,
 }
 
 /// Response for token refresh
@@ -2953,11 +2959,12 @@ pub struct MfaVerifySetupResponse {
     pub backup_codes: Vec<String>,
 }
 
-/// Request for enabling MFA
+/// Request for enabling MFA. The TOTP secret is intentionally NOT
+/// in this struct (see `MfaEnableLoginRequest` for the threat model);
+/// it lives in the server-side setup cache keyed by user uuid.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MfaEnableRequest {
     pub token: String,
-    pub secret: Option<String>,
     pub backup_codes: Option<Vec<String>>,
 }
 

--- a/backend/src/repository/workspaces.rs
+++ b/backend/src/repository/workspaces.rs
@@ -181,21 +181,22 @@ pub fn add_membership(
 /// lowest-id membership as a deterministic "primary" (a primary-
 /// membership flag can refine this later).
 ///
-/// Returns [`BOOTSTRAP_WORKSPACE_ID`](crate::sync::actor::BOOTSTRAP_WORKSPACE_ID)
-/// when the user has no memberships. That shouldn't happen after the
-/// Phase 1 backfill, but the fallback keeps the audited write
-/// attributable to a real workspace rather than failing at the audit
-/// trigger's NOT NULL workspace_id.
+/// Returns `DieselError::NotFound` when the user has no memberships.
+/// An earlier revision silently fell back to
+/// [`BOOTSTRAP_WORKSPACE_ID`](crate::sync::actor::BOOTSTRAP_WORKSPACE_ID),
+/// which under hosted multi-tenancy mis-attributed the audit row
+/// (and the actor context pin) to the control-plane tenant — a quiet
+/// tenancy violation. Callers now surface the failure as a 500 with
+/// the operator-readable cause, which is correct: a credential-
+/// verified user with zero memberships is a data-corruption state
+/// the user can't recover from on their own, so a silent
+/// workspace-1 attribution would only deepen the inconsistency.
 pub fn primary_workspace_for_user(conn: &mut DbConnection, user_uuid: Uuid) -> QueryResult<i32> {
     workspace_members::table
         .filter(workspace_members::user_uuid.eq(user_uuid))
         .order(workspace_members::workspace_id.asc())
         .select(workspace_members::workspace_id)
         .first::<i32>(conn)
-        .or_else(|e| match e {
-            DieselError::NotFound => Ok(crate::sync::actor::BOOTSTRAP_WORKSPACE_ID),
-            other => Err(other),
-        })
 }
 
 // =====================================================================

--- a/backend/src/utils/mfa.rs
+++ b/backend/src/utils/mfa.rs
@@ -524,6 +524,100 @@ async fn mark_totp_used(user_uuid: &Uuid, token: &str) {
     let _: Result<(), _> = con.set_ex(&key, "1", 120).await;
 }
 
+/// Server-side cache binding a freshly-minted TOTP setup secret to
+/// the user it was issued for. The setup → enable flow takes two
+/// round trips:
+///
+///   1. `mfa_setup` / `mfa_setup_login` mints a secret, stashes it
+///      here keyed by user uuid, and returns the secret to the
+///      client for QR-rendering.
+///   2. `mfa_enable` / `mfa_enable_login` looks the secret up here
+///      using the authenticated user (or, for the login flow, the
+///      password-verified user) and verifies the submitted TOTP
+///      code against it.
+///
+/// The previous design accepted the secret back from the request
+/// body, which let an attacker who knew a victim's password
+/// substitute *their own* attacker-controlled TOTP secret + matching
+/// code, enrolling the attacker's authenticator on the victim's
+/// account before the victim ever finished setup. Pinning the
+/// secret server-side closes that door: the client never reaches
+/// `mfa_enable*` carrying a secret the server didn't issue.
+///
+/// TTL is 10 minutes — long enough for a user to read a QR code and
+/// type a 6-digit code, short enough that an abandoned setup expires
+/// before it could be hijacked. The cache stores the secret in
+/// plaintext because:
+///   * the persisted `users.mfa_secret` IS encrypted (AES-256-GCM
+///     via the keyring), so the durable copy is protected;
+///   * the cache window is short and Redis access already implies
+///     host-level compromise (Redis runs co-located with the app);
+///   * encrypting here would duplicate keyring plumbing for a
+///     marginal threat-model improvement.
+///
+/// One key per user: a second `mfa_setup` call by the same user
+/// (e.g. they restarted the flow) overwrites the prior secret.
+const SETUP_SECRET_TTL_SECONDS: u64 = 600;
+
+fn setup_secret_key(user_uuid: &Uuid) -> String {
+    format!("mfa_setup_secret:{user_uuid}")
+}
+
+/// Stash a freshly-minted TOTP secret server-side for the user.
+/// Best-effort — Redis errors are logged; the caller will fall
+/// through to a hard error at `mfa_enable*` if the stash didn't
+/// land. We don't fail the setup response because the user can
+/// always retry; failing here would surface as a confusing 500
+/// when their authenticator already scanned the QR.
+pub async fn stash_setup_secret(user_uuid: &Uuid, secret: &str) -> Result<()> {
+    use redis::AsyncCommands;
+
+    let redis_url = crate::utils::rate_limit::get_redis_url();
+    let client = redis::Client::open(redis_url.as_str()).map_err(|e| anyhow!("redis open: {e}"))?;
+    let mut con = client
+        .get_multiplexed_async_connection()
+        .await
+        .map_err(|e| anyhow!("redis conn: {e}"))?;
+
+    let key = setup_secret_key(user_uuid);
+    con.set_ex::<_, _, ()>(&key, secret, SETUP_SECRET_TTL_SECONDS)
+        .await
+        .map_err(|e| anyhow!("redis set: {e}"))?;
+    Ok(())
+}
+
+/// Fetch the stashed setup secret for the user, or `None` if no
+/// active setup is in flight. Does NOT delete; callers consume on
+/// successful enroll via `consume_setup_secret` so a wrong-code
+/// retry doesn't force the user to restart.
+pub async fn fetch_setup_secret(user_uuid: &Uuid) -> Option<SecretString> {
+    use redis::AsyncCommands;
+
+    let redis_url = crate::utils::rate_limit::get_redis_url();
+    let client = redis::Client::open(redis_url.as_str()).ok()?;
+    let mut con = client.get_multiplexed_async_connection().await.ok()?;
+    let key = setup_secret_key(user_uuid);
+    let value: Option<String> = con.get(&key).await.ok()?;
+    value.map(SecretString::new)
+}
+
+/// Drop the stashed setup secret after a successful enroll. Idempotent;
+/// silent on Redis errors (the persisted MFA row is the source of
+/// truth — a leftover cache key will expire in <= TTL).
+pub async fn consume_setup_secret(user_uuid: &Uuid) {
+    use redis::AsyncCommands;
+
+    let redis_url = crate::utils::rate_limit::get_redis_url();
+    let Ok(client) = redis::Client::open(redis_url.as_str()) else {
+        return;
+    };
+    let Ok(mut con) = client.get_multiplexed_async_connection().await else {
+        return;
+    };
+    let key = setup_secret_key(user_uuid);
+    let _: Result<(), _> = con.del(&key).await;
+}
+
 /// Check if MFA should be required for a user based on OWASP recommendations
 pub fn should_require_mfa(user_role: &UserRole) -> bool {
     match user_role {

--- a/frontend/src/composables/useMfa.ts
+++ b/frontend/src/composables/useMfa.ts
@@ -181,7 +181,6 @@ export function useMfa(options?: { isLoginSetup?: boolean }) {
 
       const request: MFAEnableRequest = {
         token,
-        secret: mfaSecret.value,
         password
       };
 
@@ -223,7 +222,6 @@ export function useMfa(options?: { isLoginSetup?: boolean }) {
         email,
         password,
         token,
-        secret: mfaSecret.value,
         backup_codes: backupCodes.value
       };
 

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -66,9 +66,15 @@ export interface MFAVerifyRequest {
   secret: string;
 }
 
+/**
+ * MFA enable requests no longer carry the TOTP `secret`: the backend
+ * mfa_setup / mfa_setup_login call pins it server-side (Redis cache,
+ * 10-minute TTL) keyed by user. Sending it here would let an
+ * attacker-with-password substitute their own secret, so the field
+ * was removed from the request schema.
+ */
 export interface MFAEnableRequest {
   token: string;
-  secret: string;
   password?: string;
 }
 
@@ -81,7 +87,6 @@ export interface MFALoginEnableRequest {
   email: string;
   password: string;
   token: string;
-  secret: string;
   backup_codes: string[];
 }
 


### PR DESCRIPTION
## Summary
Two surgical fixes for the design issues flagged in PR #10's review:

**fix(mfa): bind setup secret server-side, refuse client-supplied secret**

`mfa_enable` / `mfa_enable_login` previously accepted the TOTP secret from the request body. An attacker who knew a victim's password could substitute their own attacker-controlled secret + matching code and enroll their authenticator on the victim's account before the victim ever finished setup. Now: `mfa_setup` / `mfa_setup_login` pins the secret server-side via Redis (`mfa_setup_secret:<uuid>`, 10-min TTL); the enable handlers retrieve it from there and consume on success. The `secret` field is dropped from the request schemas entirely and the frontend services / composable stop sending it.

**fix(workspaces): primary_workspace_for_user fails loud**

`primary_workspace_for_user` previously mapped `DieselError::NotFound` to `BOOTSTRAP_WORKSPACE_ID` (=1) silently. Under hosted multi-tenancy that mis-attributed the audit row + actor context to the control-plane tenant — a quiet tenancy violation. NotFound now propagates as Err; `accept_invitation` joins the other call sites in surfacing the failure as a 500.

## Test plan
- [x] cargo check clean
- [x] vue-tsc + eslint clean
- [ ] Manual: full MFA enroll round-trip in dev — setup → enable should succeed; tampering with the request body to inject a different `secret` should be ignored (the field no longer exists in the schema and the secret is fetched from cache).
- [ ] Manual: invitation accept for a user with zero workspace_members rows returns 500 with a clear log line.