### PR TITLE
Security: authorization, visibility, SSRF, and hardening fixes (2026-06 audit)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -131,15 +131,22 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # pdfium for PDF thumbnails. https://github.com/bblanchon/pdfium-binaries
+# Pinned to a specific release and sha256-verified: `latest` plus no
+# checksum meant a compromised or republished upstream release would
+# land silently in the image, and builds were non-reproducible. To bump:
+# choose a new tag, then update PDFIUM_VERSION and both checksums from
+# that release's asset digests. See security-audit-2026-06.
 ARG TARGETARCH
+ARG PDFIUM_VERSION=chromium/7881
 RUN case "$TARGETARCH" in \
-      arm64) PDFIUM_PKG=pdfium-linux-arm64.tgz ;; \
-      amd64) PDFIUM_PKG=pdfium-linux-x64.tgz ;; \
+      arm64) PDFIUM_PKG=pdfium-linux-arm64.tgz; PDFIUM_SHA256=ee7f7b7d5468958336a818c1cd580bdd20972846b7377b13f9a923d92d1d4674 ;; \
+      amd64) PDFIUM_PKG=pdfium-linux-x64.tgz;   PDFIUM_SHA256=1470e21b8b4a3b4ad7f85684e2da11d94f3b69a86d81dee11b9b6709d927ac1d ;; \
       *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2 && exit 1 ;; \
     esac && \
     mkdir -p /tmp/pdfium && \
     cd /tmp/pdfium && \
-    wget -q "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/$PDFIUM_PKG" && \
+    wget -q "https://github.com/bblanchon/pdfium-binaries/releases/download/${PDFIUM_VERSION}/$PDFIUM_PKG" && \
+    echo "${PDFIUM_SHA256}  ${PDFIUM_PKG}" | sha256sum -c - && \
     tar -xzf "$PDFIUM_PKG" && \
     cp lib/libpdfium.so /usr/local/lib/ && \
     ldconfig && \

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -13,15 +13,19 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # pdfium for PDF thumbnails. https://github.com/bblanchon/pdfium-binaries
+# Pinned + sha256-verified; keep in sync with backend/Dockerfile. See
+# security-audit-2026-06.
 ARG TARGETARCH
+ARG PDFIUM_VERSION=chromium/7881
 RUN case "$TARGETARCH" in \
-      arm64) PDFIUM_PKG=pdfium-linux-arm64.tgz ;; \
-      amd64) PDFIUM_PKG=pdfium-linux-x64.tgz ;; \
+      arm64) PDFIUM_PKG=pdfium-linux-arm64.tgz; PDFIUM_SHA256=ee7f7b7d5468958336a818c1cd580bdd20972846b7377b13f9a923d92d1d4674 ;; \
+      amd64) PDFIUM_PKG=pdfium-linux-x64.tgz;   PDFIUM_SHA256=1470e21b8b4a3b4ad7f85684e2da11d94f3b69a86d81dee11b9b6709d927ac1d ;; \
       *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2 && exit 1 ;; \
     esac && \
     mkdir -p /tmp/pdfium && \
     cd /tmp/pdfium && \
-    wget -q "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/$PDFIUM_PKG" && \
+    wget -q "https://github.com/bblanchon/pdfium-binaries/releases/download/${PDFIUM_VERSION}/$PDFIUM_PKG" && \
+    echo "${PDFIUM_SHA256}  ${PDFIUM_PKG}" | sha256sum -c - && \
     tar -xzf "$PDFIUM_PKG" && \
     cp lib/libpdfium.so /usr/local/lib/ && \
     ldconfig && \

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -535,8 +535,11 @@ pub async fn oauth_callback(
                         }
                     }
 
-                    // Extract user UUID from the redirect URL params if present
-                    // For added security, we get the UUID from the query string in redirect_uri if provided
+                    // The connecting user's UUID is carried in the
+                    // signed state's redirect_uri. oauth_connect sets it
+                    // authoritatively from the authenticated session and
+                    // strips any caller-supplied value, and the state JWT
+                    // is integrity-protected, so this value is trusted.
                     let user_uuid_param = if state_data.redirect_uri.contains('?') {
                         let query_params = state_data.redirect_uri.split('?').nth(1).unwrap_or("");
                         let params = querystring::querify(query_params);
@@ -548,11 +551,6 @@ pub async fn oauth_callback(
                         None
                     };
 
-                    // Get user UUID from SessionStorage on client side if not in URL
-                    // SessionStorage on the frontend should contain the authRedirect with the user's path
-
-                    // Add the identity to the user - for now we use a hardcoded false value
-                    // but in a real implementation you'd get the UUID from auth token
                     let user_uuid = match user_uuid_param {
                         Some(uuid) => uuid,
                         None => {
@@ -1319,6 +1317,30 @@ async fn add_oauth_identity_to_user(
     Ok(())
 }
 
+/// Remove every occurrence of `key` from the query string of a
+/// (possibly relative) URI, preserving the path and any other params.
+/// Used to strip a caller-supplied `user_uuid` from an OAuth connect
+/// redirect before we set it authoritatively from the authenticated
+/// session. Trusting a client-provided `user_uuid` is an account-
+/// linking takeover vector. See security-audit-2026-06.
+fn strip_query_param(uri: &str, key: &str) -> String {
+    match uri.split_once('?') {
+        None => uri.to_string(),
+        Some((path, query)) => {
+            let kept: Vec<&str> = query
+                .split('&')
+                .filter(|pair| !pair.is_empty())
+                .filter(|pair| pair.split('=').next().unwrap_or("") != key)
+                .collect();
+            if kept.is_empty() {
+                path.to_string()
+            } else {
+                format!("{path}?{}", kept.join("&"))
+            }
+        }
+    }
+}
+
 // Direct endpoint for connecting a new authentication method to an existing user
 pub async fn oauth_connect(
     db_pool: web::Data<Pool>,
@@ -1410,22 +1432,28 @@ pub async fn oauth_connect(
             }
         };
 
-        // Prepare redirect URI with user UUID
-        let mut actual_redirect_uri = oauth_request
-            .redirect_uri
-            .clone()
-            .unwrap_or_else(|| "/profile/settings".to_string());
-        if !actual_redirect_uri.contains("user_uuid=") {
-            let separator = if actual_redirect_uri.contains('?') {
-                "&"
-            } else {
-                "?"
-            };
-            actual_redirect_uri = format!(
-                "{}{}user_uuid={}",
-                actual_redirect_uri, separator, user.uuid
-            );
-        }
+        // Prepare the redirect URI. The connecting user's UUID is set
+        // authoritatively from the authenticated session; any caller-
+        // supplied user_uuid is stripped first. The callback links the
+        // IdP identity to whatever UUID the signed state carries, so
+        // trusting a client-provided value here would let an attacker
+        // link their own IdP account to a victim's UUID (account
+        // takeover). The state JWT is signed, so a server-set UUID
+        // cannot be tampered with at the callback. See
+        // security-audit-2026-06.
+        let base_redirect_uri = strip_query_param(
+            &oauth_request
+                .redirect_uri
+                .clone()
+                .unwrap_or_else(|| "/profile/settings".to_string()),
+            "user_uuid",
+        );
+        let separator = if base_redirect_uri.contains('?') {
+            "&"
+        } else {
+            "?"
+        };
+        let actual_redirect_uri = format!("{base_redirect_uri}{separator}user_uuid={}", user.uuid);
 
         // Generate a JWT state token with user_connection=true
         let state = match create_oauth_state(
@@ -1454,5 +1482,37 @@ pub async fn oauth_connect(
             "{} authentication is not implemented",
             provider.name
         ))
+    }
+}
+
+#[cfg(test)]
+mod connect_redirect_tests {
+    use super::strip_query_param;
+
+    #[test]
+    fn strips_caller_supplied_user_uuid() {
+        // No query: untouched.
+        assert_eq!(
+            strip_query_param("/profile/settings", "user_uuid"),
+            "/profile/settings"
+        );
+        // Sole param: query removed entirely.
+        assert_eq!(strip_query_param("/p?user_uuid=victim", "user_uuid"), "/p");
+        // Mixed params: only user_uuid dropped, order preserved.
+        assert_eq!(
+            strip_query_param("/p?foo=1&user_uuid=victim", "user_uuid"),
+            "/p?foo=1"
+        );
+        assert_eq!(
+            strip_query_param("/p?user_uuid=victim&foo=1", "user_uuid"),
+            "/p?foo=1"
+        );
+        // Repeated keys: all removed.
+        assert_eq!(
+            strip_query_param("/p?user_uuid=a&user_uuid=b", "user_uuid"),
+            "/p"
+        );
+        // Unrelated query: preserved.
+        assert_eq!(strip_query_param("/p?foo=1", "user_uuid"), "/p?foo=1");
     }
 }

--- a/backend/src/handlers/branding.rs
+++ b/backend/src/handlers/branding.rs
@@ -229,22 +229,23 @@ pub async fn upload_branding_image(
         debug!(content_type = %content_type, "Received file upload");
 
         // Validate content type based on image type
+        // SVG is intentionally excluded. An attacker-uploaded SVG is a
+        // stored-XSS vector when served inline (it can carry <script> /
+        // event handlers), and branding renders on the unauthenticated
+        // login screen. The global CSP + nosniff already blunt this, but
+        // not accepting SVG at all removes the vector outright. See
+        // security-audit-2026-06.
         let valid_types: &[&str] = if image_type == "favicon" {
-            &[
-                "image/x-icon",
-                "image/vnd.microsoft.icon",
-                "image/png",
-                "image/svg+xml",
-            ]
+            &["image/x-icon", "image/vnd.microsoft.icon", "image/png"]
         } else {
-            &["image/png", "image/svg+xml", "image/jpeg", "image/webp"]
+            &["image/png", "image/jpeg", "image/webp"]
         };
 
         if !valid_types.iter().any(|t| content_type.starts_with(t)) {
             let allowed = if image_type == "favicon" {
-                "ICO, PNG, or SVG"
+                "ICO or PNG"
             } else {
-                "PNG, SVG, JPEG, or WebP"
+                "PNG, JPEG, or WebP"
             };
             return errors::bad_request(format!(
                 "Invalid file type for {}. Allowed: {}",
@@ -448,18 +449,45 @@ async fn cleanup_old_branding_images(dir: &str, image_type: &str) {
     }
 }
 
+/// Validate a branding filename against the exact shape the upload
+/// handler writes: `{type}[_{timestamp}].{ext}` (e.g.
+/// `logo_1699999999.png`). A `starts_with` prefix check is not enough
+/// here because this handler reads from the filesystem directly: a
+/// value like `logo/../../../proc/self/environ` starts with an allowed
+/// prefix yet escapes the branding directory. Pairs with the
+/// `is_safe_storage_path` traversal guard in the caller.
+fn is_allowed_branding_filename(filename: &str) -> bool {
+    let (stem, ext) = match filename.rsplit_once('.') {
+        Some(parts) => parts,
+        None => return false,
+    };
+    if !matches!(ext, "png" | "ico" | "jpg" | "jpeg" | "webp" | "svg") {
+        return false;
+    }
+    // stem is exactly an allowed base, or base + "_" + all-digits.
+    ["logo_light", "logo", "favicon"].iter().any(|base| {
+        if stem == *base {
+            return true;
+        }
+        match stem.strip_prefix(base).and_then(|r| r.strip_prefix('_')) {
+            Some(rest) => !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()),
+            None => false,
+        }
+    })
+}
+
 // Serve branding files publicly (no auth required)
 pub async fn serve_branding_file(filename: web::Path<String>, _req: HttpRequest) -> impl Responder {
     let filename = filename.into_inner();
 
-    // Only allow specific branding files
-    let allowed_prefixes = ["logo", "logo_light", "favicon"];
-    let is_allowed = allowed_prefixes
-        .iter()
-        .any(|prefix| filename.starts_with(prefix));
-
-    if !is_allowed {
-        return errors::forbidden("Access denied");
+    // Defence in depth: reject any path traversal before the
+    // exact-shape allowlist. `{filename:.*}` captures `/` and `..`,
+    // and there is no NormalizePath middleware, so an unsanitised
+    // `fs::read` here is an arbitrary-file-read sink.
+    if !crate::utils::storage::is_safe_storage_path(&filename)
+        || !is_allowed_branding_filename(&filename)
+    {
+        return HttpResponse::NotFound().finish();
     }
 
     let file_path = format!("uploads/branding/{filename}");
@@ -487,5 +515,37 @@ pub async fn serve_branding_file(filename: web::Path<String>, _req: HttpRequest)
                 .body(content)
         }
         Err(_) => HttpResponse::NotFound().finish(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_allowed_branding_filename;
+
+    #[test]
+    fn rejects_traversal_and_unexpected_shapes() {
+        // Traversal payloads that start with an allowed prefix.
+        assert!(!is_allowed_branding_filename(
+            "logo/../../../proc/self/environ"
+        ));
+        assert!(!is_allowed_branding_filename("logo/../secret.png"));
+        assert!(!is_allowed_branding_filename("../favicon.ico"));
+        // Subdirectories and missing separators.
+        assert!(!is_allowed_branding_filename("logo/foo.png"));
+        assert!(!is_allowed_branding_filename("logolight.png"));
+        // No extension / disallowed extension / non-numeric suffix.
+        assert!(!is_allowed_branding_filename("logo"));
+        assert!(!is_allowed_branding_filename("logo_123.exe"));
+        assert!(!is_allowed_branding_filename("logo_abc.png"));
+        assert!(!is_allowed_branding_filename("evil.png"));
+    }
+
+    #[test]
+    fn accepts_filenames_the_upload_handler_writes() {
+        assert!(is_allowed_branding_filename("logo.png"));
+        assert!(is_allowed_branding_filename("logo_1699999999.png"));
+        assert!(is_allowed_branding_filename("logo_light_1699999999.webp"));
+        assert!(is_allowed_branding_filename("favicon_123.ico"));
+        assert!(is_allowed_branding_filename("favicon.ico"));
     }
 }

--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -16,7 +16,7 @@ use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
 use yrs::{Doc, GetString, ReadTxn, StateVector, Transact, Update, WriteTxn, XmlFragment};
 
-use crate::extractors::TenantConn;
+use crate::extractors::{AuthContext, TenantConn};
 use crate::handlers::errors;
 use crate::repository;
 use crate::sync::actor::ActorContext as DbActor;
@@ -162,16 +162,13 @@ enum DocumentType {
 /// against the request's WorkspaceContext.workspace_uuid and
 /// fail-fast on a cross-workspace request before opening the doc.
 ///
-/// `document` is parsed today but unused by the WS handler that
-/// currently consumes the type — it's surfaced for the future
-/// "verify the row exists before opening the doc" check, and
-/// dropping it would force every caller to re-parse the resource
-/// half of the doc_id. The `#[allow(dead_code)]` is a deliberate
-/// reservation, not an unused-field oversight.
+/// `document` is consumed by the WS handler's per-document visibility
+/// gate (and could back a future "verify the row exists" check);
+/// keeping it on the parse result avoids re-parsing the resource half
+/// of the doc_id at the call site.
 #[derive(Debug, Clone)]
 struct ParsedDocId {
     workspace_uuid: Uuid,
-    #[allow(dead_code)]
     document: DocumentType,
 }
 
@@ -361,8 +358,125 @@ mod doc_id_tests {
     }
 }
 
+/// Identity resolved enough to authorize collaborative-document
+/// access. Tickets gate on visibility (requester/watcher vs staff);
+/// documentation pages and collections gate on their ACL with a
+/// workspace-admin override. Reuses the same primitives as the REST
+/// ticket/documentation read paths and the SSE topic gate so the
+/// three can't drift. See security-audit-2026-06.
+struct DocAccessor {
+    vis: crate::repository::ticket_visibility::VisibilityContext,
+    is_workspace_admin: bool,
+}
+
+impl DocAccessor {
+    /// Build from the `AuthContext` extractor the REST handlers
+    /// already destructure (uses the request-resolved workspace role).
+    fn from_auth(auth: &AuthContext) -> Self {
+        Self {
+            vis: crate::repository::ticket_visibility::VisibilityContext::from_auth(auth),
+            is_workspace_admin: auth.is_workspace_admin(),
+        }
+    }
+
+    /// Build from JWT claims when no `AuthContext` is in scope (the
+    /// WebSocket handshake validates the token by hand). Resolves the
+    /// workspace role from the bootstrap workspace, matching
+    /// `VisibilityContext::resolve` and the SSE `SyncViewer`.
+    fn from_claims(
+        claims: &crate::models::Claims,
+        conn: &mut crate::db::DbConnection,
+    ) -> Option<Self> {
+        let user_uuid = Uuid::parse_str(&claims.sub).ok()?;
+        let platform_role = crate::models::PlatformRole::from_db(&claims.platform_role);
+        let workspace_role =
+            crate::repository::user_helpers::bootstrap_workspace_role(conn, user_uuid);
+        let vis = crate::repository::ticket_visibility::VisibilityContext::new(
+            user_uuid,
+            platform_role,
+            workspace_role,
+        );
+        let is_workspace_admin = platform_role.is_platform_admin()
+            || workspace_role.is_some_and(|r| r.meets(crate::models::WorkspaceRole::Admin));
+        Some(Self {
+            vis,
+            is_workspace_admin,
+        })
+    }
+}
+
+/// True when `accessor` may read/edit `document`. The error type is
+/// Diesel's so callers can map a DB failure to a 500 and a `false`
+/// to a 404 (never 403: a 403 leaks existence, per OWASP IDOR).
+fn can_access_document(
+    conn: &mut crate::db::DbConnection,
+    accessor: &DocAccessor,
+    document: &DocumentType,
+) -> Result<bool, diesel::result::Error> {
+    match document {
+        DocumentType::Ticket(id) => {
+            crate::repository::ticket_visibility::can_view_ticket(conn, &accessor.vis, *id)
+        }
+        DocumentType::Documentation(id) => repository::can_user_access_page(
+            conn,
+            *id,
+            &accessor.vis.user_uuid,
+            accessor.is_workspace_admin,
+        ),
+        DocumentType::Collection(id) => {
+            repository::documentation_collections::can_user_access_collection(
+                conn,
+                *id,
+                &accessor.vis.user_uuid,
+                accessor.is_workspace_admin,
+            )
+        }
+    }
+}
+
+/// Gate a ticket-scoped REST handler on visibility: `Ok(())` when the
+/// caller may read the ticket, else a ready 404 (404 not 403 so we
+/// don't leak existence), or 500 on a check failure.
+fn gate_ticket(
+    tc: &mut TenantConn,
+    auth: &AuthContext,
+    ticket_id: i32,
+) -> Result<(), HttpResponse> {
+    let accessor = DocAccessor::from_auth(auth);
+    match tc.run(|conn| can_access_document(conn, &accessor, &DocumentType::Ticket(ticket_id))) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(errors::not_found_msg("Ticket not found")),
+        Err(e) => {
+            error!(ticket_id, error = ?e, "ticket access check failed");
+            Err(errors::internal("Failed to check ticket access"))
+        }
+    }
+}
+
+/// Documentation-page equivalent of [`gate_ticket`].
+fn gate_doc_page(
+    tc: &mut TenantConn,
+    auth: &AuthContext,
+    page_id: i32,
+) -> Result<(), HttpResponse> {
+    let accessor = DocAccessor::from_auth(auth);
+    match tc.run(|conn| can_access_document(conn, &accessor, &DocumentType::Documentation(page_id)))
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(errors::not_found_msg("Page not found")),
+        Err(e) => {
+            error!(page_id, error = ?e, "page access check failed");
+            Err(errors::internal("Failed to check page access"))
+        }
+    }
+}
+
 // Simple handler to get article content by ticket ID or documentation page ID
-pub async fn get_article_content(mut tc: TenantConn, doc_id: web::Path<String>) -> impl Responder {
+pub async fn get_article_content(
+    mut tc: TenantConn,
+    doc_id: web::Path<String>,
+    auth: AuthContext,
+) -> impl Responder {
     let doc_id = doc_id.into_inner();
     let clean_doc_id = doc_id.replace("/", "_");
 
@@ -376,6 +490,20 @@ pub async fn get_article_content(mut tc: TenantConn, doc_id: web::Path<String>) 
             );
         }
     };
+
+    // Per-document visibility gate. Without it a restricted member who
+    // cannot read ticket N via the REST API could still pull its note
+    // body (and revision history) here. Reuses the REST/SSE primitives.
+    // See security-audit-2026-06.
+    let accessor = DocAccessor::from_auth(&auth);
+    match tc.run(|conn| can_access_document(conn, &accessor, &doc_type)) {
+        Ok(true) => {}
+        Ok(false) => return errors::not_found_msg("Document not found"),
+        Err(e) => {
+            error!(doc_id = %clean_doc_id, error = ?e, "Document access check failed");
+            return errors::internal("Failed to check document access");
+        }
+    }
 
     match doc_type {
         DocumentType::Ticket(ticket_id) => {
@@ -2108,8 +2236,9 @@ pub async fn ws_handler(
         .cookie(crate::utils::cookies::ACCESS_TOKEN_COOKIE)
         .ok_or_else(|| actix_web::error::ErrorUnauthorized("No authentication cookie"))?;
 
-    // Validate the token and extract user UUID
-    let user_uuid = if let Some(pool) = req.app_data::<web::Data<crate::db::Pool>>() {
+    // Validate the token, extract the user UUID, and resolve the
+    // visibility context used to gate per-document access below.
+    let (user_uuid, accessor) = if let Some(pool) = req.app_data::<web::Data<crate::db::Pool>>() {
         let mut conn = pool.get().map_err(|_| {
             actix_web::error::ErrorInternalServerError("Database connection failed")
         })?;
@@ -2118,7 +2247,11 @@ pub async fn ws_handler(
         use crate::utils::jwt::JwtUtils;
 
         match JwtUtils::validate_token_with_user_check(token.value(), &mut conn).await {
-            Ok((_claims, user)) => user.uuid,
+            Ok((claims, user)) => {
+                let accessor = DocAccessor::from_claims(&claims, &mut conn)
+                    .ok_or_else(|| actix_web::error::ErrorUnauthorized("Invalid token subject"))?;
+                (user.uuid, accessor)
+            }
             Err(_) => {
                 return Err(actix_web::error::ErrorUnauthorized(
                     "Invalid or expired token",
@@ -2171,6 +2304,35 @@ pub async fn ws_handler(
         workspace_id = ws.workspace_id,
         "WebSocket authentication + workspace check successful"
     );
+
+    // Per-document visibility gate. The workspace check above bounds
+    // the tenant; this bounds which documents *within* the workspace
+    // the caller may open. Without it a restricted member who cannot
+    // read ticket N via REST/SSE could still read and write its Yjs
+    // note here. See security-audit-2026-06.
+    {
+        let pool = req
+            .app_data::<web::Data<crate::db::Pool>>()
+            .ok_or_else(|| {
+                actix_web::error::ErrorInternalServerError("Database pool not available")
+            })?;
+        let mut conn = pool.get().map_err(|_| {
+            actix_web::error::ErrorInternalServerError("Database connection failed")
+        })?;
+        match can_access_document(&mut conn, &accessor, &parsed.document) {
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(doc_id = %doc_id, user_uuid = %user_uuid, "WebSocket document access denied");
+                return Err(actix_web::error::ErrorNotFound("Document not found"));
+            }
+            Err(e) => {
+                error!(doc_id = %doc_id, error = ?e, "WebSocket document visibility check failed");
+                return Err(actix_web::error::ErrorInternalServerError(
+                    "Access check failed",
+                ));
+            }
+        }
+    }
 
     // Per-document affinity routing (Phase 2). In single-instance mode
     // this is always `Local`. Under multi-instance routing, if another
@@ -2658,8 +2820,15 @@ async fn process_inbound_binary(
 // ============= Revision History API Endpoints =============
 
 /// GET /tickets/:id/revisions - List all revisions for a ticket
-pub async fn get_ticket_revisions(ticket_id: web::Path<i32>, mut tc: TenantConn) -> HttpResponse {
+pub async fn get_ticket_revisions(
+    ticket_id: web::Path<i32>,
+    mut tc: TenantConn,
+    auth: AuthContext,
+) -> HttpResponse {
     let ticket_id = ticket_id.into_inner();
+    if let Err(resp) = gate_ticket(&mut tc, &auth, ticket_id) {
+        return resp;
+    }
 
     // Get article content for this ticket
     let article_content = match tc.run(|conn| {
@@ -2683,8 +2852,15 @@ pub async fn get_ticket_revisions(ticket_id: web::Path<i32>, mut tc: TenantConn)
 }
 
 /// GET /tickets/:id/revisions/:revision_number - Get a specific revision
-pub async fn get_ticket_revision(path: web::Path<(i32, i32)>, mut tc: TenantConn) -> HttpResponse {
+pub async fn get_ticket_revision(
+    path: web::Path<(i32, i32)>,
+    mut tc: TenantConn,
+    auth: AuthContext,
+) -> HttpResponse {
     let (ticket_id, revision_number) = path.into_inner();
+    if let Err(resp) = gate_ticket(&mut tc, &auth, ticket_id) {
+        return resp;
+    }
 
     // Get article content for this ticket
     let article_content = match tc.run(|conn| {
@@ -2725,8 +2901,12 @@ pub async fn restore_ticket_revision(
     mut tc: TenantConn,
     ws: crate::extractors::WorkspaceContext,
     app_state: web::Data<YjsAppState>,
+    auth: AuthContext,
 ) -> HttpResponse {
     let (ticket_id, revision_number) = path.into_inner();
+    if let Err(resp) = gate_ticket(&mut tc, &auth, ticket_id) {
+        return resp;
+    }
 
     // Get article content for this ticket
     let article_content = match tc.run(|conn| {
@@ -2825,8 +3005,15 @@ pub async fn restore_ticket_revision(
 // ============= Documentation Revision History API Endpoints =============
 
 /// GET /docs/:id/revisions - List all revisions for a documentation page
-pub async fn get_doc_revisions(doc_id: web::Path<i32>, mut tc: TenantConn) -> HttpResponse {
+pub async fn get_doc_revisions(
+    doc_id: web::Path<i32>,
+    mut tc: TenantConn,
+    auth: AuthContext,
+) -> HttpResponse {
     let doc_id = doc_id.into_inner();
+    if let Err(resp) = gate_doc_page(&mut tc, &auth, doc_id) {
+        return resp;
+    }
 
     // Get all revisions
     match tc.run(|conn| crate::repository::documentation::get_documentation_revisions(conn, doc_id))
@@ -2837,8 +3024,15 @@ pub async fn get_doc_revisions(doc_id: web::Path<i32>, mut tc: TenantConn) -> Ht
 }
 
 /// GET /docs/:id/revisions/:revision_number - Get a specific revision
-pub async fn get_doc_revision(path: web::Path<(i32, i32)>, mut tc: TenantConn) -> HttpResponse {
+pub async fn get_doc_revision(
+    path: web::Path<(i32, i32)>,
+    mut tc: TenantConn,
+    auth: AuthContext,
+) -> HttpResponse {
     let (doc_id, revision_number) = path.into_inner();
+    if let Err(resp) = gate_doc_page(&mut tc, &auth, doc_id) {
+        return resp;
+    }
 
     // Get the specific revision
     match tc.run(|conn| {
@@ -2869,8 +3063,12 @@ pub async fn restore_doc_revision(
     mut tc: TenantConn,
     ws: crate::extractors::WorkspaceContext,
     app_state: web::Data<YjsAppState>,
+    auth: AuthContext,
 ) -> HttpResponse {
     let (doc_id, revision_number) = path.into_inner();
+    if let Err(resp) = gate_doc_page(&mut tc, &auth, doc_id) {
+        return resp;
+    }
 
     // Get the revision to restore
     let revision = match tc.run(|conn| {

--- a/backend/src/handlers/imports.rs
+++ b/backend/src/handlers/imports.rs
@@ -46,6 +46,12 @@ pub async fn upload(
     query: web::Query<UploadQuery>,
     mut payload: Multipart,
 ) -> impl Responder {
+    // Bulk import can create/update users (including their roles),
+    // assets, and tickets. Restrict to workspace admins. See
+    // security-audit-2026-06.
+    if !auth.is_workspace_admin() {
+        return errors::forbidden("Import requires workspace admin");
+    }
     let user_uuid = auth.user_uuid;
 
     let job_type = match ImportType::from_str(query.job_type.as_str()) {
@@ -154,10 +160,15 @@ enum CommitOutcome {
 /// job already in `done` returns the existing row unchanged.
 pub async fn commit(
     mut tc: TenantConn,
-    _auth: AuthContext,
+    auth: AuthContext,
     search_service: web::Data<Arc<SearchService>>,
     path: web::Path<Uuid>,
 ) -> impl Responder {
+    // Committing an import applies row writes (roles included).
+    // Workspace-admin only. See security-audit-2026-06.
+    if !auth.is_workspace_admin() {
+        return errors::forbidden("Import requires workspace admin");
+    }
     let id = path.into_inner();
 
     let result = tc.run(|conn| {
@@ -281,9 +292,14 @@ fn index_imported_records(search_service: &Arc<SearchService>, records: Imported
 
 pub async fn get_job(
     mut tc: TenantConn,
-    _auth: AuthContext,
+    auth: AuthContext,
     path: web::Path<Uuid>,
 ) -> impl Responder {
+    // Job rows carry import previews that can include other users'
+    // PII. Workspace-admin only. See security-audit-2026-06.
+    if !auth.is_workspace_admin() {
+        return errors::forbidden("Import requires workspace admin");
+    }
     let id = path.into_inner();
     match tc.run(|conn| repo::get(conn, id)) {
         Ok(j) => HttpResponse::Ok().json(j),

--- a/backend/src/handlers/microsoft_graph.rs
+++ b/backend/src/handlers/microsoft_graph.rs
@@ -1,4 +1,4 @@
-use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Responder};
+use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use serde::Deserialize;
 use serde_json::json;
 use tracing::error;
@@ -172,11 +172,15 @@ pub async fn process_graph_request(
         Err(e) => return e,
     };
 
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // Proxying arbitrary Microsoft Graph requests runs through the
+    // org's privileged app credentials, so restrict to workspace
+    // admins. See security-audit-2026-06.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     // Get the provider_id from the request or use the default Microsoft provider
     let provider_id_val = match request_data.provider_id {

--- a/backend/src/handlers/msgraph_integration.rs
+++ b/backend/src/handlers/msgraph_integration.rs
@@ -1002,11 +1002,15 @@ pub async fn sync_data(
         Ok(c) => c,
         Err(e) => return e,
     };
-    // Extract claims from cookie auth middleware
-    let _claims = match req.extensions().get::<crate::models::Claims>() {
-        Some(claims) => claims.clone(),
-        None => return errors::unauthorized("Authentication required"),
-    };
+    // Triggering a full Entra/Intune directory sync (mass record
+    // create/update via the integration's credentials) is workspace-
+    // admin only. See security-audit-2026-06.
+    let _claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
 
     // Get Microsoft provider
     let provider = match get_default_microsoft_provider() {

--- a/backend/src/handlers/system.rs
+++ b/backend/src/handlers/system.rs
@@ -1,4 +1,4 @@
-use actix_web::{web, HttpResponse, Responder};
+use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 
@@ -118,7 +118,18 @@ async fn check_for_updates() -> Option<(String, String)> {
 }
 
 // GET /api/admin/system/info
-pub async fn get_system_info(system_state: web::Data<SystemState>) -> impl Responder {
+pub async fn get_system_info(
+    req: HttpRequest,
+    system_state: web::Data<SystemState>,
+) -> impl Responder {
+    // Version / environment / uptime is operator info: useful for
+    // fingerprinting against known CVEs, so gate it to admins. See
+    // security-audit-2026-06.
+    if let Err(resp) =
+        crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+    {
+        return resp;
+    }
     let current_version = get_current_version();
     let uptime = system_state.start_time.elapsed();
 
@@ -138,7 +149,14 @@ pub async fn get_system_info(system_state: web::Data<SystemState>) -> impl Respo
 }
 
 // GET /api/admin/system/updates
-pub async fn check_system_updates() -> impl Responder {
+pub async fn check_system_updates(req: HttpRequest) -> impl Responder {
+    // Admin-only: this triggers an outbound GitHub request and reveals
+    // the running version. See security-audit-2026-06.
+    if let Err(resp) =
+        crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+    {
+        return resp;
+    }
     let current_version = get_current_version();
 
     let (update_available, latest_version, release_url) = match check_for_updates().await {

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -581,21 +581,27 @@ pub async fn create_user(
     user_data: web::Json<CreateUserRequest>,
     req: HttpRequest,
 ) -> impl Responder {
+    // Authorization: creating a user (and assigning its role) is a
+    // workspace-admin operation. Without this gate any authenticated
+    // user could POST role:"admin" / "audit_reviewer" plus a password
+    // and mint a privileged account. See security-audit-2026-06.
+    let actor_claims =
+        match crate::utils::rbac::require_workspace_role(&req, crate::models::WorkspaceRole::Admin)
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+
     let mut conn = match helpers::db_conn(&db_pool) {
         Ok(c) => c,
         Err(e) => return e,
     };
 
-    // Get the admin user who is creating this user (for invitation email)
-    let admin_name = req
-        .extensions()
-        .get::<crate::models::Claims>()
-        .and_then(|claims| {
-            uuid::Uuid::parse_str(&claims.sub)
-                .ok()
-                .and_then(|uuid| repository::get_user_by_uuid(&uuid, &mut conn).ok())
-                .map(|u| u.name)
-        })
+    // Resolve the inviter's display name for the invitation email.
+    let admin_name = uuid::Uuid::parse_str(&actor_claims.sub)
+        .ok()
+        .and_then(|uuid| repository::get_user_by_uuid(&uuid, &mut conn).ok())
+        .map(|u| u.name)
         .unwrap_or_else(|| "An administrator".to_string());
 
     // Check email configuration. Provider-aware (SMTP or Resend):

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1326,7 +1326,15 @@ async fn main() -> std::io::Result<()> {
             .wrap(crate::middleware::WorkspaceContextMiddleware::new(
                 workspace_config.clone(),
             ))
-            .app_data(public_limiter_data.clone())
+            // The authenticated limiter is the app-level default that
+            // `RateLimiter::default()` resolves by type (it looks up
+            // `web::Data<Limiter>`). The stricter public limiter is
+            // registered at the scope level on each public / auth
+            // surface below so it shadows this one there. Registering
+            // both app-level would make the second silently win for
+            // every scope (both are the same `web::Data<Limiter>`
+            // type), which is the bug that left the public limit
+            // unused. See security-audit-2026-06.
             .app_data(auth_limiter_data.clone())
             .app_data(web::Data::new(pool.clone()))
             .app_data(yjs_app_state.clone())
@@ -1354,6 +1362,7 @@ async fn main() -> std::io::Result<()> {
             .service(
                 web::resource("/api/debug/frontend-logs")
                     .app_data(web::JsonConfig::default().limit(512 * 1024))
+                    .app_data(public_limiter_data.clone())
                     .wrap(RateLimiter::default())
                     .route(web::post().to(handlers::debug::receive_frontend_logs)),
             )
@@ -1374,6 +1383,7 @@ async fn main() -> std::io::Result<()> {
             .service(
                 web::scope("/api/public")
                     .app_data(web::JsonConfig::default().limit(32 * 1024))
+                    .app_data(public_limiter_data.clone())
                     .wrap(RateLimiter::default())
                     .route("/settings", web::get().to(handlers::guest::get_public_settings))
                     .route("/tickets", web::post().to(handlers::guest::submit_guest_ticket))
@@ -1401,6 +1411,7 @@ async fn main() -> std::io::Result<()> {
             .service(
                 web::resource("/api/csp-report")
                     .app_data(web::PayloadConfig::new(16 * 1024))
+                    .app_data(public_limiter_data.clone())
                     .wrap(RateLimiter::default())
                     .route(web::post().to(handlers::csp_reports::report_violation))
             )
@@ -1430,6 +1441,10 @@ async fn main() -> std::io::Result<()> {
             // Authentication routes (public by design)
             .service(
                 web::scope("/api/auth")
+                    // Brute-force defence: auth endpoints get the
+                    // stricter public limit (shadows the app-level auth
+                    // limiter for this scope). See security-audit-2026-06.
+                    .app_data(public_limiter_data.clone())
                     .wrap(RateLimiter::default())
                     .service({
                         // Restore moved to `nosdesk-cli db restore` (AUD-005).
@@ -1532,6 +1547,16 @@ async fn main() -> std::io::Result<()> {
             // Supports both cookie-based auth (browser) and Bearer token auth (API clients)
             .service(
                 web::scope("/api")
+                    // Throttle authenticated traffic (per-IP, 600/min via
+                    // the auth limiter) so expensive endpoints
+                    // (/search/rebuild, /sync/bootstrap, /admin/backup/export)
+                    // can't be hammered unthrottled. Registered after the
+                    // auth wrap so it runs first and rejects before the
+                    // auth/DB work. SSE (/api/events/stream) and the
+                    // collaboration WS are separate top-level services, so
+                    // this does not throttle long-lived connections. See
+                    // security-audit-2026-06.
+                    .wrap(RateLimiter::default())
                     .wrap(actix_web::middleware::from_fn(middleware::dual_auth_middleware))
 
                     // Authentication Provider management (admin only) - simplified for environment-based config

--- a/backend/src/services/backup.rs
+++ b/backend/src/services/backup.rs
@@ -22,7 +22,13 @@ use crate::repository::backup as backup_repo;
 // same primitives the MFA encryption path uses; reusing them keeps
 // the crypto surface area small.
 const SALT_LENGTH: usize = 32;
-const PBKDF2_ITERATIONS: u32 = 100_000;
+// OWASP's current floor for PBKDF2-HMAC-SHA256. Bumped from 100_000;
+// the decrypt path hard-rejects any format-version mismatch (there is
+// no cross-version restore), so BACKUP_FORMAT_VERSION is bumped in
+// lockstep below — an older backup encrypted at the previous iteration
+// count gets a clean "unsupported version" error instead of a cryptic
+// GCM auth failure. See security-audit-2026-06.
+const PBKDF2_ITERATIONS: u32 = 600_000;
 
 /// Outer wrapper magic — 4 bytes prepended to encrypted backups so
 /// the reader can tell at a glance whether to decrypt before
@@ -35,9 +41,10 @@ const ENCRYPTED_HEADER_LEN: usize = 4 + 4 + SALT_LENGTH + NONCE_LEN;
 
 /// Current on-disk backup format. Bumped only on breaking changes
 /// to the wire shape (manifest schema, encryption envelope, etc.).
-/// Pre-launch we start at 1; the field exists so future bumps can
-/// refuse archives they can't parse.
-const BACKUP_FORMAT_VERSION: u32 = 1;
+/// v2 raised the PBKDF2 iteration count (see PBKDF2_ITERATIONS); the
+/// field lets the reader refuse archives it can't parse rather than
+/// fail cryptically.
+const BACKUP_FORMAT_VERSION: u32 = 2;
 
 /// Server schema hash baked in at compile time from the migrations
 /// directory (see `build.rs`). Restore refuses backups whose
@@ -56,6 +63,15 @@ const SENSITIVE_FIELDS: &[(&str, &[&str])] = &[
     ("user_auth_identities", &["password_hash", "metadata"]),
     ("refresh_tokens", &["token_hash"]),
     ("reset_tokens", &["token_hash", "metadata"]),
+    // The webhook secret is the plaintext HMAC signing key, and the
+    // custom headers commonly carry an Authorization value for the
+    // receiver. Both would let a reader of a plaintext backup forge
+    // signed deliveries / harvest receiver credentials. See
+    // security-audit-2026-06.
+    ("webhooks", &["secret", "headers"]),
+    // SHA-256 of a 128-bit random token: low impact, but stripping it
+    // keeps parity with refresh_tokens.token_hash above.
+    ("api_tokens", &["token_hash"]),
 ];
 
 /// Tables to export in backup
@@ -695,6 +711,20 @@ pub fn preview_restore(
 }
 
 /// Restore files from a backup archive. For encrypted backups
+/// True when `rel` is a plain relative path safe to join under the
+/// uploads root: every component is a normal name (or `.`), with no
+/// `..`, no absolute/root/prefix component, and no NUL/backslash. Used
+/// as the zip-slip guard in [`restore_backup_files`].
+fn is_safe_backup_relative_path(rel: &str) -> bool {
+    use std::path::Component;
+    if rel.is_empty() || rel.contains('\0') || rel.contains('\\') {
+        return false;
+    }
+    Path::new(rel)
+        .components()
+        .all(|c| matches!(c, Component::Normal(_) | Component::CurDir))
+}
+
 /// the password is required to unwrap the outer envelope.
 pub fn restore_backup_files(
     backup_path: &Path,
@@ -713,6 +743,17 @@ pub fn restore_backup_files(
 
         if name.starts_with("files/") && !name.ends_with('/') {
             let relative_path = name.strip_prefix("files/").unwrap();
+
+            // Zip-slip guard: a crafted backup with an entry like
+            // `files/../../../etc/cron.d/x` (or an absolute path, which
+            // would replace uploads_dir entirely in `join`) must not
+            // escape the uploads root. Reject anything that isn't a
+            // plain relative path before touching the filesystem. See
+            // security-audit-2026-06.
+            if !is_safe_backup_relative_path(relative_path) {
+                log::warn!("restore: skipping backup file entry with unsafe path '{name}'");
+                continue;
+            }
             let dest_path = uploads_dir.join(relative_path);
 
             if let Some(parent) = dest_path.parent() {
@@ -1106,6 +1147,21 @@ fn restore_table_data(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── zip-slip guard ───────────────────────────────────────────
+
+    #[test]
+    fn backup_relative_path_guard_blocks_traversal_and_absolute() {
+        assert!(is_safe_backup_relative_path("avatars/u1.png"));
+        assert!(is_safe_backup_relative_path("a/b/c.bin"));
+        // Traversal and absolute paths must be rejected (the latter
+        // would replace uploads_dir in PathBuf::join).
+        assert!(!is_safe_backup_relative_path("../../etc/passwd"));
+        assert!(!is_safe_backup_relative_path("a/../../b"));
+        assert!(!is_safe_backup_relative_path("/etc/passwd"));
+        assert!(!is_safe_backup_relative_path("a\\b"));
+        assert!(!is_safe_backup_relative_path(""));
+    }
 
     // ── derive_key ───────────────────────────────────────────────
 

--- a/backend/src/services/imports/assets.rs
+++ b/backend/src/services/imports/assets.rs
@@ -353,12 +353,17 @@ fn opt_string_field(value: &Option<String>) -> String {
     value.as_deref().unwrap_or("").to_string()
 }
 
-/// Neutralize spreadsheet formula injection. Excel and Sheets treat
-/// cells starting with `=`, `+`, `-`, or `@` as formulas; prefix
-/// with `'` so the value opens as plain text. The `csv` crate
-/// already quotes commas and newlines; this is separate hardening.
+/// Neutralize spreadsheet formula injection. Excel and Sheets treat a
+/// cell as a formula when its first non-whitespace character is `=`,
+/// `+`, `-`, or `@`. Some importers strip leading whitespace (space,
+/// tab, CR, LF, NUL) before evaluating, so a payload like "\t=cmd"
+/// would slip past a first-byte-only check; look past the leading
+/// whitespace before deciding. Prefix with `'` so the value opens as
+/// plain text. The `csv` crate already quotes commas and newlines;
+/// this is separate hardening. See security-audit-2026-06.
 fn csv_formula_safe(value: String) -> String {
-    match value.chars().next() {
+    let leading = value.trim_start_matches(|c: char| c.is_whitespace() || c == '\u{0}');
+    match leading.chars().next() {
         Some('=' | '+' | '-' | '@') => format!("'{value}"),
         _ => value,
     }
@@ -471,5 +476,21 @@ mod export_tests {
         let row = text.lines().nth(1).unwrap();
         assert!(row.starts_with("'=SUM(A1)"));
         assert!(row.contains(",'+cmd,"));
+    }
+
+    #[test]
+    fn formula_guard_handles_leading_whitespace_and_controls() {
+        // Direct triggers.
+        assert_eq!(csv_formula_safe("=cmd".into()), "'=cmd");
+        assert_eq!(csv_formula_safe("@SUM".into()), "'@SUM");
+        // Leading whitespace / control chars before the trigger must
+        // still be neutralised (some importers strip them first).
+        assert_eq!(csv_formula_safe(" =cmd".into()), "' =cmd");
+        assert_eq!(csv_formula_safe("\t=cmd".into()), "'\t=cmd");
+        assert_eq!(csv_formula_safe("\r-cmd".into()), "'\r-cmd");
+        // Benign values are untouched.
+        assert_eq!(csv_formula_safe("Laptop".into()), "Laptop");
+        assert_eq!(csv_formula_safe("  hello".into()), "  hello");
+        assert_eq!(csv_formula_safe(String::new()), "");
     }
 }

--- a/backend/src/services/plugins/proxy.rs
+++ b/backend/src/services/plugins/proxy.rs
@@ -137,6 +137,31 @@ impl PluginProxyService {
                 client_id_secret,
                 client_secret_secret,
             } => {
+                // The token endpoint is manifest-controlled and may
+                // differ from the request host, so it must clear the
+                // same gates as request.url: the network allowlist (or
+                // a plugin could exfil the admin-configured client_secret
+                // to any host) and the IP-literal SSRF guard (a literal
+                // token_url host bypasses the resolver). See
+                // security-audit-2026-06.
+                if !self.has_permission(manifest, token_url) {
+                    warn!(
+                        plugin = plugin_name,
+                        token_url = token_url,
+                        "OAuth2 token_url is not in the plugin's network permissions"
+                    );
+                    return None;
+                }
+                if let Err(e) = crate::utils::safe_http::reject_unsafe_ip_literal(token_url) {
+                    warn!(
+                        plugin = plugin_name,
+                        token_url = token_url,
+                        error = %e,
+                        "OAuth2 token_url blocked by SSRF guard"
+                    );
+                    return None;
+                }
+
                 let client_id = secrets.get(client_id_secret)?;
                 let client_secret = secrets.get(client_secret_secret)?;
 

--- a/backend/src/utils/csrf.rs
+++ b/backend/src/utils/csrf.rs
@@ -152,11 +152,16 @@ where
             .cookie(crate::utils::cookies::CSRF_TOKEN_COOKIE)
             .map(|c| c.value().to_string());
 
+        // Log only a short prefix, taken char-wise so an attacker-
+        // supplied header shorter than 10 bytes (or with a multi-byte
+        // char straddling the boundary) can't panic the middleware via
+        // a byte-index slice. See security-audit-2026-06.
+        let prefix = |t: &String| t.chars().take(8).collect::<String>();
         tracing::debug!(
             "🔒 CSRF Check for {}: header={:?}, cookie={:?}",
             path,
-            header_token.as_ref().map(|t| &t[..10]),
-            cookie_token.as_ref().map(|t| &t[..10])
+            header_token.as_ref().map(prefix),
+            cookie_token.as_ref().map(prefix)
         );
 
         // Validate CSRF token

--- a/backend/src/utils/reset_tokens.rs
+++ b/backend/src/utils/reset_tokens.rs
@@ -78,8 +78,12 @@ impl ResetTokenUtils {
     #[allow(dead_code)]
     pub fn validate_token_hash(raw_token: &str, stored_hash: &str) -> bool {
         let computed_hash = Self::hash_token(raw_token);
-        // Use constant-time comparison to prevent timing attacks
-        computed_hash == stored_hash
+        // Constant-time comparison so a future caller can't introduce a
+        // timing oracle on the token hash. (The live path looks tokens
+        // up by hash in the DB, which has no such oracle; this keeps the
+        // helper honest with its own doc comment.) See
+        // security-audit-2026-06.
+        constant_time_eq::constant_time_eq(computed_hash.as_bytes(), stored_hash.as_bytes())
     }
 
     /// Check if a token is expired

--- a/backend/src/utils/safe_http.rs
+++ b/backend/src/utils/safe_http.rs
@@ -77,6 +77,27 @@ pub enum SafeHttpError {
 /// fixed by the factory: divergent client configs are a common
 /// way for "I added one more safe client" to drift away from
 /// "actually safe."
+/// Redirect policy that re-applies the IP-literal SSRF guard to every
+/// hop, capped at 5 redirects. `Policy::limited` only bounds the count:
+/// hyper-util bypasses our custom resolver when a redirect `Location`
+/// host is already an IP literal, and the per-call
+/// `reject_unsafe_ip_literal` only sees the *initial* URL. Without this,
+/// a public host can answer `302 Location: http://169.254.169.254/...`
+/// and the client follows it into the private network. Hostname
+/// redirects are still re-resolved (and filtered) by `SafeResolver` on
+/// each hop. See security-audit-2026-06.
+fn ssrf_safe_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() >= 5 {
+            return attempt.stop();
+        }
+        match reject_unsafe_ip_literal(attempt.url().as_str()) {
+            Ok(()) => attempt.follow(),
+            Err(e) => attempt.error(e),
+        }
+    })
+}
+
 pub fn client(timeout: Duration) -> reqwest::Result<reqwest::Client> {
     reqwest::Client::builder()
         .user_agent(concat!("nosdesk/", env!("CARGO_PKG_VERSION")))
@@ -87,7 +108,7 @@ pub fn client(timeout: Duration) -> reqwest::Result<reqwest::Client> {
         // scheme check and the resolver, not just one of them.
         // Defence-in-depth, not redundancy.
         .https_only(false) // see below — some webhook receivers are still http://
-        .redirect(reqwest::redirect::Policy::limited(5))
+        .redirect(ssrf_safe_redirect_policy())
         .dns_resolver(Arc::new(SafeResolver))
         .build()
 }
@@ -101,7 +122,7 @@ pub fn https_only_client(timeout: Duration) -> reqwest::Result<reqwest::Client> 
         .user_agent(concat!("nosdesk/", env!("CARGO_PKG_VERSION")))
         .timeout(timeout)
         .https_only(true)
-        .redirect(reqwest::redirect::Policy::limited(5))
+        .redirect(ssrf_safe_redirect_policy())
         .dns_resolver(Arc::new(SafeResolver))
         .build()
 }

--- a/backend/tests/collaboration_ws.rs
+++ b/backend/tests/collaboration_ws.rs
@@ -152,6 +152,32 @@ fn test_workspace() -> WorkspaceContext {
     }
 }
 
+/// Seed a ticket in the bootstrap workspace and return its id. The
+/// collaboration handshake's per-document visibility gate
+/// (security-audit-2026-06) calls `can_view_ticket`, which requires the
+/// ticket to exist; pointing the doc_id at a real ticket lets the
+/// transport smoke test exercise the handshake. The caller (WSAlice) is
+/// a platform admin, so any existing ticket is visible to her.
+fn seed_ticket(conn: &mut diesel::pg::PgConnection) -> i32 {
+    use backend::schema::{tickets, workflow_states};
+    use diesel::prelude::*;
+    let state_id: i32 = workflow_states::table
+        .filter(workflow_states::workspace_id.eq(1))
+        .filter(workflow_states::is_default.eq(true))
+        .select(workflow_states::id)
+        .first(conn)
+        .expect("default workflow state seeded");
+    let t: backend::models::Ticket = diesel::insert_into(tickets::table)
+        .values(&backend::models::NewTicket {
+            title: "WS collab test ticket".to_string(),
+            workflow_state_id: state_id,
+            ..Default::default()
+        })
+        .get_result(conn)
+        .expect("insert ticket");
+    t.id
+}
+
 #[actix_web::test]
 async fn handshake_broadcast_and_clean_disconnect() {
     install_fast_heartbeat();
@@ -182,6 +208,10 @@ async fn handshake_broadcast_and_clean_disconnect() {
     .expect("create active session");
     let token = JwtUtils::create_token(&user, &session_row.session_id).expect("mint JWT");
 
+    // Seed a ticket so the WS visibility gate admits the handshake
+    // (see the doc_id construction below).
+    let ticket_id = seed_ticket(&mut pool.get().expect("conn"));
+
     let state_pool_inner = pool.clone();
 
     let srv = actix_test::start(move || {
@@ -210,9 +240,10 @@ async fn handshake_broadcast_and_clean_disconnect() {
     // `ws-{uuid}_{kind}-{id}`; ws_handler rejects bare ids with a 400
     // and rejects a uuid that doesn't match the request's
     // WorkspaceContext with a 403. Build it from test_workspace()'s
-    // uuid (nil) so both checks pass. The ticket row need not exist:
-    // the Yjs doc layer starts an empty document for an unseen id.
-    let doc_id = format!("ws-{}_ticket-1", test_workspace().workspace_uuid);
+    // uuid (nil) so both checks pass. The per-document visibility gate
+    // (security-audit-2026-06) requires the ticket to exist and be
+    // visible, so point the doc at the seeded ticket above.
+    let doc_id = format!("ws-{}_ticket-{ticket_id}", test_workspace().workspace_uuid);
     let url = srv.url(&format!("/ws/{doc_id}"));
 
     // Own our own awc::Client so we can attach the auth cookie.

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -109,6 +109,13 @@ services:
       # zips produced by `nosdesk-plugin sign --dev`.
       - ./plugins:/app/plugins:ro
     environment:
+      # Pin the dev stack to the development posture regardless of what
+      # docker.env carries. docker.env.example now defaults
+      # ENVIRONMENT=production so a self-hoster copying it for a real
+      # deployment gets the production secret gates; this override (which
+      # takes precedence over env_file) keeps `make dev` in dev mode
+      # (HTTP cookies, lenient secret checks). See security-audit-2026-06.
+      - ENVIRONMENT=development
       # Per-crate caps for chatty third-party crates: tantivy logs every
       # segment open and commit at INFO+DEBUG (saw ~90% of stdout); the
       # connection plumbing crates (h2, hyper, rustls, mio, want) emit

--- a/docker.env.example
+++ b/docker.env.example
@@ -78,8 +78,13 @@ MFA_KEK_V1=your-64-character-hex-encryption-key-change-this-in-production
 # NOSDESK_TENANT_DOMAIN=nosdesk.app
 
 # Environment — production | development | dev | staging | ...
-# Auth cookies use Secure unless this is development/dev (fail-closed default).
-ENVIRONMENT=development
+# Auth cookies use Secure unless this is development/dev (fail-closed default),
+# and the placeholder-secret / key-strength startup gates only enforce in
+# production. This file is the template a real deployment copies, so it
+# defaults to production: leaving the example JWT_SECRET/MFA_KEK_V1 in place
+# then fails fast instead of booting with a forgeable key. The dev stack
+# (compose.dev.yaml) overrides this back to development. See security-audit-2026-06.
+ENVIRONMENT=production
 
 # Labs ONLY (production): allow docker.env.example Postgres/Redis passwords to boot.
 # Never enable outside isolated test environments.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5183,9 +5183,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/src/components/common/MarkdownRenderer.vue
+++ b/frontend/src/components/common/MarkdownRenderer.vue
@@ -11,6 +11,7 @@
 import { computed, ref, watch, nextTick } from 'vue';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import { isAllowedImageSrc } from '@/composables/useSanitise';
 import { enhanceMentions } from '@/plugins/prosemirror-mention-view';
 import { enhanceTicketLinks } from '@/components/editor/ticketLinkPlugin';
 
@@ -47,6 +48,15 @@ const renderedHtml = computed(() => {
   // Parse markdown
   const html = marked.parse(withMentions) as string;
 
+  // Block off-origin <img src> (tracking-pixel exfiltration) while
+  // allowing same-origin / relative / data: images. See
+  // security-audit-2026-06.
+  DOMPurify.addHook('uponSanitizeAttribute', (node, data) => {
+    if (node.nodeName === 'IMG' && data.attrName === 'src' && !isAllowedImageSrc(data.attrValue)) {
+      data.keepAttr = false;
+    }
+  });
+
   // Sanitize HTML but allow our mention spans
   const clean = DOMPurify.sanitize(html, {
     ALLOWED_TAGS: [
@@ -66,6 +76,8 @@ const renderedHtml = computed(() => {
       'data-ticket-link', 'data-ticket-id', 'data-href',
     ],
   });
+
+  DOMPurify.removeHook('uponSanitizeAttribute');
 
   return clean;
 });

--- a/frontend/src/composables/useSanitise.ts
+++ b/frontend/src/composables/useSanitise.ts
@@ -63,6 +63,37 @@ const MARKDOWN_CONFIG: Config = {
 export type SanitiseProfile = 'default' | 'svg' | 'markdown' | 'strict';
 
 /**
+ * Whether an <img> src is safe to load without leaking a request to a
+ * third party. Allows same-origin / relative URLs and inline data:
+ * images; blocks off-origin http(s) and protocol-relative URLs.
+ *
+ * User-authored markdown and ticket comments are rendered through this
+ * sanitiser. An off-origin `<img src>` is a tracking pixel: when an
+ * agent opens the ticket the browser fetches the remote URL, leaking
+ * their IP, approximate location, and a precise read-receipt timestamp
+ * to an attacker-controlled host. The email-body path already blocks
+ * this via a server-side proxy + CSP img-src; this closes the same gap
+ * for the client-rendered markdown/comment paths. See
+ * security-audit-2026-06.
+ */
+export function isAllowedImageSrc(src: string): boolean {
+  const value = (src || '').trim();
+  if (!value) return false;
+  // Relative, same-origin URLs (/uploads/*, /api/*, ...). Exclude
+  // protocol-relative `//host` which is off-origin.
+  if (value.startsWith('/') && !value.startsWith('//')) return true;
+  // Inline images carry no network beacon. (SVG loaded via <img> does
+  // not execute script, so data:image/svg+xml is safe here too.)
+  if (/^data:image\//i.test(value)) return true;
+  // Absolute URLs: same-origin only.
+  try {
+    return new URL(value, window.location.origin).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Composable for HTML sanitisation
  */
 export function useSanitise() {
@@ -99,10 +130,18 @@ export function useSanitise() {
       }
     });
 
+    // Block off-origin image sources (tracking-pixel exfiltration).
+    DOMPurify.addHook('uponSanitizeAttribute', (node, data) => {
+      if (node.nodeName === 'IMG' && data.attrName === 'src' && !isAllowedImageSrc(data.attrValue)) {
+        data.keepAttr = false;
+      }
+    });
+
     const clean = DOMPurify.sanitize(dirty, { ...config, RETURN_TRUSTED_TYPE: false });
 
-    // Remove the hook to avoid affecting other sanitisations
+    // Remove the hooks to avoid affecting other sanitisations
     DOMPurify.removeHook('afterSanitizeAttributes');
+    DOMPurify.removeHook('uponSanitizeAttribute');
 
     return clean as string;
   }

--- a/frontend/src/composables/useTwemoji.ts
+++ b/frontend/src/composables/useTwemoji.ts
@@ -8,7 +8,12 @@ import twemoji from '@twemoji/api'
 
 // Use CDN when VITE_TWEMOJI_CDN=true, otherwise serve locally from public/twemoji/
 const useCdn = import.meta.env.VITE_TWEMOJI_CDN === 'true'
-const CDN_BASE = 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/svg/'
+// Pin the CDN to an immutable version tag. `@latest` is mutable: a
+// hijacked or republished upstream release would serve attacker assets
+// to clients. See security-audit-2026-06. (The CDN path is off by
+// default; local serving from public/twemoji/ is the default.)
+const TWEMOJI_VERSION = '15.1.0'
+const CDN_BASE = `https://cdn.jsdelivr.net/gh/jdecked/twemoji@${TWEMOJI_VERSION}/assets/svg/`
 const LOCAL_BASE = '/twemoji/'
 
 export const TWEMOJI_BASE = useCdn ? CDN_BASE : LOCAL_BASE
@@ -17,7 +22,7 @@ export const TWEMOJI_BASE = useCdn ? CDN_BASE : LOCAL_BASE
 const defaultOptions: Parameters<typeof twemoji.parse>[1] = {
   folder: useCdn ? 'svg' : '',
   ext: '.svg',
-  base: useCdn ? 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/' : LOCAL_BASE,
+  base: useCdn ? `https://cdn.jsdelivr.net/gh/jdecked/twemoji@${TWEMOJI_VERSION}/assets/` : LOCAL_BASE,
   className: 'twemoji'
 }
 


### PR DESCRIPTION
## Summary

Addresses findings from a full security audit run on 2026-06-10. Covers
the Critical, High, and Medium fixes plus a batch of low-severity
hardening. Each change reuses an existing primitive (the role guards,
the ticket/doc visibility checks, the SSRF-safe HTTP client) rather than
introducing new mechanisms.

Full backend suite passes (`make test`: 1298 passed, 0 failed). Frontend
type-checks clean.

## What's included

### Authorization (Critical/High)
- `POST /api/users`, `/admin/import` (upload/commit/get_job), the MS
  Graph proxy and sync endpoints, and `/admin/system/*` were reachable
  by any authenticated user. All now require workspace admin.
- OAuth account-linking trusted a caller-supplied `user_uuid`, allowing
  an attacker to link their IdP identity to a victim's account. The
  connect flow now derives the UUID from the authenticated session and
  strips any caller value (the state JWT is signed, so the callback can
  trust it).
- Public branding file route allowed path traversal
  (`/uploads/branding/logo/../../../proc/self/environ`). Now rejected
  via the shared storage-path guard plus a strict filename allowlist.

### Collaboration visibility (High)
- The Yjs WebSocket handshake, article-content read, and revision/restore
  endpoints performed no per-document permission check, so a restricted
  member could read or edit notes for a ticket they cannot see. Added a
  shared visibility gate reusing `can_view_ticket` /
  `can_user_access_page` / `can_user_access_collection`, matching the
  REST and SSE paths.

### Web layer (Medium)
- The public rate limiter was dead code: both limiters registered as the
  same `web::Data<Limiter>` type, so the auth limiter (10x higher) won
  for every scope. The public limiter is now registered at scope level,
  and the authenticated `/api` scope is throttled.
- The SSRF-safe client only checked the initial URL for IP literals;
  redirects to an IP literal bypassed the resolver. Every redirect hop
  is now re-validated. The plugin OAuth2 `token_url` is now gated on the
  manifest network allowlist and the IP-literal guard.

### Frontend (Medium)
- Off-origin `<img src>` in user-authored markdown and comments is now
  blocked (tracking-pixel / read-receipt exfiltration), allowing
  same-origin, relative, and `data:` images.
- Pinned the Twemoji CDN to a fixed version.

### Secrets, backup, config (Medium/Low)
- Plaintext backups stripped auth hashes but not the webhook signing
  secret or custom headers (often an Authorization value), nor the API
  token hash. All now stripped.
- `docker.env.example` defaults to production so a self-hoster copying it
  gets the placeholder-secret startup gates; the dev stack is pinned to
  development in `compose.dev.yaml`.
- Backup KDF raised to PBKDF2 600k (format v2), CSV formula-injection
  guard hardened for leading whitespace/control prefixes, reset-token
  hash comparison made constant-time, backup file restore guarded
  against zip-slip, pdfium download pinned and sha256-verified in both
  Dockerfiles.
- `/admin/system/*` admin-gated; CSRF debug log uses a panic-safe prefix;
  SVG dropped from branding uploads.

## Testing
- `make test`: 1298 passed, 0 failed, 4 ignored (34 binaries).
- New unit tests: branding filename allowlist, OAuth `user_uuid` strip,
  CSV formula guard, backup zip-slip guard.
- `npm run type-check` clean.

## Reviewer notes
- `backend/tests/collaboration_ws.rs` was updated to seed a visible
  ticket. The new handshake gate requires the ticket to exist and be
  visible; the smoke test previously connected to a synthetic
  non-existent ticket id.
- Single-workspace self-hosted installs are unaffected by the
  hosted-mode isolation findings, which are tracked separately (below).

## Deferred (not in this PR)
- API-token scope enforcement at the handler level (needs a design
  decision on the scope model).
- Hosted-mode isolation: per-workspace SSE topic scoping, and
  `admin_conn` gating on the resolved workspace rather than the
  bootstrap workspace.
- Lower-priority hardening: notifications error sanitisation, login
  Origin check, passkey-setup-login timing, SSE token in query string,
  app-wide JSON body limit, SSE/WS connection caps, OAuth login state
  cookie, webhook signature-verification docs.
