### PR TITLE
msgraph sync: typed errors + retry classification + structured failure logging

### DIFF
--- a/backend/src/handlers/msgraph_integration.rs
+++ b/backend/src/handlers/msgraph_integration.rs
@@ -1279,13 +1279,32 @@ pub async fn run_scheduled_delta_sync(pool: &crate::db::Pool) -> anyhow::Result<
         session_id: session_id.clone(),
     };
 
+    // Job-level Result answers "did the sync run?" not "were all
+    // items perfect?". Partial item failures are a normal operating
+    // state for a delta sync (a single user with a malformed email,
+    // a transient HTTP blip, etc.) — they get logged at the failure
+    // site with structured fields and don't bubble up here, because
+    // the alternative is `anyhow::anyhow!(...)` which captures a
+    // backtrace and dumps a 60-frame stack trace into the scheduler
+    // log for what's effectively normal noise.
+    //
+    // Only "couldn't even start" failures (token fetch error, DB
+    // unreachable, internal sync-machinery bug) return Err. Those
+    // are real operator-attention events the scheduler's status
+    // registry should reflect as a failed run.
     match perform_sync(&mut conn, provider.id, &entities, &session_id, true).await {
-        Ok(result) if result.success => Ok(()),
-        Ok(result) => Err(anyhow::anyhow!(
-            "sync completed with errors: {}",
-            result.message
-        )),
-        Err(e) => Err(anyhow::anyhow!("sync failed: {e}")),
+        Ok(result) => {
+            if result.total_errors > 0 {
+                tracing::warn!(
+                    provider_id = provider.id,
+                    processed = result.total_processed,
+                    failed = result.total_errors,
+                    "msgraph scheduled sync completed with partial item failures"
+                );
+            }
+            Ok(())
+        }
+        Err(e) => Err(anyhow::anyhow!("msgraph sync machinery failed: {e}")),
     }
 }
 

--- a/backend/src/handlers/msgraph_integration.rs
+++ b/backend/src/handlers/msgraph_integration.rs
@@ -3859,10 +3859,35 @@ async fn sync_group_membership(
     graph_group_id: &str,
     local_group_id: i32,
 ) -> Result<usize, crate::services::msgraph::MsGraphSyncError> {
+    use crate::services::msgraph::{with_retry, RetryConfig};
     use std::collections::HashSet;
+    use tokio_util::sync::CancellationToken;
 
-    // Fetch current members from Microsoft Graph
-    let graph_members = fetch_group_members(client, access_token, graph_group_id).await?;
+    // Fetch current members from Microsoft Graph, with retry on
+    // transient HTTP failures. fetch_group_members's status
+    // decomposition already classifies 429 / 5xx as HttpTransient
+    // and 4xx as HttpPermanent, so the executor's classify-driven
+    // retry policy does the right thing: pagination retries the
+    // failing page (idempotent since each page request is independent
+    // of the others' completion state), permanent failures bail out
+    // immediately.
+    //
+    // Cancellation: a CancellationToken is required by the executor
+    // signature. The scheduler's own shutdown token isn't currently
+    // threaded into the sync flow (SYNC_CANCELLATION static + the
+    // scheduler's shutdown live in separate registries today); a
+    // follow-up will wire them together via a child token spawned
+    // at the entry of `perform_sync`. Until then we pass a fresh
+    // token that never fires — the inner sleeps are bounded by
+    // RetryConfig::max_backoff so the retry chain can't outlive the
+    // scheduler's 30-min tick.
+    let cancel = CancellationToken::new();
+    let retry_config = RetryConfig::default();
+    let graph_members = with_retry("groups.members", retry_config, &cancel, || async {
+        fetch_group_members(client, access_token, graph_group_id).await
+    })
+    .await
+    .map_err(|f| f.error)?;
 
     // Filter to only user members (not devices or nested groups)
     let user_members: Vec<_> = graph_members.iter().filter(|m| m.is_user()).collect();
@@ -4034,10 +4059,21 @@ async fn sync_device_group_membership(
     graph_group_id: &str,
     local_group_id: i32,
 ) -> Result<usize, crate::services::msgraph::MsGraphSyncError> {
+    use crate::services::msgraph::{with_retry, RetryConfig};
     use std::collections::HashSet;
+    use tokio_util::sync::CancellationToken;
 
-    // Fetch current members from Microsoft Graph
-    let graph_members = fetch_group_members(client, access_token, graph_group_id).await?;
+    // Retry on transient HTTP failures — see the analogous comment
+    // in sync_group_membership for the cancellation gap.
+    let cancel = CancellationToken::new();
+    let graph_members = with_retry(
+        "groups.device_members",
+        RetryConfig::default(),
+        &cancel,
+        || async { fetch_group_members(client, access_token, graph_group_id).await },
+    )
+    .await
+    .map_err(|f| f.error)?;
 
     debug!(
         group_id = graph_group_id,

--- a/backend/src/handlers/msgraph_integration.rs
+++ b/backend/src/handlers/msgraph_integration.rs
@@ -389,7 +389,12 @@ impl GroupSyncConfig {
     }
 }
 
-// Group sync statistics
+// Group sync statistics. `errors` is the legacy string-typed channel
+// the admin UI's existing JSON consumer reads; `failures` is the new
+// typed channel — same data, classifier-routed, used by the
+// scheduler's structured tracing and by the typed
+// SyncOutcome -> SyncResult projection. New code should push through
+// `record_failure(&mut self, ...)` so both stay in lockstep.
 #[derive(Serialize, Debug, Default)]
 pub struct GroupSyncStats {
     pub groups_created: usize,
@@ -397,6 +402,8 @@ pub struct GroupSyncStats {
     pub user_membership_changes: usize,
     pub device_membership_changes: usize,
     pub errors: Vec<String>,
+    #[serde(skip)]
+    pub failures: Vec<crate::services::msgraph::ItemFailure>,
 }
 
 // User sync statistics
@@ -406,6 +413,8 @@ pub struct UserSyncStats {
     pub existing_users_updated: usize,
     pub identities_linked: usize,
     pub errors: Vec<String>,
+    #[serde(skip)]
+    pub failures: Vec<crate::services::msgraph::ItemFailure>,
 }
 
 // Asset sync statistics
@@ -415,6 +424,70 @@ pub struct DeviceSyncStats {
     pub existing_devices_updated: usize,
     pub devices_assigned: usize,
     pub errors: Vec<String>,
+    #[serde(skip)]
+    pub failures: Vec<crate::services::msgraph::ItemFailure>,
+}
+
+/// Shared "push a failure into a sync-stats struct" surface. The
+/// three stats structs are nominally distinct (different counter
+/// fields per entity) but they all carry the same dual error
+/// channel — legacy `errors: Vec<String>` for the admin UI's JSON
+/// consumer, typed `failures: Vec<ItemFailure>` for the scheduler /
+/// structured tracing / SyncOutcome projection. The trait keeps
+/// the dual write in lockstep so a future PR can't silently break
+/// one of the two.
+trait SyncStatsExt {
+    fn errors_mut(&mut self) -> &mut Vec<String>;
+    fn failures_mut(&mut self) -> &mut Vec<crate::services::msgraph::ItemFailure>;
+
+    /// Push a typed failure. Emits the structured warn (entity,
+    /// external_id, error_kind, classification, attempt) via the
+    /// pipeline helper, mirrors a classifier-only line into the
+    /// legacy string channel for the admin UI, and stores the
+    /// typed record for the outcome aggregate.
+    fn record_failure(
+        &mut self,
+        entity: crate::services::msgraph::EntityKind,
+        external_id: &str,
+        error: crate::services::msgraph::MsGraphSyncError,
+        attempt: u32,
+    ) {
+        // Classifier-only string: error's Display contract excludes
+        // user-typed content (name, email, ticket title), so this
+        // legacy line is safe to surface in the admin UI without
+        // re-leaking PII the typed channel already filters out.
+        let legacy_line = format!("{} {}: {}", entity.as_str(), external_id, error);
+        let failure = crate::services::msgraph::record_failure(entity, external_id, error, attempt);
+        self.errors_mut().push(legacy_line);
+        self.failures_mut().push(failure);
+    }
+}
+
+impl SyncStatsExt for UserSyncStats {
+    fn errors_mut(&mut self) -> &mut Vec<String> {
+        &mut self.errors
+    }
+    fn failures_mut(&mut self) -> &mut Vec<crate::services::msgraph::ItemFailure> {
+        &mut self.failures
+    }
+}
+
+impl SyncStatsExt for DeviceSyncStats {
+    fn errors_mut(&mut self) -> &mut Vec<String> {
+        &mut self.errors
+    }
+    fn failures_mut(&mut self) -> &mut Vec<crate::services::msgraph::ItemFailure> {
+        &mut self.failures
+    }
+}
+
+impl SyncStatsExt for GroupSyncStats {
+    fn errors_mut(&mut self) -> &mut Vec<String> {
+        &mut self.errors
+    }
+    fn failures_mut(&mut self) -> &mut Vec<crate::services::msgraph::ItemFailure> {
+        &mut self.failures
+    }
 }
 
 /// Parameters for updating sync progress
@@ -1536,6 +1609,7 @@ async fn sync_users(
         existing_users_updated: 0,
         identities_linked: 0,
         errors: Vec::new(),
+        failures: Vec::new(),
     };
 
     let sync_mode_msg = if use_delta { "delta" } else { "full" };
@@ -1826,12 +1900,12 @@ async fn sync_users(
                         );
                     }
                     Err(error) => {
-                        let error_msg = format!(
-                            "Failed to process user {}: {}",
-                            ms_user.user_principal_name, error
+                        stats.record_failure(
+                            crate::services::msgraph::EntityKind::Users,
+                            &ms_user.id,
+                            error.into(),
+                            1,
                         );
-                        warn!("{}", error_msg);
-                        stats.errors.push(error_msg);
                     }
                 }
             } else {
@@ -1853,12 +1927,12 @@ async fn sync_users(
                         );
                     }
                     Err(error) => {
-                        let error_msg = format!(
-                            "Failed to process user {}: {}",
-                            ms_user.user_principal_name, error
+                        stats.record_failure(
+                            crate::services::msgraph::EntityKind::Users,
+                            &ms_user.id,
+                            error.into(),
+                            1,
                         );
-                        warn!("{}", error_msg);
-                        stats.errors.push(error_msg);
                     }
                 }
             }
@@ -2323,7 +2397,7 @@ async fn process_microsoft_user_optimized_v2(
     stats: &mut UserSyncStats,
     access_token: &str,
     client: &reqwest::Client,
-) -> Result<(), String> {
+) -> Result<(), crate::services::msgraph::MsGraphSyncError> {
     // Step 1: Check if this Microsoft user already has an identity in our system
     if let Ok(existing_identity) = find_identity_by_provider_user_id(conn, provider_id, &ms_user.id)
     {
@@ -2408,16 +2482,16 @@ async fn update_existing_microsoft_user_optimized(
     stats: &mut UserSyncStats,
     access_token: &str,
     client: &reqwest::Client,
-) -> Result<(), String> {
+) -> Result<(), crate::services::msgraph::MsGraphSyncError> {
+    use crate::services::msgraph::MsGraphSyncError;
+
     // User info is in the span context
 
-    // Get the associated user
-    let user = user_repo::get_user_by_uuid(&existing_identity.user_uuid, conn).map_err(|e| {
-        format!(
-            "Failed to get user by UUID {}: {}",
-            existing_identity.user_uuid, e
-        )
-    })?;
+    // Get the associated user. diesel::Error has a typed From impl
+    // that routes NotFound / unique-violation / FK-violation through
+    // DbConflict and infra errors through DbInfra; `?` does the
+    // right classification without an intermediate format!.
+    let user = user_repo::get_user_by_uuid(&existing_identity.user_uuid, conn)?;
 
     // Extract all email addresses from Microsoft Graph
     let emails = extract_user_emails(ms_user);
@@ -2441,16 +2515,18 @@ async fn update_existing_microsoft_user_optimized(
         avatar_url: None,   // Preserve avatar
         banner_url: None,   // Preserve banner
         avatar_thumb: None, // Preserve avatar thumb
-        microsoft_uuid: Some(
-            utils::parse_uuid(&ms_user.id).map_err(|_| "Invalid Microsoft UUID format")?,
-        ), // Always update Microsoft UUID with proper conversion
+        microsoft_uuid: Some(utils::parse_uuid(&ms_user.id).map_err(|_| {
+            MsGraphSyncError::Mapping {
+                hint: "invalid Microsoft UUID format",
+                source: None,
+            }
+        })?),
         updated_at: Some(chrono::Utc::now().naive_utc()),
     };
 
     // Update user if there are changes
     if user_update.name.is_some() || user_update.microsoft_uuid.is_some() {
-        user_repo::update_user(&user.uuid, user_update, conn, None)
-            .map_err(|e| format!("Failed to update user: {e}"))?;
+        user_repo::update_user(&user.uuid, user_update, conn, None)?;
         debug!(user_name = %user.name, "Updated user information");
     }
 
@@ -2503,26 +2579,25 @@ async fn update_existing_microsoft_user_optimized(
                 }
             }
             Err(e) => {
-                error!(
-                    "Failed to store email addresses for user {}: {}",
-                    user.name, e
+                stats.record_failure(
+                    crate::services::msgraph::EntityKind::Users,
+                    &ms_user.id,
+                    e.into(),
+                    1,
                 );
-                stats.errors.push(format!(
-                    "Failed to store emails for user {}: {}",
-                    user.name, e
-                ));
             }
         }
     } else {
         trace!("No email addresses to store for user: {}", user.name);
     }
 
-    // Update identity data with latest from Microsoft Graph
-    let identity_data = serde_json::to_value(ms_user)
-        .map_err(|e| format!("Failed to serialize Microsoft user data: {e}"))?;
-
-    update_identity_data(conn, existing_identity.id, Some(identity_data))
-        .map_err(|e| format!("Failed to update identity data: {e}"))?;
+    // Update identity data with latest from Microsoft Graph. The
+    // From impls on MsGraphSyncError route serde_json::Error to
+    // Parse (Permanent) and diesel::Error to DbConflict / DbInfra
+    // so `?` carries the classification through without an
+    // intermediate `format!`.
+    let identity_data = serde_json::to_value(ms_user)?;
+    update_identity_data(conn, existing_identity.id, Some(identity_data))?;
 
     // Sync profile photo using optimized client
     if let Ok(photo_urls) = sync_user_profile_photo(
@@ -2559,12 +2634,14 @@ async fn link_existing_user_to_microsoft_optimized(
     stats: &mut UserSyncStats,
     access_token: &str,
     client: &reqwest::Client,
-) -> Result<(), String> {
-    // Linking info is in the span context
+) -> Result<(), crate::services::msgraph::MsGraphSyncError> {
+    use crate::services::msgraph::MsGraphSyncError;
 
-    // Create Microsoft identity for existing user
-    let identity_data = serde_json::to_value(ms_user)
-        .map_err(|e| format!("Failed to serialize Microsoft user data: {e}"))?;
+    // Create Microsoft identity for existing user. The typed From
+    // impls on serde_json::Error and diesel::result::Error mean
+    // these `?` calls classify themselves at the source — no
+    // intermediate `format!` stringification.
+    let identity_data = serde_json::to_value(ms_user)?;
 
     let new_identity = NewUserAuthIdentity {
         user_uuid: existing_user.uuid,
@@ -2575,8 +2652,7 @@ async fn link_existing_user_to_microsoft_optimized(
         password_hash: None,
     };
 
-    identity_repo::create_identity(new_identity, conn)
-        .map_err(|e| format!("Failed to create Microsoft identity: {e}"))?;
+    identity_repo::create_identity(new_identity, conn)?;
 
     // Extract all email addresses from Microsoft Graph
     let emails = extract_user_emails(ms_user);
@@ -2598,15 +2674,17 @@ async fn link_existing_user_to_microsoft_optimized(
         avatar_url: None,
         banner_url: None,
         avatar_thumb: None,
-        microsoft_uuid: Some(
-            utils::parse_uuid(&ms_user.id).map_err(|_| "Invalid Microsoft UUID format")?,
-        ), // Store Microsoft UUID with proper conversion
+        microsoft_uuid: Some(utils::parse_uuid(&ms_user.id).map_err(|_| {
+            MsGraphSyncError::Mapping {
+                hint: "invalid Microsoft UUID format",
+                source: None,
+            }
+        })?),
         updated_at: Some(chrono::Utc::now().naive_utc()),
     };
 
     // Always update to store the Microsoft UUID
-    user_repo::update_user(&existing_user.uuid, user_update, conn, None)
-        .map_err(|e| format!("Failed to update user with Microsoft UUID: {e}"))?;
+    user_repo::update_user(&existing_user.uuid, user_update, conn, None)?;
 
     // Store all email addresses
     let email_data: Vec<(String, String, bool, String)> = emails
@@ -2630,14 +2708,12 @@ async fn link_existing_user_to_microsoft_optimized(
                 );
             }
             Err(e) => {
-                error!(
-                    "Failed to store email addresses for linked user {}: {}",
-                    existing_user.name, e
+                stats.record_failure(
+                    crate::services::msgraph::EntityKind::Users,
+                    &ms_user.id,
+                    e.into(),
+                    1,
                 );
-                stats.errors.push(format!(
-                    "Failed to store emails for linked user {}: {}",
-                    existing_user.name, e
-                ));
             }
         }
     } else {
@@ -2684,8 +2760,8 @@ async fn create_new_user_from_microsoft_optimized(
     stats: &mut UserSyncStats,
     access_token: &str,
     client: &reqwest::Client,
-) -> Result<(), String> {
-    // User info is in the span context
+) -> Result<(), crate::services::msgraph::MsGraphSyncError> {
+    use crate::services::msgraph::MsGraphSyncError;
 
     // Generate UUID for new user (this is our local UUID, different from Microsoft's)
     let _user_uuid = Uuid::now_v7().to_string();
@@ -2711,9 +2787,13 @@ async fn create_new_user_from_microsoft_optimized(
 
     // Create new user with default role 'user' and store Microsoft UUID
     let user_uuid = Uuid::now_v7();
-    // Create Microsoft user with UUID
     let microsoft_uuid =
-        Some(utils::parse_uuid(&ms_user.id).map_err(|_| "Invalid Microsoft UUID format")?);
+        Some(
+            utils::parse_uuid(&ms_user.id).map_err(|_| MsGraphSyncError::Mapping {
+                hint: "invalid Microsoft UUID format",
+                source: None,
+            })?,
+        );
     let new_user = utils::NewUserBuilder::microsoft_user(
         name.clone(),
         primary_email.clone(),
@@ -2724,8 +2804,11 @@ async fn create_new_user_from_microsoft_optimized(
     .build();
     let (new_user, _role) = new_user;
 
-    let created_user = user_repo::create_user(new_user, conn)
-        .map_err(|e| format!("Failed to create user: {e}"))?;
+    // diesel::result::Error has a typed From impl on
+    // MsGraphSyncError that routes unique-violation / FK to
+    // DbConflict and infrastructural failures to DbInfra; `?`
+    // classifies at the source.
+    let created_user = user_repo::create_user(new_user, conn)?;
 
     // Store all email addresses
     let email_data: Vec<(String, String, bool, String)> = emails
@@ -2740,31 +2823,22 @@ async fn create_new_user_from_microsoft_optimized(
             name
         );
 
-        match user_emails_repo::add_multiple_emails(conn, &created_user.uuid, email_data.clone()) {
-            Ok(stored_emails) => {
-                let added_count = stored_emails.len();
-                debug!(
-                    "Successfully stored {} email addresses for new user: {}",
-                    added_count, name
-                );
-            }
-            Err(e) => {
-                error!(
-                    "Failed to store email addresses for new user {}: {}",
-                    name, e
-                );
-                stats
-                    .errors
-                    .push(format!("Failed to store emails for new user {name}: {e}"));
-            }
+        if let Err(e) =
+            user_emails_repo::add_multiple_emails(conn, &created_user.uuid, email_data.clone())
+        {
+            stats.record_failure(
+                crate::services::msgraph::EntityKind::Users,
+                &ms_user.id,
+                e.into(),
+                1,
+            );
         }
     } else {
         trace!("No email addresses to store for new user: {}", name);
     }
 
     // Create Microsoft identity for the new user
-    let identity_data = serde_json::to_value(ms_user)
-        .map_err(|e| format!("Failed to serialize Microsoft user data: {e}"))?;
+    let identity_data = serde_json::to_value(ms_user)?;
 
     let new_identity = NewUserAuthIdentity {
         user_uuid: created_user.uuid,
@@ -2775,8 +2849,7 @@ async fn create_new_user_from_microsoft_optimized(
         password_hash: None,
     };
 
-    identity_repo::create_identity(new_identity, conn)
-        .map_err(|e| format!("Failed to create Microsoft identity: {e}"))?;
+    identity_repo::create_identity(new_identity, conn)?;
 
     // Sync profile photo using optimized client
     if let Ok(photo_urls) = sync_user_profile_photo(
@@ -2822,6 +2895,7 @@ async fn sync_devices(
         existing_devices_updated: 0,
         devices_assigned: 0,
         errors: Vec::new(),
+        failures: Vec::new(),
     };
 
     let sync_mode_msg = if use_delta { "delta" } else { "full" };
@@ -2991,9 +3065,12 @@ async fn sync_devices(
                 debug!(device_name = %device_name, "Successfully processed Entra device");
             }
             Err(error) => {
-                let error_msg = format!("Failed to process device {device_name}: {error}");
-                error!(device_name = %device_name, error = %error, "Failed to process Entra device");
-                stats.errors.push(error_msg);
+                stats.record_failure(
+                    crate::services::msgraph::EntityKind::Devices,
+                    &entra_device.id,
+                    error.into(),
+                    1,
+                );
             }
         }
 
@@ -3299,11 +3376,12 @@ async fn sync_groups(
                             }
                         }
                         Err(e) => {
-                            let error_msg = format!(
-                                "Failed to apply delta membership for group {group_name}: {e}"
+                            stats.record_failure(
+                                crate::services::msgraph::EntityKind::Groups,
+                                &ms_group.id,
+                                e.into(),
+                                1,
                             );
-                            warn!("{}", error_msg);
-                            stats.errors.push(error_msg);
                         }
                     }
                 } else {
@@ -3325,11 +3403,12 @@ async fn sync_groups(
                             }
                         }
                         Err(e) => {
-                            let error_msg = format!(
-                                "Failed to sync user membership for group {group_name}: {e}"
+                            stats.record_failure(
+                                crate::services::msgraph::EntityKind::Groups,
+                                &ms_group.id,
+                                e.into(),
+                                1,
                             );
-                            warn!("{}", error_msg);
-                            stats.errors.push(error_msg);
                         }
                     }
 
@@ -3350,19 +3429,23 @@ async fn sync_groups(
                             }
                         }
                         Err(e) => {
-                            let error_msg = format!(
-                                "Failed to sync device membership for group {group_name}: {e}"
+                            stats.record_failure(
+                                crate::services::msgraph::EntityKind::Groups,
+                                &ms_group.id,
+                                e.into(),
+                                1,
                             );
-                            warn!("{}", error_msg);
-                            stats.errors.push(error_msg);
                         }
                     }
                 }
             }
             Err(e) => {
-                let error_msg = format!("Failed to upsert group {group_name}: {e}");
-                error!(group_name = %group_name, error = %e, "Failed to upsert group");
-                stats.errors.push(error_msg);
+                stats.record_failure(
+                    crate::services::msgraph::EntityKind::Groups,
+                    &ms_group.id,
+                    e.into(),
+                    1,
+                );
             }
         }
 
@@ -4970,7 +5053,7 @@ async fn process_microsoft_user_no_photos(
     provider_id: i32,
     ms_user: &MicrosoftGraphUser,
     stats: &mut UserSyncStats,
-) -> Result<(), String> {
+) -> Result<(), crate::services::msgraph::MsGraphSyncError> {
     // Check if identity already exists
     match find_identity_by_provider_user_id(conn, provider_id, &ms_user.id) {
         Ok(existing_identity) => {
@@ -4982,7 +5065,6 @@ async fn process_microsoft_user_no_photos(
             let emails = extract_user_emails(ms_user);
 
             if let Some(existing_user) = find_existing_user_by_emails(conn, &emails) {
-                // Link existing user to Microsoft account without photos
                 link_existing_user_to_microsoft_no_photos(
                     conn,
                     provider_id,
@@ -4992,13 +5074,15 @@ async fn process_microsoft_user_no_photos(
                 )
                 .await
             } else {
-                // Create new user without photos
                 create_new_user_from_microsoft_no_photos(conn, provider_id, ms_user, stats).await
             }
         }
-        Err(e) => Err(format!(
-            "Database error checking for existing identity: {e}"
-        )),
+        // Any other diesel error here is an infrastructural failure
+        // — pool gone, server going away. The typed From impl routes
+        // it to DbInfra (Auth classification), which bubbles up and
+        // aborts the run rather than treating the misclassification
+        // as a per-item conflict.
+        Err(e) => Err(e.into()),
     }
 }
 
@@ -5133,16 +5217,11 @@ async fn update_existing_microsoft_user_no_photos(
     ms_user: &MicrosoftGraphUser,
     existing_identity: UserAuthIdentity,
     stats: &mut UserSyncStats,
-) -> Result<(), String> {
-    // Get the associated user
-    let user = user_repo::get_user_by_uuid(&existing_identity.user_uuid, conn).map_err(|e| {
-        format!(
-            "Failed to get user by UUID {}: {}",
-            existing_identity.user_uuid, e
-        )
-    })?;
+) -> Result<(), crate::services::msgraph::MsGraphSyncError> {
+    use crate::services::msgraph::MsGraphSyncError;
 
-    // Extract emails and update user info
+    let user = user_repo::get_user_by_uuid(&existing_identity.user_uuid, conn)?;
+
     let emails = extract_user_emails(ms_user);
     let _primary_email = emails
         .first()
@@ -5151,7 +5230,6 @@ async fn update_existing_microsoft_user_no_photos(
 
     let updated_name = ms_user.display_name.as_ref().unwrap_or(&user.name);
 
-    // Update user if needed
     let user_update = crate::models::UserUpdate {
         name: if updated_name != &user.name {
             Some(updated_name.clone())
@@ -5163,18 +5241,19 @@ async fn update_existing_microsoft_user_no_photos(
         avatar_url: None,
         banner_url: None,
         avatar_thumb: None,
-        microsoft_uuid: Some(
-            utils::parse_uuid(&ms_user.id).map_err(|_| "Invalid Microsoft UUID format")?,
-        ),
+        microsoft_uuid: Some(utils::parse_uuid(&ms_user.id).map_err(|_| {
+            MsGraphSyncError::Mapping {
+                hint: "invalid Microsoft UUID format",
+                source: None,
+            }
+        })?),
         updated_at: Some(chrono::Utc::now().naive_utc()),
     };
 
     if user_update.name.is_some() || user_update.microsoft_uuid.is_some() {
-        user_repo::update_user(&user.uuid, user_update, conn, None)
-            .map_err(|e| format!("Failed to update user: {e}"))?;
+        user_repo::update_user(&user.uuid, user_update, conn, None)?;
     }
 
-    // Store emails if any
     if !emails.is_empty() {
         let email_data: Vec<(String, String, bool, String)> = emails
             .into_iter()
@@ -5186,12 +5265,8 @@ async fn update_existing_microsoft_user_no_photos(
         let _ = user_emails_repo::add_multiple_emails(conn, &user.uuid, email_data);
     }
 
-    // Update identity data
-    let identity_data = serde_json::to_value(ms_user)
-        .map_err(|e| format!("Failed to serialize Microsoft user data: {e}"))?;
-
-    update_identity_data(conn, existing_identity.id, Some(identity_data))
-        .map_err(|e| format!("Failed to update identity data: {e}"))?;
+    let identity_data = serde_json::to_value(ms_user)?;
+    update_identity_data(conn, existing_identity.id, Some(identity_data))?;
 
     stats.existing_users_updated += 1;
     Ok(())
@@ -5204,10 +5279,10 @@ async fn link_existing_user_to_microsoft_no_photos(
     ms_user: &MicrosoftGraphUser,
     existing_user: User,
     stats: &mut UserSyncStats,
-) -> Result<(), String> {
-    // Create Microsoft identity
-    let identity_data = serde_json::to_value(ms_user)
-        .map_err(|e| format!("Failed to serialize Microsoft user data: {e}"))?;
+) -> Result<(), crate::services::msgraph::MsGraphSyncError> {
+    use crate::services::msgraph::MsGraphSyncError;
+
+    let identity_data = serde_json::to_value(ms_user)?;
 
     let new_identity = NewUserAuthIdentity {
         user_uuid: existing_user.uuid,
@@ -5218,10 +5293,8 @@ async fn link_existing_user_to_microsoft_no_photos(
         password_hash: None,
     };
 
-    identity_repo::create_identity(new_identity, conn)
-        .map_err(|e| format!("Failed to create Microsoft identity: {e}"))?;
+    identity_repo::create_identity(new_identity, conn)?;
 
-    // Update user with Microsoft UUID
     let user_update = crate::models::UserUpdate {
         name: None,
 
@@ -5229,14 +5302,16 @@ async fn link_existing_user_to_microsoft_no_photos(
         avatar_url: None,
         banner_url: None,
         avatar_thumb: None,
-        microsoft_uuid: Some(
-            utils::parse_uuid(&ms_user.id).map_err(|_| "Invalid Microsoft UUID format")?,
-        ),
+        microsoft_uuid: Some(utils::parse_uuid(&ms_user.id).map_err(|_| {
+            MsGraphSyncError::Mapping {
+                hint: "invalid Microsoft UUID format",
+                source: None,
+            }
+        })?),
         updated_at: Some(chrono::Utc::now().naive_utc()),
     };
 
-    user_repo::update_user(&existing_user.uuid, user_update, conn, None)
-        .map_err(|e| format!("Failed to update user with Microsoft UUID: {e}"))?;
+    user_repo::update_user(&existing_user.uuid, user_update, conn, None)?;
 
     stats.identities_linked += 1;
     Ok(())
@@ -5248,11 +5323,11 @@ async fn create_new_user_from_microsoft_no_photos(
     _provider_id: i32,
     ms_user: &MicrosoftGraphUser,
     stats: &mut UserSyncStats,
-) -> Result<(), String> {
-    // Generate UUID for new user
+) -> Result<(), crate::services::msgraph::MsGraphSyncError> {
+    use crate::services::msgraph::MsGraphSyncError;
+
     let user_uuid = Uuid::now_v7();
 
-    // Determine name and email
     let name = ms_user
         .display_name
         .clone()
@@ -5270,9 +5345,13 @@ async fn create_new_user_from_microsoft_no_photos(
         .unwrap_or(&ms_user.user_principal_name)
         .clone();
 
-    // Create user with Microsoft UUID
     let microsoft_uuid =
-        Some(utils::parse_uuid(&ms_user.id).map_err(|_| "Invalid Microsoft UUID format")?);
+        Some(
+            utils::parse_uuid(&ms_user.id).map_err(|_| MsGraphSyncError::Mapping {
+                hint: "invalid Microsoft UUID format",
+                source: None,
+            })?,
+        );
     let (new_user, _role) = utils::NewUserBuilder::microsoft_user(
         name.clone(),
         primary_email,
@@ -5282,12 +5361,9 @@ async fn create_new_user_from_microsoft_no_photos(
     .with_uuid(user_uuid)
     .build();
 
-    let created_user = user_repo::create_user(new_user, conn)
-        .map_err(|e| format!("Failed to create user: {e}"))?;
+    let created_user = user_repo::create_user(new_user, conn)?;
 
-    // Create Microsoft identity
-    let identity_data = serde_json::to_value(ms_user)
-        .map_err(|e| format!("Failed to serialize Microsoft user data: {e}"))?;
+    let identity_data = serde_json::to_value(ms_user)?;
 
     let new_identity = NewUserAuthIdentity {
         user_uuid: created_user.uuid,
@@ -5298,10 +5374,8 @@ async fn create_new_user_from_microsoft_no_photos(
         password_hash: None,
     };
 
-    identity_repo::create_identity(new_identity, conn)
-        .map_err(|e| format!("Failed to create Microsoft identity: {e}"))?;
+    identity_repo::create_identity(new_identity, conn)?;
 
-    // Store emails if any
     let emails = extract_user_emails(ms_user);
     if !emails.is_empty() {
         let email_data: Vec<(String, String, bool, String)> = emails

--- a/backend/src/handlers/msgraph_integration.rs
+++ b/backend/src/handlers/msgraph_integration.rs
@@ -3800,30 +3800,37 @@ async fn fetch_group_members(
     client: &reqwest::Client,
     access_token: &str,
     group_id: &str,
-) -> Result<Vec<MicrosoftGraphGroupMember>, String> {
+) -> Result<Vec<MicrosoftGraphGroupMember>, crate::services::msgraph::MsGraphSyncError> {
+    use crate::services::msgraph::MsGraphSyncError;
     let mut all_members: Vec<MicrosoftGraphGroupMember> = Vec::new();
     let mut next_link: Option<String> = Some(format!(
         "https://graph.microsoft.com/v1.0/groups/{group_id}/members?$select=id,displayName,userPrincipalName&$top=999"
     ));
 
     while let Some(url) = next_link {
-        let response = client
-            .get(&url)
-            .bearer_auth(access_token)
-            .send()
-            .await
-            .map_err(|e| format!("Failed to fetch group members: {e}"))?;
+        // reqwest::Error -> MsGraphSyncError classifies the network
+        // failure kind (timeout / connect / tls / body) via the From
+        // impl; if the status reached the response, it routes to
+        // HttpTransient (429 / 5xx) or HttpPermanent (everything
+        // else) via the same impl.
+        let response = client.get(&url).bearer_auth(access_token).send().await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await.unwrap_or_default();
-            return Err(format!("Failed to fetch members ({status}): {error_text}"));
+            // Decompose into status + body. `from_status` does the
+            // transient/permanent split (429/5xx -> retryable,
+            // 4xx -> skip) so the retry executor can act on it.
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(MsGraphSyncError::from_status(
+                status,
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("graph members fetch body: {body}"),
+                ),
+            ));
         }
 
-        let data: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| format!("Failed to parse members response: {e}"))?;
+        let data: serde_json::Value = response.json().await?;
 
         if let Some(members) = data["value"].as_array() {
             for member_value in members {
@@ -3851,7 +3858,7 @@ async fn sync_group_membership(
     access_token: &str,
     graph_group_id: &str,
     local_group_id: i32,
-) -> Result<usize, String> {
+) -> Result<usize, crate::services::msgraph::MsGraphSyncError> {
     use std::collections::HashSet;
 
     // Fetch current members from Microsoft Graph
@@ -3860,16 +3867,15 @@ async fn sync_group_membership(
     // Filter to only user members (not devices or nested groups)
     let user_members: Vec<_> = graph_members.iter().filter(|m| m.is_user()).collect();
 
-    // Get current local membership
-    let current_local_members = groups_repo::get_member_uuids_for_group(conn, local_group_id)
-        .map_err(|e| format!("Failed to get local members: {e}"))?;
+    // Get current local membership. diesel error routes to DbConflict
+    // or DbInfra via the typed From impl.
+    let current_local_members = groups_repo::get_member_uuids_for_group(conn, local_group_id)?;
     let current_local_set: HashSet<_> = current_local_members.into_iter().collect();
 
     // Map Graph user IDs to local user UUIDs
     let graph_member_ids: Vec<&str> = user_members.iter().map(|m| m.id.as_str()).collect();
     let user_mappings =
-        identity_repo::get_user_uuids_by_external_ids(&graph_member_ids, "microsoft", conn)
-            .map_err(|e| format!("Failed to lookup users: {e}"))?;
+        identity_repo::get_user_uuids_by_external_ids(&graph_member_ids, "microsoft", conn)?;
 
     let new_member_uuids: HashSet<_> = user_mappings.into_iter().map(|(_, uuid)| uuid).collect();
 
@@ -3924,7 +3930,7 @@ async fn apply_delta_group_membership(
     local_group_id: i32,
     members_added: &[MicrosoftGraphGroupMember],
     members_removed: &[String],
-) -> Result<usize, String> {
+) -> Result<usize, crate::services::msgraph::MsGraphSyncError> {
     let mut changes = 0;
 
     // Process added members (users only for now)
@@ -3932,8 +3938,7 @@ async fn apply_delta_group_membership(
     if !user_members_added.is_empty() {
         let external_ids: Vec<&str> = user_members_added.iter().map(|m| m.id.as_str()).collect();
         let user_mappings =
-            identity_repo::get_user_uuids_by_external_ids(&external_ids, "microsoft", conn)
-                .map_err(|e| format!("Failed to lookup users for adding: {e}"))?;
+            identity_repo::get_user_uuids_by_external_ids(&external_ids, "microsoft", conn)?;
 
         for (external_id, user_uuid) in user_mappings {
             // Check if user is already a member
@@ -3957,8 +3962,7 @@ async fn apply_delta_group_membership(
     if !members_removed.is_empty() {
         let external_ids_refs: Vec<&str> = members_removed.iter().map(|s| s.as_str()).collect();
         let user_mappings =
-            identity_repo::get_user_uuids_by_external_ids(&external_ids_refs, "microsoft", conn)
-                .map_err(|e| format!("Failed to lookup users for removal: {e}"))?;
+            identity_repo::get_user_uuids_by_external_ids(&external_ids_refs, "microsoft", conn)?;
 
         for (external_id, user_uuid) in user_mappings {
             if let Err(e) = groups_repo::remove_user_from_group(conn, &user_uuid, local_group_id) {
@@ -4029,7 +4033,7 @@ async fn sync_device_group_membership(
     access_token: &str,
     graph_group_id: &str,
     local_group_id: i32,
-) -> Result<usize, String> {
+) -> Result<usize, crate::services::msgraph::MsGraphSyncError> {
     use std::collections::HashSet;
 
     // Fetch current members from Microsoft Graph
@@ -4057,8 +4061,7 @@ async fn sync_device_group_membership(
 
     // Get current local device membership (only synced ones from Microsoft)
     let current_synced_devices =
-        groups_repo::get_synced_device_ids_for_group(conn, local_group_id, "microsoft")
-            .map_err(|e| format!("Failed to get local device members: {e}"))?;
+        groups_repo::get_synced_device_ids_for_group(conn, local_group_id, "microsoft")?;
     let current_local_set: HashSet<_> = current_synced_devices.into_iter().collect();
 
     // Map Graph device IDs (Entra Object IDs) to local device IDs
@@ -4070,8 +4073,7 @@ async fn sync_device_group_membership(
         "Looking up local devices by Entra IDs"
     );
 
-    let device_mappings = asset_repo::get_devices_by_entra_ids(conn, &graph_device_ids)
-        .map_err(|e| format!("Failed to lookup devices: {e}"))?;
+    let device_mappings = asset_repo::get_devices_by_entra_ids(conn, &graph_device_ids)?;
 
     debug!(
         group_id = graph_group_id,
@@ -4650,7 +4652,7 @@ async fn process_entra_device(
     _provider_id: i32,
     entra_device: &EntraDevice,
     stats: &mut DeviceSyncStats,
-) -> Result<(), String> {
+) -> Result<(), crate::services::msgraph::MsGraphSyncError> {
     let device_name = entra_device
         .display_name
         .as_deref()
@@ -4776,8 +4778,8 @@ async fn process_entra_device(
             ..Default::default()
         };
 
-        asset_repo::update_device(conn, existing.id, device_update)
-            .map_err(|e| format!("Failed to update device: {e}"))?;
+        // diesel error classified at source by MsGraphSyncError::from.
+        asset_repo::update_device(conn, existing.id, device_update)?;
 
         debug!(device_name = %device_display_name, "Updated existing Entra device");
         stats.existing_devices_updated += 1;
@@ -4806,8 +4808,7 @@ async fn process_entra_device(
             low_stock_threshold: None,
         };
 
-        asset_repo::create_device(conn, new_device)
-            .map_err(|e| format!("Failed to create device: {e}"))?;
+        asset_repo::create_device(conn, new_device)?;
 
         info!(device_name = %device_display_name, "Created new Entra device");
         stats.new_devices_created += 1;

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -6,6 +6,7 @@ pub mod backup;
 pub mod channels;
 pub mod email_queue;
 pub mod imports;
+pub mod msgraph;
 pub mod notifications;
 pub mod oauth_provisioning;
 pub mod plugins;

--- a/backend/src/services/msgraph/error.rs
+++ b/backend/src/services/msgraph/error.rs
@@ -1,0 +1,362 @@
+//! Typed errors for the Microsoft Graph delta-sync pipeline.
+//!
+//! The pre-typed implementation collected per-item errors as
+//! `Vec<String>` and tried to flatten them into an `anyhow::Error`
+//! at the job boundary. That conflated three different concerns
+//! (per-item failure, per-entity failure, job-level failure) into
+//! the same channel and threw away all classification: a transient
+//! HTTP 429 looked identical to a permanent 404 looked identical
+//! to a parser bug looked identical to a database conflict.
+//!
+//! `MsGraphSyncError` is the typed equivalent. Each variant carries
+//! the context an operator needs to act on it, and each variant
+//! classifies itself into one of four buckets the executor reads:
+//!
+//!   * **Transient** — retry within the run with backoff; if it
+//!     keeps failing, log and skip the item, the next delta tick
+//!     will see it again.
+//!   * **Permanent** — don't retry; the item itself is the problem
+//!     (malformed Graph response, schema mismatch, unsupported
+//!     payload). Skip and log; the source-of-truth fix is upstream
+//!     in MS Graph or in the local schema.
+//!   * **Conflict** — local DB rejected the write (unique-index
+//!     race, FK pointing at a now-deleted row). Don't retry within
+//!     this run; the next tick after the conflicting state settles
+//!     can succeed.
+//!   * **Auth** — bubbles up to the JOB level, not the item level.
+//!     A token failure means none of the remaining items will
+//!     succeed either; aborting the whole run is the cheapest
+//!     correct response.
+//!
+//! `Display` is deliberately classifier-only and never includes
+//! user-typed content (email, display name, ticket title, ...) so
+//! it can flow through the tracing-allowlist JSON layer without
+//! leaking PII. Full source-chain detail lives in `source()` for
+//! callers that want it via Debug / `error_chain()`.
+
+use std::fmt;
+
+use thiserror::Error;
+
+/// Classification an item-level failure gets routed by. Maps 1:1 to
+/// the variants of `MsGraphSyncError` via `classify()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Classification {
+    /// Worth retrying within this sync run with exponential backoff.
+    Transient,
+    /// Skip the item; logging it surfaces the problem upstream.
+    Permanent,
+    /// DB-level conflict — the next run after the racing state
+    /// settles can succeed; don't retry within this run.
+    Conflict,
+    /// The whole run can't proceed (token gone, DB unreachable).
+    /// Pipeline aborts; the scheduler logs the Job-level Err.
+    Auth,
+}
+
+impl Classification {
+    /// String tag for structured tracing fields. Bounded enum so
+    /// the value is safe for the allowlist filter.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Transient => "transient",
+            Self::Permanent => "permanent",
+            Self::Conflict => "conflict",
+            Self::Auth => "auth",
+        }
+    }
+}
+
+/// Item / pipeline-level error type for the MS Graph delta sync.
+///
+/// Variants split by *cause*, not by *call site*: an HTTP failure is
+/// a single variant whether it came from the user fetcher or the
+/// device fetcher, and the call-site context goes on the
+/// `ItemFailure` wrapper. That keeps the retry classifier a pure
+/// function of the error and lets the retry/backoff code stay
+/// generic.
+#[derive(Debug, Error)]
+pub enum MsGraphSyncError {
+    /// MS Graph or the OAuth provider returned a token failure
+    /// (401, refresh failed, no provider configured). Affects every
+    /// item in the run, so the executor surfaces this at the job
+    /// level and aborts.
+    #[error("auth: {hint}")]
+    Auth {
+        hint: &'static str,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    },
+
+    /// MS Graph returned a transient HTTP status (429, 500..=599,
+    /// connection reset). Retried by the executor with backoff.
+    #[error("transient http: status {status}")]
+    HttpTransient {
+        status: u16,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// MS Graph returned a permanent HTTP status (400, 404, 410).
+    /// Item is skipped; next tick may pick up its replacement.
+    #[error("permanent http: status {status}")]
+    HttpPermanent {
+        status: u16,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// reqwest itself errored (DNS, TLS handshake, connection
+    /// refused). Treated as transient.
+    #[error("network: {kind}")]
+    Network {
+        kind: NetworkErrorKind,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    /// Local DB rejected a write — unique violation, FK miss, check
+    /// constraint, etc. Conflict-classified: next tick after the
+    /// racing state settles can succeed.
+    #[error("database conflict")]
+    DbConflict {
+        #[source]
+        source: diesel::result::Error,
+    },
+
+    /// Local DB failed for an infrastructural reason (pool, dead
+    /// connection, server going away). Transient at the item level
+    /// in theory; in practice it usually means the whole run is
+    /// hosed, so we promote to Auth-class at the executor boundary.
+    #[error("database infra")]
+    DbInfra {
+        #[source]
+        source: diesel::result::Error,
+    },
+
+    /// Couldn't parse or map a Graph payload into our domain model.
+    /// Permanent: retrying won't help.
+    #[error("mapping: {hint}")]
+    Mapping {
+        hint: &'static str,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    },
+
+    /// A serde JSON parse failed on a Graph response body. Permanent.
+    #[error("parse: graph response")]
+    Parse {
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// The cancellation token fired; pipeline unwinds gracefully.
+    /// Not a real failure but flows through the same channel so
+    /// per-item callers don't need two code paths.
+    #[error("cancelled")]
+    Cancelled,
+}
+
+/// Network-layer error sub-kind, since reqwest::Error covers a wide
+/// range and we want the structured tracing field to be bounded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkErrorKind {
+    Timeout,
+    Connect,
+    Tls,
+    Body,
+    Other,
+}
+
+impl fmt::Display for NetworkErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Timeout => "timeout",
+            Self::Connect => "connect",
+            Self::Tls => "tls",
+            Self::Body => "body",
+            Self::Other => "other",
+        })
+    }
+}
+
+impl NetworkErrorKind {
+    /// Cheap classifier over reqwest::Error. Order matters: timeout
+    /// has its own predicate, so check it before falling through.
+    pub fn from_reqwest(e: &reqwest::Error) -> Self {
+        if e.is_timeout() {
+            Self::Timeout
+        } else if e.is_connect() {
+            Self::Connect
+        } else if e.is_body() {
+            Self::Body
+        } else if e.to_string().to_lowercase().contains("tls")
+            || e.to_string().to_lowercase().contains("certificate")
+        {
+            // reqwest doesn't expose a typed TLS predicate; fall
+            // back to substring on the message. Rough but bounded
+            // because we only emit the *enum tag* into tracing, not
+            // the raw message.
+            Self::Tls
+        } else {
+            Self::Other
+        }
+    }
+}
+
+impl MsGraphSyncError {
+    /// Pure classifier — the executor reads this to decide between
+    /// retry / skip / abort. Keep the match exhaustive so adding a
+    /// new variant forces the classification decision at the type
+    /// system level.
+    pub fn classify(&self) -> Classification {
+        match self {
+            Self::Auth { .. } | Self::DbInfra { .. } => Classification::Auth,
+            Self::HttpTransient { .. } | Self::Network { .. } | Self::Cancelled => {
+                Classification::Transient
+            }
+            Self::HttpPermanent { .. } | Self::Mapping { .. } | Self::Parse { .. } => {
+                Classification::Permanent
+            }
+            Self::DbConflict { .. } => Classification::Conflict,
+        }
+    }
+
+    /// Convenience: bounded-enum tag for the structured `error_kind`
+    /// tracing field. Maps 1:1 to the variant; cheaper than calling
+    /// classify() at every log site.
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            Self::Auth { .. } => "auth",
+            Self::HttpTransient { .. } => "http_transient",
+            Self::HttpPermanent { .. } => "http_permanent",
+            Self::Network { .. } => "network",
+            Self::DbConflict { .. } => "db_conflict",
+            Self::DbInfra { .. } => "db_infra",
+            Self::Mapping { .. } => "mapping",
+            Self::Parse { .. } => "parse",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// Construct a typed HTTP error from a status code. Splits
+    /// transient (429 / 5xx) from permanent (everything else with
+    /// an error class) at the boundary so callers don't have to
+    /// repeat the predicate.
+    pub fn from_status<E>(status: u16, source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        let source = Box::new(source);
+        if status == 429 || (500..=599).contains(&status) {
+            Self::HttpTransient { status, source }
+        } else {
+            Self::HttpPermanent { status, source }
+        }
+    }
+}
+
+impl From<reqwest::Error> for MsGraphSyncError {
+    fn from(e: reqwest::Error) -> Self {
+        // If reqwest already saw the status, prefer the status-based
+        // classification — it's more specific than the network kind.
+        if let Some(status) = e.status() {
+            return Self::from_status(status.as_u16(), e);
+        }
+        Self::Network {
+            kind: NetworkErrorKind::from_reqwest(&e),
+            source: e,
+        }
+    }
+}
+
+impl From<serde_json::Error> for MsGraphSyncError {
+    fn from(source: serde_json::Error) -> Self {
+        Self::Parse { source }
+    }
+}
+
+impl From<diesel::result::Error> for MsGraphSyncError {
+    fn from(source: diesel::result::Error) -> Self {
+        use diesel::result::{DatabaseErrorKind as Dk, Error as De};
+        match &source {
+            De::DatabaseError(
+                Dk::UniqueViolation
+                | Dk::ForeignKeyViolation
+                | Dk::CheckViolation
+                | Dk::NotNullViolation,
+                _,
+            )
+            | De::NotFound => Self::DbConflict { source },
+            // ClosedConnection / BrokenPipe / generic SerializationFailure
+            // are infrastructural failures; we promote them so the
+            // executor can abort the run rather than treating them
+            // as recoverable item-level conflicts.
+            _ => Self::DbInfra { source },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_classifier_splits_transient_and_permanent() {
+        // Build a synthetic permanent / transient pair using a
+        // serde_json::Error as the inner source; the variant choice
+        // is what we're verifying, not the source content.
+        let err = MsGraphSyncError::from_status(
+            429,
+            std::io::Error::new(std::io::ErrorKind::Other, "rate limited"),
+        );
+        assert!(matches!(
+            err,
+            MsGraphSyncError::HttpTransient { status: 429, .. }
+        ));
+        assert_eq!(err.classify(), Classification::Transient);
+
+        let err = MsGraphSyncError::from_status(
+            404,
+            std::io::Error::new(std::io::ErrorKind::Other, "gone"),
+        );
+        assert!(matches!(
+            err,
+            MsGraphSyncError::HttpPermanent { status: 404, .. }
+        ));
+        assert_eq!(err.classify(), Classification::Permanent);
+
+        let err = MsGraphSyncError::from_status(
+            503,
+            std::io::Error::new(std::io::ErrorKind::Other, "down"),
+        );
+        assert_eq!(err.classify(), Classification::Transient);
+    }
+
+    #[test]
+    fn diesel_unique_violation_is_conflict_not_infra() {
+        let inner = diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            Box::new("dup".to_string()),
+        );
+        let err = MsGraphSyncError::from(inner);
+        assert_eq!(err.classify(), Classification::Conflict);
+        assert_eq!(err.kind_str(), "db_conflict");
+    }
+
+    #[test]
+    fn display_never_includes_pii() {
+        // Sanity check: the classifier-only Display contract means
+        // a user-facing field like "display_name" must not appear
+        // in the rendered string. We test the auth + mapping
+        // variants since they carry a `hint` literal under our
+        // control.
+        let err = MsGraphSyncError::Auth {
+            hint: "token expired",
+            source: None,
+        };
+        let s = err.to_string();
+        assert_eq!(s, "auth: token expired");
+        assert!(!s.contains("user@example.com"));
+    }
+}

--- a/backend/src/services/msgraph/error.rs
+++ b/backend/src/services/msgraph/error.rs
@@ -276,6 +276,59 @@ impl From<serde_json::Error> for MsGraphSyncError {
     }
 }
 
+/// Thin `std::error::Error` wrapper around a `String`. Used by the
+/// `From<String> for MsGraphSyncError` impl so legacy call sites
+/// whose inner error type is just `Result<_, String>` can flow
+/// through the typed pipeline without losing the original message.
+/// Display of `MsGraphSyncError::Mapping` itself never includes this
+/// string — only the source chain does — so a future PR can pivot
+/// the legacy site to a more specific variant (HttpPermanent,
+/// DbConflict, ...) by reading the source's classification.
+#[derive(Debug)]
+struct OpaqueStringError(String);
+
+impl fmt::Display for OpaqueStringError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for OpaqueStringError {}
+
+impl From<String> for MsGraphSyncError {
+    fn from(msg: String) -> Self {
+        Self::Mapping {
+            hint: "legacy string error",
+            source: Some(Box::new(OpaqueStringError(msg))),
+        }
+    }
+}
+
+impl From<&str> for MsGraphSyncError {
+    fn from(msg: &str) -> Self {
+        Self::from(msg.to_string())
+    }
+}
+
+impl From<anyhow::Error> for MsGraphSyncError {
+    /// Generic fallback for legacy call sites whose inner error type
+    /// has already been erased through `anyhow`. Maps to `Mapping`
+    /// (Permanent classification) since by the time we've lost
+    /// type info we can't safely retry; future PRs that need
+    /// retry on a specific site should add a typed variant + a
+    /// matching From impl above this fallback.
+    fn from(err: anyhow::Error) -> Self {
+        // anyhow::Error -> Box<dyn Error> uses the standard impl
+        // anyhow ships; we wrap in Option since `Mapping.source` is
+        // optional to support the "we know the hint but the source
+        // is gone" call site (rare, but valid).
+        Self::Mapping {
+            hint: "legacy anyhow error",
+            source: Some(Into::<Box<dyn std::error::Error + Send + Sync>>::into(err)),
+        }
+    }
+}
+
 impl From<diesel::result::Error> for MsGraphSyncError {
     fn from(source: diesel::result::Error) -> Self {
         use diesel::result::{DatabaseErrorKind as Dk, Error as De};

--- a/backend/src/services/msgraph/mod.rs
+++ b/backend/src/services/msgraph/mod.rs
@@ -1,0 +1,27 @@
+//! Microsoft Graph delta-sync infrastructure.
+//!
+//! The HTTP handlers + per-entity fetch/upsert logic still live in
+//! `crate::handlers::msgraph_integration` (that's the historical
+//! 5k-LOC module). This module owns the *cohesive sync machinery*
+//! that wraps it:
+//!
+//!   * [`error`] — typed `MsGraphSyncError` with thiserror, with a
+//!     [`Classification`](error::Classification) the executor reads.
+//!   * [`outcome`] — `EntityOutcome` / `SyncOutcome` carrying typed
+//!     per-item failures, replacing the old `Vec<String>` channel.
+//!   * [`retry`] — `with_retry` executor that runs an item-producing
+//!     closure with exponential backoff on transient failures and a
+//!     bounded attempt cap on permanent ones.
+//!
+//! The handler module imports these types and delegates classifying
+//! its existing reqwest/diesel errors through the `From` impls; no
+//! caller has to format an error as a `String` to push into a
+//! result struct any more.
+
+pub mod error;
+pub mod outcome;
+pub mod retry;
+
+pub use error::{Classification, MsGraphSyncError, NetworkErrorKind};
+pub use outcome::{EntityKind, EntityOutcome, ItemFailure, SyncOutcome};
+pub use retry::{with_retry, RetryConfig};

--- a/backend/src/services/msgraph/mod.rs
+++ b/backend/src/services/msgraph/mod.rs
@@ -20,8 +20,10 @@
 
 pub mod error;
 pub mod outcome;
+pub mod pipeline;
 pub mod retry;
 
 pub use error::{Classification, MsGraphSyncError, NetworkErrorKind};
 pub use outcome::{EntityKind, EntityOutcome, ItemFailure, SyncOutcome};
+pub use pipeline::{log_outcome_summary, record_failure};
 pub use retry::{with_retry, RetryConfig};

--- a/backend/src/services/msgraph/outcome.rs
+++ b/backend/src/services/msgraph/outcome.rs
@@ -1,0 +1,190 @@
+//! Structured outcomes for a delta-sync run.
+//!
+//! These replace the previous `SyncProgress { errors: Vec<String> }`
+//! / `SyncResult { total_errors: usize, message: String }` shape with
+//! a typed equivalent: per-item failures carry an `MsGraphSyncError`
+//! (not a string) plus identity + attempt count, and the aggregate
+//! `SyncOutcome` is the source of truth that the admin-UI response
+//! struct (`handlers::msgraph_integration::SyncResult`) is projected
+//! from at the boundary.
+//!
+//! Two layers, deliberately:
+//!
+//!   * **`EntityOutcome`** — the result of syncing one entity
+//!     (users / devices / groups) within a run. Carries its own
+//!     processed + failure list so the executor can stitch them
+//!     together without flattening.
+//!   * **`SyncOutcome`** — the result of the whole run. Wraps a
+//!     `Vec<EntityOutcome>` plus timing and cancellation state.
+//!
+//! Neither layer talks to anyhow. Job-level Err is reserved for
+//! "the sync couldn't even start" (token unavailable, DB pool
+//! exhausted, machinery bug); a sync that ran to completion always
+//! returns `Ok(SyncOutcome)`, with item failures recorded inside.
+
+use std::fmt;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+
+use super::error::{Classification, MsGraphSyncError};
+
+/// Entity kinds the delta sync knows how to pull. Bounded enum so
+/// it's safe to emit on the `entity` tracing field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EntityKind {
+    Users,
+    Devices,
+    Groups,
+}
+
+impl EntityKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Users => "users",
+            Self::Devices => "devices",
+            Self::Groups => "groups",
+        }
+    }
+
+    /// Parse the wire identifier used by the admin UI's "select
+    /// which entities to sync" request. Returns None on unknown
+    /// values so the handler boundary can reject them with a 400.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "users" => Some(Self::Users),
+            "devices" => Some(Self::Devices),
+            "groups" => Some(Self::Groups),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for EntityKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A single item that the sync tried and failed to process.
+///
+/// `external_id` is the MS Graph stable identifier (a GUID-shaped
+/// string). It's tenant data but not user-typed; it's allowlisted
+/// on the tracing layer alongside other tenant-stable identifiers
+/// (user_uuid, ticket_id, etc.).
+///
+/// `attempt` records how many tries the retry executor made before
+/// giving up — so an admin reviewing a run can tell "this failed
+/// once on a 429" from "this failed five times and we still
+/// couldn't get it through".
+#[derive(Debug)]
+pub struct ItemFailure {
+    pub entity: EntityKind,
+    pub external_id: String,
+    pub error: MsGraphSyncError,
+    pub attempt: u32,
+}
+
+impl ItemFailure {
+    pub fn classification(&self) -> Classification {
+        self.error.classify()
+    }
+
+    pub fn kind_str(&self) -> &'static str {
+        self.error.kind_str()
+    }
+}
+
+/// Result of syncing one entity within a run. Always returned by
+/// the per-entity sync functions, even when nothing went wrong
+/// (failures is empty in that case).
+#[derive(Debug)]
+pub struct EntityOutcome {
+    pub entity: EntityKind,
+    /// Items that landed in the DB successfully (new or updated).
+    pub processed: usize,
+    /// Item-level failures. Always typed; never strings.
+    pub failures: Vec<ItemFailure>,
+    /// Did the cancellation token fire mid-entity?
+    pub cancelled: bool,
+}
+
+impl EntityOutcome {
+    pub fn empty(entity: EntityKind) -> Self {
+        Self {
+            entity,
+            processed: 0,
+            failures: Vec::new(),
+            cancelled: false,
+        }
+    }
+
+    pub fn failed(&self) -> usize {
+        self.failures.len()
+    }
+
+    pub fn ok(&self) -> bool {
+        self.failures.is_empty() && !self.cancelled
+    }
+}
+
+/// Result of a whole sync run. Built by the executor by walking the
+/// requested entity list and accumulating the per-entity outcomes;
+/// never returned directly from a handler — the
+/// `handlers::msgraph_integration::SyncResult` wire shape is
+/// projected from this at the API boundary so the admin UI's
+/// response stays stable.
+#[derive(Debug)]
+pub struct SyncOutcome {
+    pub started_at: DateTime<Utc>,
+    pub finished_at: DateTime<Utc>,
+    pub elapsed: Duration,
+    pub cancelled: bool,
+    pub entities: Vec<EntityOutcome>,
+}
+
+impl SyncOutcome {
+    /// Total items written to the local DB across all entities.
+    pub fn processed(&self) -> usize {
+        self.entities.iter().map(|e| e.processed).sum()
+    }
+
+    /// Total per-item failures across all entities.
+    pub fn failed(&self) -> usize {
+        self.entities.iter().map(EntityOutcome::failed).sum()
+    }
+
+    pub fn ok(&self) -> bool {
+        !self.cancelled && self.entities.iter().all(EntityOutcome::ok)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entity_kind_round_trip() {
+        assert_eq!(EntityKind::parse("users"), Some(EntityKind::Users));
+        assert_eq!(EntityKind::parse("devices"), Some(EntityKind::Devices));
+        assert_eq!(EntityKind::parse("groups"), Some(EntityKind::Groups));
+        assert_eq!(EntityKind::parse("bogus"), None);
+        assert_eq!(EntityKind::Users.as_str(), "users");
+    }
+
+    #[test]
+    fn entity_outcome_ok_only_with_no_failures_and_not_cancelled() {
+        let mut o = EntityOutcome::empty(EntityKind::Users);
+        assert!(o.ok());
+        o.cancelled = true;
+        assert!(!o.ok());
+        o.cancelled = false;
+        o.failures.push(ItemFailure {
+            entity: EntityKind::Users,
+            external_id: "abc".into(),
+            error: MsGraphSyncError::Cancelled,
+            attempt: 1,
+        });
+        assert!(!o.ok());
+    }
+}

--- a/backend/src/services/msgraph/pipeline.rs
+++ b/backend/src/services/msgraph/pipeline.rs
@@ -1,0 +1,142 @@
+//! Sync pipeline glue: the typed-error / typed-outcome layer that
+//! wraps the existing `crate::handlers::msgraph_integration` sync
+//! functions.
+//!
+//! The pre-pipeline error-collection pattern was:
+//! ```ignore
+//! let error_msg = format!("Failed to ... user {}: {}", user.name, e);
+//! warn!("{}", error_msg);          // leaks user.name into the message body
+//! stats.errors.push(error_msg);    // string-typed, classifier-free
+//! ```
+//! ten times across users / devices / groups. That conflated four
+//! responsibilities — emit a log line, classify the error, identify
+//! the failing item, persist the failure for the admin UI — into
+//! one ad-hoc snippet, and leaked user-typed content (`user.name`,
+//! `device_name`, `group_name`) into both the log body and the
+//! Vec<String> the admin UI eventually displays.
+//!
+//! [`record_failure`] centralises the same job in one well-typed
+//! call. The caller hands it the failing entity, the upstream
+//! stable identifier, and the typed `MsGraphSyncError`; the helper
+//! emits a structured-fields-only `tracing::warn` event (no user-
+//! typed content in the body) and returns an [`ItemFailure`] for
+//! the caller to push into its outcome list.
+//!
+//! Call sites end up looking like:
+//! ```ignore
+//! match upsert_user(conn, &ms_user).await {
+//!     Ok(()) => stats.existing_users_updated += 1,
+//!     Err(e) => stats
+//!         .failures
+//!         .push(pipeline::record_failure(EntityKind::Users, &ms_user.id, e, 1)),
+//! }
+//! ```
+
+use tracing::warn;
+
+use super::error::MsGraphSyncError;
+use super::outcome::{EntityKind, ItemFailure};
+
+/// Emit a structured warn for a per-item failure and produce the
+/// matching `ItemFailure`. One call, four responsibilities done
+/// uniformly:
+///
+///   1. Bounded-fields tracing event with `entity`, `external_id`,
+///      `error_kind`, `classification`, `attempt`. No user-typed
+///      content in the message body — Display of the error is
+///      classifier-only by design.
+///   2. The returned `ItemFailure` carries the same context for
+///      the admin-UI / outcome aggregate.
+///   3. The `error_kind` + `classification` tags route to the right
+///      operator playbook (transient -> wait for next tick;
+///      permanent -> investigate upstream; conflict -> wait for
+///      racing state; auth -> page operator).
+///   4. The pipeline reads `attempt` to distinguish a one-shot
+///      failure from one that survived the retry executor.
+///
+/// `external_id` is borrowed because it's already in a struct on
+/// the caller's stack; the helper clones it onto the failure
+/// record so the caller can drop the source struct without a
+/// lifetime fight.
+pub fn record_failure(
+    entity: EntityKind,
+    external_id: &str,
+    error: MsGraphSyncError,
+    attempt: u32,
+) -> ItemFailure {
+    let cls = error.classify();
+    warn!(
+        entity = entity.as_str(),
+        external_id,
+        attempt,
+        error_kind = error.kind_str(),
+        classification = cls.as_str(),
+        "msgraph sync item failed"
+    );
+    ItemFailure {
+        entity,
+        external_id: external_id.to_string(),
+        error,
+        attempt,
+    }
+}
+
+/// Aggregate a slice of `ItemFailure`s into structured tracing
+/// summaries by classification. Useful at the end-of-run boundary
+/// when the executor has the whole outcome in hand: one event per
+/// classification bucket beats N events for N failures when the
+/// admin only wants the headline.
+pub fn log_outcome_summary(entity: EntityKind, failures: &[ItemFailure], processed: usize) {
+    use super::error::Classification::*;
+    let mut transient = 0usize;
+    let mut permanent = 0usize;
+    let mut conflict = 0usize;
+    let mut auth = 0usize;
+    for f in failures {
+        match f.classification() {
+            Transient => transient += 1,
+            Permanent => permanent += 1,
+            Conflict => conflict += 1,
+            Auth => auth += 1,
+        }
+    }
+    if failures.is_empty() {
+        return;
+    }
+    warn!(
+        entity = entity.as_str(),
+        processed,
+        failed = failures.len(),
+        // Per-bucket counts are themselves bounded numerics; the
+        // labels match the classifier tag values in the per-item
+        // warns so an operator can `grep classification=transient`
+        // and find the matching item rows.
+        transient,
+        permanent,
+        conflict,
+        auth,
+        "msgraph entity sync finished with failures"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_failure_carries_through_attempt_and_external_id() {
+        let f = record_failure(
+            EntityKind::Users,
+            "graph-user-123",
+            MsGraphSyncError::HttpPermanent {
+                status: 404,
+                source: Box::new(std::io::Error::new(std::io::ErrorKind::Other, "gone")),
+            },
+            2,
+        );
+        assert_eq!(f.entity, EntityKind::Users);
+        assert_eq!(f.external_id, "graph-user-123");
+        assert_eq!(f.attempt, 2);
+        assert_eq!(f.kind_str(), "http_permanent");
+    }
+}

--- a/backend/src/services/msgraph/retry.rs
+++ b/backend/src/services/msgraph/retry.rs
@@ -1,0 +1,258 @@
+//! Per-item retry executor.
+//!
+//! Wraps an async closure that produces a single item with the
+//! retry policy derived from [`MsGraphSyncError::classify`]:
+//!
+//!   * `Transient` — retry with exponential backoff up to
+//!     [`RetryConfig::max_attempts`]; the last attempt's error is
+//!     returned to the caller, carrying the attempt count.
+//!   * `Permanent` / `Conflict` / `Auth` — give up immediately.
+//!     There's nothing useful to do by trying again, and a
+//!     conflict in particular needs the racing state to settle
+//!     between runs (which won't happen if we keep hammering it).
+//!
+//! Cancellation: the executor checks the supplied
+//! [`tokio_util::sync::CancellationToken`] between attempts and
+//! short-circuits with `MsGraphSyncError::Cancelled` rather than
+//! starting another backoff. The token is the same shape the rest
+//! of the codebase already uses for graceful-shutdown plumbing, so
+//! the executor composes with the scheduler's shutdown signal
+//! without a bespoke channel.
+//!
+//! The function returns the typed error directly (no anyhow); the
+//! pipeline above is what wraps the attempt count into an
+//! [`ItemFailure`].
+
+use std::future::Future;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+use super::error::{Classification, MsGraphSyncError};
+
+/// Retry policy. Defaults are tuned for MS Graph: rate-limit retries
+/// rarely need more than ~3 tries with low-second-range backoff to
+/// clear; longer waits push us past the scheduler's own tick.
+#[derive(Debug, Clone, Copy)]
+pub struct RetryConfig {
+    /// Total attempts including the first try. `max_attempts = 1`
+    /// disables retry entirely.
+    pub max_attempts: u32,
+    /// Initial backoff applied between attempt 1 and attempt 2.
+    pub initial_backoff: Duration,
+    /// Multiplier applied to the previous backoff to produce the
+    /// next one. 2.0 gives doubling: 250ms -> 500ms -> 1s -> ...
+    pub backoff_multiplier: f64,
+    /// Upper bound on a single backoff. Without this, exponential
+    /// growth past 5-6 retries pushes us toward minute-range waits
+    /// — wasted time vs. waiting for the next delta tick instead.
+    pub max_backoff: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(250),
+            backoff_multiplier: 2.0,
+            max_backoff: Duration::from_secs(5),
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Disable retry. Useful for tests + for permanent-only call
+    /// sites (the executor's classify check would skip them anyway,
+    /// but a max_attempts=1 config makes intent explicit).
+    pub fn no_retry() -> Self {
+        Self {
+            max_attempts: 1,
+            initial_backoff: Duration::ZERO,
+            backoff_multiplier: 1.0,
+            max_backoff: Duration::ZERO,
+        }
+    }
+
+    /// Backoff to apply *before* the given attempt number (1-based).
+    /// Returns ZERO for attempt 1 since that's the initial try.
+    fn backoff_for(&self, attempt: u32) -> Duration {
+        if attempt <= 1 {
+            return Duration::ZERO;
+        }
+        let exponent = (attempt - 2) as i32;
+        let scale = self.backoff_multiplier.powi(exponent);
+        let nanos = (self.initial_backoff.as_nanos() as f64 * scale).min(u64::MAX as f64) as u64;
+        Duration::from_nanos(nanos).min(self.max_backoff)
+    }
+}
+
+/// Execute `f` with retry on transient failures. Returns the value
+/// of the first successful attempt, or the last error encountered
+/// (with `attempts` reflecting how many tries it took).
+///
+/// `item_label` is the bounded enum tag (e.g. "users", "devices")
+/// used for the structured warn line emitted on retry. The full
+/// external id of the item belongs on the caller side; this layer
+/// stays generic over the unit of work.
+pub async fn with_retry<F, Fut, T>(
+    item_label: &'static str,
+    config: RetryConfig,
+    cancel: &CancellationToken,
+    mut f: F,
+) -> Result<T, RetryFailure>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, MsGraphSyncError>>,
+{
+    let mut attempt: u32 = 1;
+    loop {
+        if cancel.is_cancelled() {
+            return Err(RetryFailure {
+                attempts: attempt,
+                error: MsGraphSyncError::Cancelled,
+            });
+        }
+
+        let backoff = config.backoff_for(attempt);
+        if !backoff.is_zero() {
+            tokio::select! {
+                _ = tokio::time::sleep(backoff) => {}
+                _ = cancel.cancelled() => {
+                    return Err(RetryFailure {
+                        attempts: attempt,
+                        error: MsGraphSyncError::Cancelled,
+                    });
+                }
+            }
+        }
+
+        match f().await {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                let cls = err.classify();
+                // Transient failures retry up to the cap; everything
+                // else (Permanent / Conflict / Auth) gives up
+                // immediately with `attempts` reflecting how many
+                // tries we actually made.
+                if cls == Classification::Transient && attempt < config.max_attempts {
+                    warn!(
+                        entity = item_label,
+                        attempt,
+                        max_attempts = config.max_attempts,
+                        error_kind = err.kind_str(),
+                        classification = cls.as_str(),
+                        "msgraph item failed, retrying"
+                    );
+                    attempt += 1;
+                    continue;
+                }
+                return Err(RetryFailure {
+                    attempts: attempt,
+                    error: err,
+                });
+            }
+        }
+    }
+}
+
+/// What the executor returns on failure: the typed error plus how
+/// many attempts it took. The pipeline wraps this into an
+/// `ItemFailure` along with the entity + external_id context.
+#[derive(Debug)]
+pub struct RetryFailure {
+    pub attempts: u32,
+    pub error: MsGraphSyncError,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn backoff_doubles_then_caps() {
+        let cfg = RetryConfig {
+            max_attempts: 6,
+            initial_backoff: Duration::from_millis(100),
+            backoff_multiplier: 2.0,
+            max_backoff: Duration::from_millis(500),
+        };
+        // Attempt 1 = no backoff (it's the first try).
+        assert_eq!(cfg.backoff_for(1), Duration::ZERO);
+        assert_eq!(cfg.backoff_for(2), Duration::from_millis(100));
+        assert_eq!(cfg.backoff_for(3), Duration::from_millis(200));
+        assert_eq!(cfg.backoff_for(4), Duration::from_millis(400));
+        // Capped at max_backoff from here on.
+        assert_eq!(cfg.backoff_for(5), Duration::from_millis(500));
+        assert_eq!(cfg.backoff_for(6), Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn transient_retries_then_succeeds() {
+        let cfg = RetryConfig {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(1),
+            backoff_multiplier: 1.0,
+            max_backoff: Duration::from_millis(1),
+        };
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_in = attempts.clone();
+        let result = with_retry::<_, _, ()>("test", cfg, &CancellationToken::new(), move || {
+            let attempts = attempts_in.clone();
+            async move {
+                let n = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                if n < 3 {
+                    Err(MsGraphSyncError::HttpTransient {
+                        status: 429,
+                        source: Box::new(std::io::Error::new(std::io::ErrorKind::Other, "rate")),
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+        assert!(result.is_ok());
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn permanent_gives_up_after_one_try() {
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_in = attempts.clone();
+        let result = with_retry::<_, _, ()>(
+            "test",
+            RetryConfig::default(),
+            &CancellationToken::new(),
+            move || {
+                let attempts = attempts_in.clone();
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Err(MsGraphSyncError::HttpPermanent {
+                        status: 404,
+                        source: Box::new(std::io::Error::new(std::io::ErrorKind::Other, "gone")),
+                    })
+                }
+            },
+        )
+        .await;
+        assert!(result.is_err());
+        let failure = result.unwrap_err();
+        assert_eq!(failure.attempts, 1);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cancellation_short_circuits() {
+        let token = CancellationToken::new();
+        token.cancel();
+        let result = with_retry::<_, _, ()>("test", RetryConfig::default(), &token, || async {
+            panic!("closure should never run when token is pre-cancelled");
+        })
+        .await;
+        let failure = result.unwrap_err();
+        assert!(matches!(failure.error, MsGraphSyncError::Cancelled));
+    }
+}

--- a/backend/src/services/scheduler.rs
+++ b/backend/src/services/scheduler.rs
@@ -156,7 +156,16 @@ where
     match &result {
         Ok(()) => debug!(task = name, elapsed_ms = %elapsed.as_millis(), "scheduler: ok"),
         Err(e) => {
-            error!(task = name, error = ?e, elapsed_ms = %elapsed.as_millis(), "scheduler: failed; retrying next tick")
+            // Display (`%e`), not Debug (`?e`). anyhow's Debug walks
+            // the full source chain AND prints the captured backtrace,
+            // which lit up the scheduler logs with 60-frame stack
+            // traces for what was usually a one-line operational
+            // failure ("sync completed with errors", "db pool
+            // exhausted"). Display gives the message + source chain
+            // without the backtrace; if an operator wants the full
+            // chain they can re-run with RUST_LOG=debug or inspect
+            // the status registry's last_error field.
+            error!(task = name, error = %e, elapsed_ms = %elapsed.as_millis(), "scheduler: failed; retrying next tick")
         }
     }
     record(statuses, name, elapsed, result.as_ref().err());

--- a/backend/src/utils/tracing_redact.rs
+++ b/backend/src/utils/tracing_redact.rs
@@ -87,6 +87,8 @@ const ALLOWED_FIELDS: &[&str] = &[
     // bounded enums + operational dimensions. No free text.
     "aggregate",
     "category",
+    "classification",
+    "entity",
     "event_type",
     "kind",
     "op",
@@ -94,14 +96,23 @@ const ALLOWED_FIELDS: &[&str] = &[
     "recurrence",
     "role",
     "status",
+    // External (third-party-provider) stable identifiers. Like the
+    // intra-tenant uuids above, these are stable IDs assigned by
+    // the upstream system (MS Graph, etc.), not user-typed content.
+    "external_id",
     // counts, timings, structured outcomes. Cardinality is bounded;
     // values cannot leak user content.
+    "attempt",
+    "cancelled",
     "code",
     "count",
     "elapsed_ms",
     "error",
     "error_kind",
+    "failed",
+    "processed",
     "stamped",
+    "total",
     // HTTP / operational context for tracing-actix-web compatibility.
     "latency_ms",
     "method",


### PR DESCRIPTION
## Summary
The MS Graph delta-sync was dumping 60-frame backtraces into the scheduler log every time a partial-failure run produced even one item failure. Three layered design problems caused it; this PR fixes the immediate noise AND lands the typed-error / retry infrastructure that makes the partial-failure path properly observable.

**1. Immediate noise fix (`817eaf78`)**

`run_scheduled_delta_sync` was mapping "sync ran with N item failures" into `anyhow::anyhow!(...)`. anyhow captures a backtrace at construction; the scheduler then logged with `error = ?e` (Debug), which on anyhow walks the source chain AND prints the backtrace. Now: a sync that RAN returns Ok with a single structured warn line carrying provider_id + processed + failed counts. Only "couldn't even start" returns Err. Scheduler logs with Display (`%e`) so even legitimate Err lines stay readable.

**2. Typed error + retry infrastructure (`dae7ea3e`)**

New `services/msgraph/` module hierarchy:
- `error.rs` — `MsGraphSyncError` (thiserror) with eight variants classified by `classify()` into Transient / Permanent / Conflict / Auth. `From` impls for reqwest::Error / serde_json::Error / diesel::result::Error route at the boundary. Display is classifier-only — never includes user-typed content — so events flow through the tracing-allowlist JSON layer without leaking PII.
- `outcome.rs` — `ItemFailure { entity, external_id, error, attempt }`, `EntityOutcome`, `SyncOutcome`. Replaces the prior `Vec<String>` failure channel.
- `retry.rs` — `with_retry()` executor reads `classify()` to decide retry vs. give-up. Transient retries with exponential backoff (capped at max_backoff so growth past a few retries doesn't push past the scheduler tick); everything else gives up immediately. Cancellation short-circuits between attempts.
- `pipeline.rs` — `record_failure` helper emits structured fields-only `warn!` events; `SyncStatsExt` trait gives the three stats structs a `record_failure(...)` method that populates both the new typed channel and the legacy `errors: Vec<String>` channel in lockstep.
- tracing_redact allowlist gains entity / external_id / classification / attempt / failed / processed / cancelled / total.

Tests cover: status-code classifier splits, diesel UniqueViolation -> Conflict, Display omits PII, backoff doubles then caps, transient-then-success uses the right attempt count, permanent gives up after one try, cancellation short-circuits.

**3. Inner-function migration (`b0362193`, `c5fbcc8b`)**

Every per-item processing function returns `Result<_, MsGraphSyncError>` end-to-end, with errors classified at their source (diesel / serde / parse / reqwest) via the typed `From` impls instead of `format!`-stringified into a `String`. Touches:
- User chain: `process_microsoft_user_optimized_v2`, `update_existing_microsoft_user_optimized`, `link_existing_user_to_microsoft_optimized`, `create_new_user_from_microsoft_optimized`, plus the parallel `_no_photos` chain.
- Devices: `process_entra_device`.
- Groups: `sync_group_membership`, `sync_device_group_membership`, `apply_delta_group_membership`, `fetch_group_members`.

The 10 outer push sites (sync_users / sync_devices / sync_groups loops) go through `stats.record_failure(...)` which emits structured tracing (entity / external_id / attempt / error_kind / classification) and mirrors a classifier-only line into the legacy errors Vec<String> for admin UI compat.

**4. First load-bearing retry site (`40ec21dd`)**

`fetch_group_members` is now wrapped in `with_retry` at both call sites (`sync_group_membership` and `sync_device_group_membership`). It already classifies status responses via `from_status` (429/5xx -> HttpTransient, 4xx -> HttpPermanent), so the executor's classify-driven retry policy does the right thing: rate-limit and transient 5xx retry with exponential backoff up to a 5s cap; permanent failures give up immediately.

## What's deliberately NOT in this PR

These are tracked for follow-up so the scope stays reviewable:

1. **Cancellation plumbing** — `with_retry` requires a `CancellationToken`. The scheduler's shutdown token and the admin UI's `SYNC_CANCELLATION` static aren't wired into the sync flow yet; the retry call sites pass a fresh token that never fires. A follow-up will spawn a child token at the entry of `perform_sync` that watches both sources. Inner sleeps are bounded by `RetryConfig::max_backoff` (5s) so the retry chain can't outlive the scheduler's 30-min tick.

2. **Fetch-layer (page-of-items) retry** — `fetch_microsoft_graph_users_*` and friends still return `Result<_, String>` and are called via match (not `?`), so the From<String> bridge on MsGraphSyncError isn't exercised. Migrating these to typed errors lets the page fetch itself retry on transient 429s.

3. **Removing the legacy `errors: Vec<String>` field** — kept alongside `failures: Vec<ItemFailure>` for admin-UI back-compat. The admin UI consumer cutover is a separate change that touches the frontend.

## Test plan
- [x] cargo check clean across all commits
- [x] Unit tests for the error classifier, backoff math, retry policy, and pipeline helper compile + pass
- [ ] Manual: stop the dev MS Graph provider mid-sync, verify the scheduler log no longer dumps a 60-frame backtrace; verify a transient 429 (induced via the testing harness) causes a retry with the expected attempt counter