### PR TITLE
Configurable email footer security note

### DIFF
--- a/backend/migrations/2026-06-14-040000_add_email_security_note/down.sql
+++ b/backend/migrations/2026-06-14-040000_add_email_security_note/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE site_settings
+    DROP COLUMN email_security_note_enabled,
+    DROP COLUMN email_security_note_template;

--- a/backend/migrations/2026-06-14-040000_add_email_security_note/up.sql
+++ b/backend/migrations/2026-06-14-040000_add_email_security_note/up.sql
@@ -1,0 +1,7 @@
+-- Configurable anti-phishing footer note for transactional emails.
+-- Mirrors the channel_auto_ack pair: a toggle plus an optional
+-- admin-authored template. Off by default; NULL template = use the
+-- built-in localized default (FTL key email-security-note-default).
+ALTER TABLE site_settings
+    ADD COLUMN email_security_note_enabled BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN email_security_note_template TEXT;

--- a/backend/src/handlers/branding.rs
+++ b/backend/src/handlers/branding.rs
@@ -37,6 +37,15 @@ pub struct UpdateBrandingRequest {
     /// clear back to "use built-in FTL default for the locale".
     #[serde(default)]
     pub channel_auto_ack_template: Option<String>,
+    /// Whether to render the anti-phishing security note in the email
+    /// footer. Omitted = leave alone.
+    #[serde(default)]
+    pub email_security_note_enabled: Option<bool>,
+    /// Custom security-note body. Same omission / empty-string
+    /// semantics: omitted = leave alone, empty string = clear back to
+    /// the built-in localized default.
+    #[serde(default)]
+    pub email_security_note_template: Option<String>,
 }
 
 // GET /api/admin/branding/config - Get branding settings (public for initial load)
@@ -63,7 +72,9 @@ pub async fn get_branding_config(pool: web::Data<Pool>) -> impl Responder {
                 "updated_at": null,
                 "signature_default": null,
                 "channel_auto_ack_enabled": true,
-                "channel_auto_ack_template": null
+                "channel_auto_ack_template": null,
+                "email_security_note_enabled": false,
+                "email_security_note_template": null
             }))
         }
     }
@@ -143,6 +154,24 @@ pub async fn update_branding_config(
         }
     }
 
+    // Same allow-list rule for the security note. Empty / blank clears
+    // back to the built-in localized default.
+    if let Some(ref tmpl) = body.email_security_note_template {
+        if !tmpl.trim().is_empty() {
+            let unknown = crate::utils::template_variables::unknown_variables(
+                tmpl,
+                crate::utils::template_variables::SECURITY_NOTE_VARIABLES,
+            );
+            if !unknown.is_empty() {
+                return errors::bad_request(format!(
+                    "Unknown security-note variables: {}. Supported: {}.",
+                    unknown.join(", "),
+                    crate::utils::template_variables::SECURITY_NOTE_VARIABLES.join(", ")
+                ));
+            }
+        }
+    }
+
     // Mirror the user-signature empty-string-is-clear semantic from
     // users.rs so the admin UI can revert to "no org default"
     // without a separate API call.
@@ -160,6 +189,13 @@ pub async fn update_branding_config(
             Some(s.clone())
         }
     });
+    let security_note_template_change = body.email_security_note_template.as_ref().map(|s| {
+        if s.trim().is_empty() {
+            None
+        } else {
+            Some(s.clone())
+        }
+    });
 
     let update = UpdateSiteSettings {
         app_name: body.app_name.clone(),
@@ -171,6 +207,8 @@ pub async fn update_branding_config(
         signature_default: signature_default_change,
         channel_auto_ack_enabled: body.channel_auto_ack_enabled,
         channel_auto_ack_template: auto_ack_template_change,
+        email_security_note_enabled: body.email_security_note_enabled,
+        email_security_note_template: security_note_template_change,
         ..Default::default()
     };
 

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -3934,6 +3934,14 @@ pub struct SiteSettings {
     /// no org default; reply goes out unsigned, matching the pre-
     /// migration behaviour.
     pub signature_default: Option<String>,
+    /// Whether to render the anti-phishing security note in the
+    /// transactional email footer. Defaults false: the note is
+    /// brand-specific, so it stays opt-in until an admin enables it.
+    pub email_security_note_enabled: bool,
+    /// Admin-overridden security-note body. `None` uses the built-in
+    /// localized default (FTL key `email-security-note-default`).
+    /// Supports `{{app_name}}` and `{{domain}}` placeholders.
+    pub email_security_note_template: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, AsChangeset)]
@@ -3963,6 +3971,10 @@ pub struct UpdateSiteSettings {
     /// `Some(None)` = clear back to NULL (no org default),
     /// `Some(Some(_))` = set the org-wide template.
     pub signature_default: Option<Option<String>>,
+    pub email_security_note_enabled: Option<bool>,
+    /// Same `Option<Option<String>>` clear semantics as the auto-ack
+    /// template: `Some(None)` reverts to the built-in default.
+    pub email_security_note_template: Option<Option<String>>,
 }
 
 // API response for site settings (without internal fields)
@@ -3995,6 +4007,12 @@ pub struct SiteSettingsResponse {
     /// Admin-overridden template for the auto-ack body. `None` =
     /// use the built-in FTL default for the resolved locale.
     pub channel_auto_ack_template: Option<String>,
+    /// Whether the anti-phishing security note renders in the email
+    /// footer. See `utils::email_branding::resolve_security_note`.
+    pub email_security_note_enabled: bool,
+    /// Admin-overridden security-note body. `None` = use the built-in
+    /// localized default.
+    pub email_security_note_template: Option<String>,
 }
 
 impl From<SiteSettings> for SiteSettingsResponse {
@@ -4019,6 +4037,8 @@ impl From<SiteSettings> for SiteSettingsResponse {
             signature_default: settings.signature_default,
             channel_auto_ack_enabled: settings.channel_auto_ack_enabled,
             channel_auto_ack_template: settings.channel_auto_ack_template,
+            email_security_note_enabled: settings.email_security_note_enabled,
+            email_security_note_template: settings.email_security_note_template,
         }
     }
 }

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1362,6 +1362,8 @@ diesel::table! {
         default_timezone -> Text,
         workspace_id -> Int4,
         signature_default -> Nullable<Text>,
+        email_security_note_enabled -> Bool,
+        email_security_note_template -> Nullable<Text>,
     }
 }
 

--- a/backend/src/services/channels/auto_ack.rs
+++ b/backend/src/services/channels/auto_ack.rs
@@ -284,6 +284,8 @@ mod tests {
             default_timezone: "UTC".into(),
             workspace_id: 1,
             signature_default: None,
+            email_security_note_enabled: false,
+            email_security_note_template: None,
         }
     }
 

--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -92,7 +92,7 @@ impl Default for EmailBranding {
         Self {
             app_name: "Nosdesk".to_string(),
             logo_url: None,
-            primary_color: "#2563eb".to_string(),
+            primary_color: "#FF6B1A".to_string(),
             base_url: env::var("FRONTEND_URL")
                 .unwrap_or_else(|_| "http://localhost:3000".to_string()),
         }
@@ -110,12 +110,16 @@ impl EmailBranding {
         Self {
             app_name,
             logo_url,
-            primary_color: primary_color.unwrap_or_else(|| "#2563eb".to_string()),
+            primary_color: primary_color.unwrap_or_else(|| "#FF6B1A".to_string()),
             base_url,
         }
     }
 
-    /// Generate lighter shade of primary color for backgrounds
+    /// Generate lighter shade of primary color for backgrounds.
+    /// Retained from the previous design (the new stationery layout uses
+    /// fixed paper tokens rather than a tinted accent), kept for callers
+    /// that derive a soft background from the brand color.
+    #[allow(dead_code)]
     fn primary_color_light(&self) -> String {
         if let Some(hex) = self.primary_color.strip_prefix('#') {
             if hex.len() == 6 {
@@ -134,6 +138,130 @@ impl EmailBranding {
     }
 }
 
+// ===========================================================================
+// Email template layer ("fine-stationery" design)
+//
+// The layer is split into three pieces so compose_* functions never
+// hand-write inline-styled HTML:
+//
+//   * `Block`    — a single body element (paragraph, sub-heading, note).
+//                  Constructed via the free helpers `text`, `heading`,
+//                  `note`. Each helper emits the correct inline-styled,
+//                  dark-mode-aware HTML *once*.
+//   * `Notice`   — the bulleted "security notes" box, with a `NoticeType`
+//                  title resolved from the FTL catalogue.
+//   * `EmailLayout` — the params struct for the whole letter. It owns the
+//                  headline, the body blocks, an optional CTA, an optional
+//                  notice, and an optional sign-off. `#[derive(Default)]`
+//                  means call sites use named fields and adding a field
+//                  never breaks them.
+//
+// `EmailTemplate::render` owns ALL chrome exactly once: `<head>` + dark-
+// mode `<style>`, hidden preheader, logo letterhead + hairline rule, CTA
+// (MSO/Outlook VML bulletproof button), notice, sign-off, footer (automated
+// notice + © + Help) and the anti-phishing trust line.
+// ===========================================================================
+
+// --- Design tokens (light) -------------------------------------------------
+// Dark-mode equivalents live in the `<style>` block via the `.nd-*` classes;
+// these are the inline (light) values email clients without media-query
+// support fall back to.
+const C_PAPER: &str = "#f6f2ea";
+const C_HEAD: &str = "#1f1a15";
+const C_BODY: &str = "#4a443c";
+const C_MUTED: &str = "#8c8378";
+const C_FAINT: &str = "#a89f93";
+const C_LINK: &str = "#be4607";
+const C_HAIR: &str = "#e6ddcd";
+const C_NOTERULE: &str = "#d8d0c2";
+const C_FALLBACK_BG: &str = "#efe9dd";
+const C_STRONG: &str = "#5b5349";
+const C_CTA: &str = "#ff6b1a";
+
+/// A single rendered body block. The inline styling is baked in by the
+/// `text` / `heading` / `note` helpers so compose_* code only ever deals
+/// in semantics, never in `<p style="...">`.
+pub struct Block(String);
+
+/// A body paragraph. `html` is trusted markup (already escaped at the Rust
+/// boundary by the caller, with `<strong>` emphasis coming from the FTL
+/// value). Styled as the letter body text.
+pub fn text(html: impl Into<String>) -> Block {
+    Block(format!(
+        r#"<p class="nd-body" style="margin:0 0 18px 0;color:{body};font-size:15px;line-height:1.72;">{content}</p>"#,
+        body = C_BODY,
+        content = html.into(),
+    ))
+}
+
+/// A muted secondary line (e.g. the notification "From: …" row).
+pub fn muted(html: impl Into<String>) -> Block {
+    Block(format!(
+        r#"<p class="nd-muted" style="margin:0 0 18px 0;color:{muted};font-size:13px;line-height:1.6;">{content}</p>"#,
+        muted = C_MUTED,
+        content = html.into(),
+    ))
+}
+
+/// A body sub-heading. Smaller than the letter headline; rarely needed,
+/// kept for completeness so compose_* never reaches for raw `<h*>`.
+#[allow(dead_code)]
+pub fn heading(html: impl Into<String>) -> Block {
+    Block(format!(
+        r#"<p class="nd-head" style="margin:0 0 12px 0;color:{head};font-size:17px;line-height:1.4;font-weight:600;">{content}</p>"#,
+        head = C_HEAD,
+        content = html.into(),
+    ))
+}
+
+/// A quiet aside with a subtle grey left rule — the "didn't request this?" note.
+pub fn note(html: impl Into<String>) -> Block {
+    Block(format!(
+        r#"<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin:0 0 18px 0;"><tr>
+                <td class="nd-noterule" style="border-left:2px solid {rule};padding:2px 0 2px 16px;">
+                  <p class="nd-muted" style="margin:0;color:{muted};font-size:13px;line-height:1.6;">{content}</p>
+                </td>
+              </tr></table>"#,
+        rule = C_NOTERULE,
+        muted = C_MUTED,
+        content = html.into(),
+    ))
+}
+
+/// Call-to-action button. `label` is plain text (escaped here); `url` is a
+/// trusted, already-constructed link.
+pub struct Cta {
+    pub label: String,
+    pub url: String,
+}
+
+/// The bulleted security-notes box.
+pub struct Notice {
+    pub kind: NoticeType,
+    /// Each item is trusted markup (FTL value with optional `<strong>`).
+    pub items: Vec<String>,
+}
+
+/// Params for a full letter. Construct with named fields and `..Default::default()`
+/// so adding a field never breaks an existing call site.
+#[derive(Default)]
+pub struct EmailLayout<'a> {
+    /// The `<title>` and `<h1>` headline (plain text, escaped on render).
+    pub headline: &'a str,
+    /// Inbox-snippet preheader (plain text, escaped on render). Falls back
+    /// to "{headline} — {app_name}" when empty.
+    pub preheader: &'a str,
+    /// Ordered body blocks built via `text` / `heading` / `note` / `muted`.
+    pub body: Vec<Block>,
+    /// Optional call-to-action button (+ paste-the-link fallback).
+    pub cta: Option<Cta>,
+    /// Optional bulleted security-notes box, rendered after the body.
+    pub notice: Option<Notice>,
+    /// Optional sign-off (e.g. "With care,"). The `app_name` team line is
+    /// appended automatically when set.
+    pub signoff: Option<&'a str>,
+}
+
 /// Email template builder for consistent, branded emails
 struct EmailTemplate<'a> {
     branding: &'a EmailBranding,
@@ -144,249 +272,285 @@ impl<'a> EmailTemplate<'a> {
         Self { branding }
     }
 
-    /// Build complete HTML email with branding. `lang` lands on
-    /// the `<html lang="...">` attribute so screen readers reading
-    /// the rendered message announce the right pronunciation rules
-    /// and clients that auto-translate inbound mail know to skip
-    /// (the body already matches).
-    #[allow(clippy::too_many_arguments)]
-    fn build(
-        &self,
-        title: &str,
-        title_color: &str,
-        content: &str,
-        button_text: &str,
-        button_url: &str,
-        button_color: &str,
-        notice_type: NoticeType,
-        notice_items: &[&str],
-        footer_text: &str,
-        locale: &unic_langid::LanguageIdentifier,
-    ) -> String {
-        let logo_html = self.build_logo_section();
-        let notice_html = self.build_notice_section(notice_type, notice_items, locale);
-        let lang = locale.to_string();
-        let fallback_link_prompt = crate::utils::i18n::tr(locale, "email-link-fallback-prompt");
-        let rights_reserved = crate::utils::i18n::tr(locale, "email-footer-rights");
-        let automated_notice = crate::utils::i18n::tr(locale, "email-footer-automated");
-
-        format!(
-            r#"<!DOCTYPE html>
-<html lang="{lang}">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{title}</title>
-    <!--[if mso]>
-    <noscript>
-        <xml>
-            <o:OfficeDocumentSettings>
-                <o:PixelsPerInch>96</o:PixelsPerInch>
-            </o:OfficeDocumentSettings>
-        </xml>
-    </noscript>
-    <![endif]-->
-</head>
-<body style="margin: 0; padding: 0; background-color: #f3f4f6; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; -webkit-font-smoothing: antialiased;">
-    <!-- Preview text (hidden) -->
-    <div style="display: none; max-height: 0; overflow: hidden;">
-        {title} - {app_name}
-    </div>
-
-    <!-- Email wrapper -->
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #f3f4f6;">
-        <tr>
-            <td style="padding: 40px 20px;">
-                <!-- Main container -->
-                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width: 600px; margin: 0 auto;">
-
-                    <!-- Header with logo -->
-                    <tr>
-                        <td style="background-color: #ffffff; border-radius: 12px 12px 0 0; padding: 32px 40px; text-align: center; border-bottom: 1px solid #e5e7eb;">
-                            {logo_html}
-                        </td>
-                    </tr>
-
-                    <!-- Title bar -->
-                    <tr>
-                        <td style="background-color: {title_color}; padding: 24px 40px;">
-                            <h1 style="margin: 0; color: #ffffff; font-size: 22px; font-weight: 600; text-align: center; letter-spacing: -0.02em;">
-                                {title}
-                            </h1>
-                        </td>
-                    </tr>
-
-                    <!-- Content area -->
-                    <tr>
-                        <td style="background-color: #ffffff; padding: 40px;">
-                            {content}
-
-                            <!-- CTA Button -->
-                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 32px 0;">
-                                <tr>
-                                    <td style="text-align: center;">
-                                        <!--[if mso]>
-                                        <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{button_url}" style="height:48px;v-text-anchor:middle;width:220px;" arcsize="12%" strokecolor="{button_color}" fillcolor="{button_color}">
-                                        <w:anchorlock/>
-                                        <center style="color:#ffffff;font-family:sans-serif;font-size:16px;font-weight:600;">{button_text}</center>
-                                        </v:roundrect>
-                                        <![endif]-->
-                                        <!--[if !mso]><!-->
-                                        <a href="{button_url}" target="_blank" style="display: inline-block; background-color: {button_color}; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-weight: 600; font-size: 16px; transition: background-color 0.2s;">
-                                            {button_text}
-                                        </a>
-                                        <!--<![endif]-->
-                                    </td>
-                                </tr>
-                            </table>
-
-                            <!-- Fallback link -->
-                            <p style="margin: 0 0 24px 0; color: #6b7280; font-size: 13px; line-height: 1.5; text-align: center;">
-                                {fallback_link_prompt}
-                            </p>
-                            <p style="margin: 0 0 32px 0; padding: 12px 16px; background-color: #f9fafb; border-radius: 6px; word-break: break-all; font-size: 12px; color: {primary_color}; font-family: 'SF Mono', Monaco, 'Courier New', monospace;">
-                                <a href="{button_url}" style="color: {primary_color}; text-decoration: none;">{button_url}</a>
-                            </p>
-
-                            <!-- Notice box -->
-                            {notice_html}
-                        </td>
-                    </tr>
-
-                    <!-- Footer -->
-                    <tr>
-                        <td style="background-color: #f9fafb; border-radius: 0 0 12px 12px; padding: 24px 40px; border-top: 1px solid #e5e7eb;">
-                            <p style="margin: 0 0 8px 0; color: #6b7280; font-size: 13px; line-height: 1.5; text-align: center;">
-                                {footer_text}
-                            </p>
-                            <p style="margin: 0; color: #9ca3af; font-size: 12px; text-align: center;">
-                                &copy; {year} {app_name}. {rights_reserved}
-                            </p>
-                        </td>
-                    </tr>
-
-                </table>
-
-                <!-- Unsubscribe / Help links -->
-                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width: 600px; margin: 24px auto 0;">
-                    <tr>
-                        <td style="text-align: center;">
-                            <p style="margin: 0; color: #9ca3af; font-size: 12px;">
-                                {automated_notice}
-                            </p>
-                        </td>
-                    </tr>
-                </table>
-
-            </td>
-        </tr>
-    </table>
-</body>
-</html>"#,
-            title = escape_html(title),
-            app_name = escape_html(&self.branding.app_name),
-            logo_html = logo_html,
-            title_color = title_color,
-            content = content,
-            button_text = escape_html(button_text),
-            button_url = button_url,
-            button_color = button_color,
-            notice_html = notice_html,
-            footer_text = escape_html(footer_text),
-            primary_color = &self.branding.primary_color,
-            year = chrono::Utc::now().format("%Y"),
-        )
+    /// Resolve the logo URL against `base_url` (relative paths get the
+    /// base prefix; absolute `http(s)` URLs pass through).
+    fn logo_full_url(&self, logo_url: &str) -> String {
+        if logo_url.starts_with("http") {
+            logo_url.to_string()
+        } else {
+            format!("{}{}", self.branding.base_url, logo_url)
+        }
     }
 
-    /// Build the logo section HTML
+    /// The letterhead: a logo `<img>` when branding carries one, otherwise
+    /// the wordmark fallback in brand orange.
     fn build_logo_section(&self) -> String {
         match &self.branding.logo_url {
             Some(logo_url) if !logo_url.is_empty() => {
-                // Construct full URL if relative path
-                let full_url = if logo_url.starts_with("http") {
-                    logo_url.clone()
-                } else {
-                    format!("{}{}", self.branding.base_url, logo_url)
-                };
+                let full_url = self.logo_full_url(logo_url);
                 format!(
-                    r#"<img src="{}" alt="{}" style="max-width: 180px; max-height: 60px; height: auto;" />"#,
-                    escape_html(&full_url),
-                    escape_html(&self.branding.app_name)
+                    r#"<img src="{src}" width="150" height="27" alt="{alt}" style="display:block;width:150px;height:27px;border:0;outline:none;" />"#,
+                    src = escape_html(&full_url),
+                    alt = escape_html(&self.branding.app_name),
                 )
             }
             _ => {
-                // Text-based logo fallback with primary color
+                // Text wordmark fallback in brand orange (not the old blue).
                 format!(
-                    r#"<h2 style="margin: 0; color: {}; font-size: 28px; font-weight: 700; letter-spacing: -0.03em;">{}</h2>"#,
-                    &self.branding.primary_color,
-                    escape_html(&self.branding.app_name)
+                    r#"<span style="display:inline-block;color:{cta};font-size:24px;font-weight:700;letter-spacing:-0.02em;">{name}</span>"#,
+                    cta = C_CTA,
+                    name = escape_html(&self.branding.app_name),
                 )
             }
         }
     }
 
-    /// Build the notice section HTML
+    /// Render the bulleted notice box, or empty string when no items.
     fn build_notice_section(
         &self,
-        notice_type: NoticeType,
-        items: &[&str],
+        notice: &Notice,
         locale: &unic_langid::LanguageIdentifier,
     ) -> String {
-        if items.is_empty() {
+        if notice.items.is_empty() {
             return String::new();
         }
 
-        let light_color = self.branding.primary_color_light();
+        let title = crate::utils::i18n::tr(locale, notice.kind.title_key());
 
-        let (bg_color, border_color): (&str, &str) = match notice_type {
-            NoticeType::Warning => ("#fef3c7", "#f59e0b"),
-            NoticeType::Critical => ("#fee2e2", "#dc2626"),
-            NoticeType::Info => (&light_color, &self.branding.primary_color),
-            NoticeType::Success => ("#ecfdf5", "#059669"),
-        };
-
-        let title_key = match notice_type {
-            NoticeType::Warning => "email-notice-security",
-            NoticeType::Critical => "email-notice-security-critical",
-            NoticeType::Info => "email-notice-getting-started",
-            NoticeType::Success => "email-notice-success",
-        };
-        let title = crate::utils::i18n::tr(locale, title_key);
-
-        let items_html: String = items
+        let items_html: String = notice
+            .items
             .iter()
-            .map(|item| format!(
-                r#"<li style="margin: 0 0 8px 0; color: #374151; font-size: 14px; line-height: 1.5;">{item}</li>"#
-            ))
+            .map(|item| {
+                format!(
+                    r#"<li class="nd-muted" style="margin:0 0 7px 0;color:{muted};font-size:13px;line-height:1.6;">{item}</li>"#,
+                    muted = C_MUTED,
+                )
+            })
             .collect();
 
         format!(
-            r#"<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-top: 8px;">
-                <tr>
-                    <td style="background-color: {bg_color}; border-left: 4px solid {border_color}; border-radius: 0 8px 8px 0; padding: 20px;">
-                        <p style="margin: 0 0 12px 0; font-weight: 600; color: #111827; font-size: 14px;">
-                            {title}
-                        </p>
-                        <ul style="margin: 0; padding: 0 0 0 20px;">
-                            {items_html}
-                        </ul>
-                    </td>
-                </tr>
-            </table>"#,
+            r#"<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"><tr>
+                <td class="nd-noterule" style="border-left:2px solid {rule};padding:2px 0 2px 16px;">
+                  <p class="nd-strong" style="margin:0 0 10px 0;color:{strong};font-size:13px;font-weight:600;">{title}</p>
+                  <ul style="margin:0;padding:0 0 0 18px;">{items_html}</ul>
+                </td>
+              </tr></table>"#,
+            rule = C_NOTERULE,
+            strong = C_STRONG,
+        )
+    }
+
+    /// Render the bulletproof CTA (VML for Outlook/MSO, anchor elsewhere)
+    /// plus the paste-the-link fallback.
+    fn build_cta_section(&self, cta: &Cta, locale: &unic_langid::LanguageIdentifier) -> String {
+        let fallback_prompt = crate::utils::i18n::tr(locale, "email-link-fallback-prompt");
+        format!(
+            r#"<tr>
+            <td class="nd-pad" style="padding:30px 8px 0 8px;">
+              <!--[if mso]>
+              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{url}" style="height:46px;v-text-anchor:middle;width:200px;" arcsize="18%" strokecolor="{cta}" fillcolor="{cta}">
+              <w:anchorlock/><center style="color:#ffffff;font-family:sans-serif;font-size:15px;font-weight:600;">{label}</center>
+              </v:roundrect>
+              <![endif]-->
+              <!--[if !mso]><!-->
+              <a href="{url}" target="_blank" role="button" style="display:inline-block;background-color:{cta};color:#ffffff;font-size:15px;font-weight:600;padding:13px 30px;border-radius:8px;letter-spacing:0.01em;">{label}</a>
+              <!--<![endif]-->
+            </td>
+          </tr>
+          <tr>
+            <td class="nd-pad" style="padding:22px 8px 0 8px;">
+              <p class="nd-muted" style="margin:0 0 8px 0;color:{muted};font-size:12.5px;line-height:1.5;">{fallback_prompt}</p>
+              <p class="nd-fallback" style="margin:0;padding:11px 14px;background-color:{fallback_bg};border-radius:7px;word-break:break-all;font-size:12px;font-family:'SF Mono',Monaco,Consolas,monospace;">
+                <a class="nd-link" href="{url}" style="color:{link};">{url_text}</a>
+              </p>
+            </td>
+          </tr>"#,
+            url = cta.url,
+            url_text = escape_html(&cta.url),
+            label = escape_html(&cta.label),
+            cta = C_CTA,
+            muted = C_MUTED,
+            link = C_LINK,
+            fallback_bg = C_FALLBACK_BG,
+        )
+    }
+
+    /// Build the complete HTML letter. `EmailLayout` carries every variable
+    /// part; this owns all the chrome. `locale` lands on `<html lang>` so
+    /// screen readers announce the right rules and clients skip auto-translate.
+    fn render(&self, layout: EmailLayout<'_>, locale: &unic_langid::LanguageIdentifier) -> String {
+        let lang = locale.to_string();
+        let app_name = escape_html(&self.branding.app_name);
+        let logo_html = self.build_logo_section();
+
+        let preheader = if layout.preheader.is_empty() {
+            format!("{} — {}", layout.headline, self.branding.app_name)
+        } else {
+            layout.preheader.to_string()
+        };
+
+        let body_html: String = layout.body.iter().map(|b| b.0.as_str()).collect();
+
+        let cta_html = layout
+            .cta
+            .as_ref()
+            .map(|c| self.build_cta_section(c, locale))
+            .unwrap_or_default();
+
+        let notice_html = layout
+            .notice
+            .as_ref()
+            .map(|n| {
+                let inner = self.build_notice_section(n, locale);
+                if inner.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        r#"<tr><td class="nd-pad" style="padding:28px 8px 0 8px;">{inner}</td></tr>"#
+                    )
+                }
+            })
+            .unwrap_or_default();
+
+        let signoff_html = layout
+            .signoff
+            .map(|s| {
+                format!(
+                    r#"<tr><td class="nd-pad" style="padding:32px 8px 0 8px;">
+              <p class="nd-body" style="margin:0;color:{body};font-size:15px;line-height:1.72;">{signoff}<br><span class="nd-strong" style="color:{head};">{team}</span></p>
+            </td></tr>"#,
+                    body = C_BODY,
+                    head = C_HEAD,
+                    signoff = escape_html(s),
+                    team = escape_html(&self.branding.app_name),
+                )
+            })
+            .unwrap_or_default();
+
+        let automated_notice = crate::utils::i18n::tr(locale, "email-footer-automated");
+        let help_label = crate::utils::i18n::tr(locale, "email-footer-help");
+        let trust_notice = crate::utils::i18n::tr(locale, "email-trust-notice");
+        let help_url = format!("{}/support", self.branding.base_url);
+
+        format!(
+            r#"<!DOCTYPE html>
+<html lang="{lang}" style="margin:0;padding:0;">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">
+  <title>{title}</title>
+  <!--[if mso]>
+  <noscript><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml></noscript>
+  <![endif]-->
+  <style>
+    @media (prefers-color-scheme: dark) {{
+      .nd-paper   {{ background:#0b0a08 !important; }}
+      .nd-head    {{ color:#f4f1ea !important; }}
+      .nd-body    {{ color:#cfc8bd !important; }}
+      .nd-muted   {{ color:#9a9082 !important; }}
+      .nd-faint   {{ color:#7a7263 !important; }}
+      .nd-link    {{ color:#ff9d57 !important; }}
+      .nd-fallback{{ background:#16140f !important; }}
+      .nd-hair    {{ border-color:#2a2620 !important; }}
+      .nd-noterule{{ border-color:#3a352d !important; }}
+      .nd-strong  {{ color:#e6ded0 !important; }}
+    }}
+    a {{ text-decoration:none; }}
+    @media only screen and (max-width:560px) {{
+      .nd-pad   {{ padding-left:14px !important; padding-right:14px !important; }}
+      .nd-outer {{ padding-left:12px !important; padding-right:12px !important; padding-top:36px !important; padding-bottom:32px !important; }}
+    }}
+  </style>
+</head>
+<body class="nd-paper" style="margin:0;padding:0;background-color:{paper};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;-webkit-font-smoothing:antialiased;">
+  <div style="display: none; max-height:0;overflow:hidden;opacity:0;">{preheader}</div>
+
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" class="nd-paper" style="background-color:{paper};">
+    <tr>
+      <td align="center" class="nd-outer" style="padding:56px 24px 44px 24px;">
+
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width:512px;margin:0 auto;">
+
+          <!-- Letterhead: wordmark + hairline rule -->
+          <tr><td align="center" style="padding:0 0 6px 0;">
+            {logo_html}
+          </td></tr>
+          <tr><td align="center" style="padding:18px 0 0 0;">
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0"><tr>
+              <td class="nd-hair" style="width:38px;border-top:1px solid {hair};font-size:0;line-height:0;">&nbsp;</td>
+            </tr></table>
+          </td></tr>
+
+          <!-- Letter body -->
+          <tr>
+            <td class="nd-pad" style="padding:40px 8px 0 8px;">
+              <h1 class="nd-head" style="margin:0 0 22px 0;color:{head};font-size:22px;line-height:1.35;font-weight:600;letter-spacing:-0.01em;">{title}</h1>
+              {body_html}
+            </td>
+          </tr>
+
+          <!-- CTA -->
+          {cta_html}
+
+          <!-- Notice -->
+          {notice_html}
+
+          <!-- Sign-off -->
+          {signoff_html}
+
+          <!-- Footer -->
+          <tr>
+            <td class="nd-pad" style="padding:40px 8px 0 8px;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"><tr>
+                <td class="nd-hair" style="border-top:1px solid {hair};font-size:0;line-height:0;">&nbsp;</td>
+              </tr></table>
+              <p class="nd-faint" style="margin:18px 0 4px 0;color:{faint};font-size:12px;line-height:1.5;">{automated_notice}</p>
+              <p class="nd-faint" style="margin:0 0 16px 0;color:{faint};font-size:12px;">&copy; {year} {app_name} &nbsp;&middot;&nbsp; <a class="nd-link" href="{help_url}" style="color:{faint};">{help_label}</a></p>
+              <p class="nd-faint" style="margin:0;color:{faint};font-size:11.5px;line-height:1.65;">{trust_notice}</p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"#,
+            title = escape_html(layout.headline),
+            preheader = escape_html(&preheader),
+            paper = C_PAPER,
+            head = C_HEAD,
+            hair = C_HAIR,
+            faint = C_FAINT,
+            year = chrono::Utc::now().format("%Y"),
         )
     }
 }
 
-/// Notice type for email templates
+/// Notice type for email templates. Picks the title key for the
+/// security-notes box and is preserved from the previous design.
 #[derive(Clone, Copy)]
-enum NoticeType {
+pub enum NoticeType {
     Warning,
     #[allow(dead_code)]
     Critical,
     Info,
     #[allow(dead_code)]
     Success,
+}
+
+impl NoticeType {
+    fn title_key(self) -> &'static str {
+        match self {
+            NoticeType::Warning => "email-notice-security",
+            NoticeType::Critical => "email-notice-security-critical",
+            NoticeType::Info => "email-notice-getting-started",
+            NoticeType::Success => "email-notice-success",
+        }
+    }
 }
 
 /// Email configuration loaded from environment variables
@@ -840,7 +1004,7 @@ impl EmailService {
         let title = tr("password-reset-title", &[]);
         let cta_label = tr("password-reset-cta-label", &[]);
         let footer = tr("password-reset-footer", &[]);
-        let notice_items_owned: Vec<String> = [
+        let notice_items: Vec<String> = [
             "password-reset-notice-expiry",
             "password-reset-notice-single-use",
             "password-reset-notice-never-share",
@@ -849,30 +1013,23 @@ impl EmailService {
         .iter()
         .map(|key| tr(key, &[]))
         .collect();
-        let notice_items: Vec<&str> = notice_items_owned.iter().map(String::as_str).collect();
 
-        let content = format!(
-            r#"<p style="margin: 0 0 16px 0; color: #374151; font-size: 16px; line-height: 1.6;">
-                {greeting}
-            </p>
-            <p style="margin: 0 0 16px 0; color: #374151; font-size: 16px; line-height: 1.6;">
-                {intro}
-            </p>
-            <p style="margin: 0 0 8px 0; color: #374151; font-size: 16px; line-height: 1.6;">
-                {action_prompt}
-            </p>"#
-        );
-
-        let html_body = template.build(
-            &title,
-            &branding.primary_color,
-            &content,
-            &cta_label,
-            &reset_link,
-            &branding.primary_color,
-            NoticeType::Warning,
-            &notice_items,
-            &footer,
+        let html_body = template.render(
+            EmailLayout {
+                headline: &title,
+                body: vec![text(greeting), text(intro), text(action_prompt)],
+                cta: Some(Cta {
+                    label: cta_label,
+                    url: reset_link.clone(),
+                }),
+                notice: Some(Notice {
+                    kind: NoticeType::Warning,
+                    items: notice_items,
+                }),
+                signoff: None,
+                preheader: &footer,
+                ..Default::default()
+            },
             locale,
         );
 
@@ -934,7 +1091,7 @@ impl EmailService {
         let action_prompt = tr("invitation-action-prompt", &[]);
         let cta_label = tr("invitation-cta-label", &[]);
         let footer = tr("invitation-footer", &[]);
-        let notice_items_owned: Vec<String> = [
+        let notice_items: Vec<String> = [
             "invitation-notice-expiry",
             "invitation-notice-create-password",
             "invitation-notice-strong-password",
@@ -943,35 +1100,23 @@ impl EmailService {
         .iter()
         .map(|key| tr(key, &[]))
         .collect();
-        let notice_items: Vec<&str> = notice_items_owned.iter().map(String::as_str).collect();
 
-        let content = format!(
-            r#"<p style="margin: 0 0 16px 0; color: #374151; font-size: 16px; line-height: 1.6;">
-                {greeting}
-            </p>
-            <p style="margin: 0 0 16px 0; color: #374151; font-size: 16px; line-height: 1.6;">
-                {intro}
-            </p>
-            <p style="margin: 0 0 8px 0; color: #374151; font-size: 16px; line-height: 1.6;">
-                {action_prompt}
-            </p>"#
-        );
-
-        // Green/success accent — the invitation flow is positive
-        // by intent (joining a workspace), distinct from password
-        // reset's warning amber.
-        let welcome_color = "#059669";
-
-        let html_body = template.build(
-            &title,
-            welcome_color,
-            &content,
-            &cta_label,
-            &setup_link,
-            welcome_color,
-            NoticeType::Info,
-            &notice_items,
-            &footer,
+        let html_body = template.render(
+            EmailLayout {
+                headline: &title,
+                body: vec![text(greeting), text(intro), text(action_prompt)],
+                cta: Some(Cta {
+                    label: cta_label,
+                    url: setup_link.clone(),
+                }),
+                notice: Some(Notice {
+                    kind: NoticeType::Info,
+                    items: notice_items,
+                }),
+                signoff: None,
+                preheader: &footer,
+                ..Default::default()
+            },
             locale,
         );
 
@@ -1005,15 +1150,30 @@ impl EmailService {
         invitation_token: &str,
         branding: &EmailBranding,
     ) -> Result<(), String> {
+        if !self.config.is_configured() {
+            return Err("Email is not configured".to_string());
+        }
+        let (subject, html_body) =
+            self.compose_guest_ticket_confirmation(user_name, invitation_token, branding);
+        self.send_html_email(to, &subject, &html_body).await
+    }
+
+    /// Render the guest ticket-confirmation email without sending. Returns
+    /// `(subject, html_body)`; the plain-text alternative is derived from the
+    /// HTML by `send_html_email`. Split out so the preview harness can render
+    /// it without a transport.
+    pub fn compose_guest_ticket_confirmation(
+        &self,
+        user_name: &str,
+        invitation_token: &str,
+        branding: &EmailBranding,
+    ) -> (String, String) {
         // Guest confirmation predates the inbound-locale plumbing.
         // Fall back to DEFAULT_LOCALE; once guest channels carry an
         // Accept-Language hint we can thread it through.
         let locale =
             unic_langid::LanguageIdentifier::from_str(crate::utils::locale::DEFAULT_LOCALE)
                 .expect("DEFAULT_LOCALE parses");
-        if !self.config.is_configured() {
-            return Err("Email is not configured".to_string());
-        }
 
         let confirm_link = format!(
             "{}/accept-invitation?token={}",
@@ -1021,44 +1181,46 @@ impl EmailService {
         );
         let template = EmailTemplate::new(branding);
 
-        let content = format!(
-            r#"<p style="margin: 0 0 16px 0; color: #374151; font-size: 16px; line-height: 1.6;">
-                Hi <strong>{}</strong>,
-            </p>
-            <p style="margin: 0 0 8px 0; color: #374151; font-size: 16px; line-height: 1.6;">
-                Thanks for submitting a ticket to <strong>{}</strong>. Confirm your email to release it to our team:
-            </p>"#,
-            escape_html(user_name),
+        // No recipient locale to resolve from at this point — the
+        // guest has just submitted a form, no account exists yet, so
+        // we default to DEFAULT_LOCALE. The copy here predates the
+        // i18n plumbing for this flow and stays hardcoded English;
+        // a future commit could resolve the inbound `Accept-Language`
+        // header or site_settings.default_locale here.
+        let greeting = format!("Hi <strong>{}</strong>,", escape_html(user_name));
+        let intro = format!(
+            "Thanks for submitting a ticket to <strong>{}</strong>. Confirm your email to release it to our team:",
             escape_html(&branding.app_name)
         );
 
-        // Use the app's accent color for the guest confirmation flow so it
-        // reads as "your helpdesk" rather than a generic invitation.
-        let accent = &branding.primary_color;
-
-        // No recipient locale to resolve from at this point — the
-        // guest has just submitted a form, no account exists yet,
-        // so we default to "en". A future commit could resolve
-        // the inbound `Accept-Language` header or
-        // site_settings.default_locale here.
-        let html_body = template.build(
-            "Confirm your ticket submission",
-            accent,
-            &content,
-            "Confirm email & send ticket",
-            &confirm_link,
-            accent,
-            NoticeType::Info,
-            &[
-                "Link expires in <strong>7 days</strong>",
-                "Confirming also gives you access to your ticket portal to track progress and reply",
-            ],
-            "If you didn't submit a ticket, you can safely ignore this email, no account will be created.",
+        let html_body = template.render(
+            EmailLayout {
+                headline: "Confirm your ticket submission",
+                body: vec![
+                    text(greeting),
+                    text(intro),
+                    note("If you didn't submit a ticket, you can safely ignore this email, no account will be created."),
+                ],
+                cta: Some(Cta {
+                    label: "Confirm email & send ticket".to_string(),
+                    url: confirm_link.clone(),
+                }),
+                notice: Some(Notice {
+                    kind: NoticeType::Info,
+                    items: vec![
+                        "Link expires in <strong>7 days</strong>".to_string(),
+                        "Confirming also gives you access to your ticket portal to track progress and reply".to_string(),
+                    ],
+                }),
+                signoff: None,
+                preheader: "",
+                ..Default::default()
+            },
             &locale,
         );
 
         let subject = format!("Confirm your ticket submission to {}", branding.app_name);
-        self.send_html_email(to, &subject, &html_body).await
+        (subject, html_body)
     }
 
     /// Send a technician's reply to a ticket as an email. Sets the
@@ -1129,28 +1291,25 @@ impl EmailService {
             "notif-from-row",
             &[("actor", escape_html(actor_name).into())],
         );
-        let content = format!(
-            r#"<p style="margin: 0 0 16px 0; color: #374151; font-size: 16px; line-height: 1.6;">{}</p>
-            <p style="margin: 0 0 24px 0; color: #6b7280; font-size: 14px;">{}</p>"#,
-            escape_html(body),
-            from_row,
-        );
 
         let button_label = tr(
             "notif-cta-view-in",
             &[("app", branding.app_name.clone().into())],
         );
         let footer = tr("notif-footer-preferences", &[]);
-        let html_body = template.build(
-            title,
-            &branding.primary_color,
-            &content,
-            &button_label,
-            cta_url,
-            &branding.primary_color,
-            NoticeType::Info,
-            &[],
-            &footer,
+        let html_body = template.render(
+            EmailLayout {
+                headline: title,
+                body: vec![text(escape_html(body)), muted(from_row)],
+                cta: Some(Cta {
+                    label: button_label,
+                    url: cta_url.to_string(),
+                }),
+                notice: None,
+                signoff: None,
+                preheader: &footer,
+                ..Default::default()
+            },
             locale,
         );
 
@@ -1355,5 +1514,69 @@ mod tests {
             .block_on(disabled.send_ticket_reply(outbound))
             .unwrap_err();
         assert!(err.contains("not configured"), "unexpected error: {err}");
+    }
+
+    // ---------- email design preview harness ----------
+    //
+    // Renders each compose_* with representative sample data + default
+    // branding and writes the HTML to `target/email-preview/<name>.html`
+    // so the "fine-stationery" design can be eyeballed in a browser
+    // without sending. Pure render — no network, no DB.
+
+    #[test]
+    fn render_email_previews() {
+        use std::str::FromStr;
+
+        let svc = svc();
+        let branding = EmailBranding::default(); // default brand orange, no logo
+        let locale = unic_langid::LanguageIdentifier::from_str("en-US").unwrap();
+
+        let out_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("email-preview");
+        std::fs::create_dir_all(&out_dir).expect("create preview dir");
+
+        let write = |name: &str, html: &str| {
+            std::fs::write(out_dir.join(format!("{name}.html")), html)
+                .unwrap_or_else(|e| panic!("write {name}: {e}"));
+        };
+
+        let (_subj, html, _text) =
+            svc.compose_password_reset("Alex", "EXAMPLE-RESET-TOKEN", &branding, &locale);
+        write("password-reset", &html);
+
+        let (_subj, html, _text) =
+            svc.compose_invitation("Alex", "EXAMPLE-INVITE-TOKEN", &branding, "Kyle", &locale);
+        write("invitation", &html);
+
+        let (_subj, html) =
+            svc.compose_guest_ticket_confirmation("Alex", "EXAMPLE-GUEST-TOKEN", &branding);
+        write("guest-ticket-confirmation", &html);
+
+        let (html, _text) = svc.compose_notification(
+            "New comment on: Printer fire",
+            "It's still burning. Can someone take a look?",
+            "Kyle",
+            "https://desk.example.com/tickets/42",
+            &branding,
+            &locale,
+        );
+        write("notification", &html);
+
+        // Sanity: every preview file exists and is non-trivial.
+        for name in [
+            "password-reset",
+            "invitation",
+            "guest-ticket-confirmation",
+            "notification",
+        ] {
+            let p = out_dir.join(format!("{name}.html"));
+            let content = std::fs::read_to_string(&p).expect("preview readable");
+            assert!(content.contains("<!DOCTYPE html>"), "{name} is a full doc");
+            assert!(
+                content.contains("email-trust") == false && content.contains("nosdesk.com"),
+                "{name} renders the trust line"
+            );
+        }
     }
 }

--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -85,6 +85,11 @@ pub struct EmailBranding {
     pub logo_url: Option<String>,
     pub primary_color: String,
     pub base_url: String,
+    /// Fully-resolved anti-phishing footer line, or `None` to omit it.
+    /// Resolution (toggle, template selection, placeholder
+    /// substitution) happens in `utils::email_branding`; the template
+    /// layer here only renders the string when present.
+    pub security_note: Option<String>,
 }
 
 impl Default for EmailBranding {
@@ -95,6 +100,7 @@ impl Default for EmailBranding {
             primary_color: "#FF6B1A".to_string(),
             base_url: env::var("FRONTEND_URL")
                 .unwrap_or_else(|_| "http://localhost:3000".to_string()),
+            security_note: None,
         }
     }
 }
@@ -112,6 +118,7 @@ impl EmailBranding {
             logo_url,
             primary_color: primary_color.unwrap_or_else(|| "#FF6B1A".to_string()),
             base_url,
+            security_note: None,
         }
     }
 
@@ -429,8 +436,25 @@ impl<'a> EmailTemplate<'a> {
 
         let automated_notice = crate::utils::i18n::tr(locale, "email-footer-automated");
         let help_label = crate::utils::i18n::tr(locale, "email-footer-help");
-        let trust_notice = crate::utils::i18n::tr(locale, "email-trust-notice");
         let help_url = format!("{}/support", self.branding.base_url);
+
+        // The anti-phishing line is opt-in and admin-authored (or the
+        // localized default), resolved upstream into `security_note`.
+        // Escaped here since it carries no trusted markup, and omitted
+        // entirely when the workspace has the note turned off.
+        let security_note_html = self
+            .branding
+            .security_note
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+            .map(|note| {
+                format!(
+                    r#"<p class="nd-faint" style="margin:0;color:{faint};font-size:11.5px;line-height:1.65;">{note}</p>"#,
+                    faint = C_FAINT,
+                    note = escape_html(note),
+                )
+            })
+            .unwrap_or_default();
 
         format!(
             r#"<!DOCTYPE html>
@@ -509,7 +533,7 @@ impl<'a> EmailTemplate<'a> {
               </tr></table>
               <p class="nd-faint" style="margin:18px 0 4px 0;color:{faint};font-size:12px;line-height:1.5;">{automated_notice}</p>
               <p class="nd-faint" style="margin:0 0 16px 0;color:{faint};font-size:12px;">&copy; {year} {app_name} &nbsp;&middot;&nbsp; <a class="nd-link" href="{help_url}" style="color:{faint};">{help_label}</a></p>
-              <p class="nd-faint" style="margin:0;color:{faint};font-size:11.5px;line-height:1.65;">{trust_notice}</p>
+              {security_note_html}
             </td>
           </tr>
 
@@ -1528,7 +1552,14 @@ mod tests {
         use std::str::FromStr;
 
         let svc = svc();
-        let branding = EmailBranding::default(); // default brand orange, no logo
+        let mut branding = EmailBranding::default(); // default brand orange, no logo
+                                                     // Opt-in anti-phishing footer, resolved upstream in
+                                                     // production. Set here so the preview shows the line.
+        branding.security_note = Some(
+            "Acme only ever emails you from acme.example.com. We will never ask \
+             for your password or a login code by email."
+                .to_string(),
+        );
         let locale = unic_langid::LanguageIdentifier::from_str("en-US").unwrap();
 
         let out_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -1574,8 +1605,8 @@ mod tests {
             let content = std::fs::read_to_string(&p).expect("preview readable");
             assert!(content.contains("<!DOCTYPE html>"), "{name} is a full doc");
             assert!(
-                content.contains("email-trust") == false && content.contains("nosdesk.com"),
-                "{name} renders the trust line"
+                content.contains("acme.example.com"),
+                "{name} renders the configured security note"
             );
         }
     }

--- a/backend/src/utils/email_branding.rs
+++ b/backend/src/utils/email_branding.rs
@@ -1,22 +1,107 @@
 use crate::db::DbConnection;
+use crate::models::SiteSettings;
 use crate::repository::site_settings;
 use crate::utils::email::EmailBranding;
 
-/// Get email branding from site settings, with fallbacks
+/// Get email branding from site settings, with fallbacks. Also
+/// resolves the opt-in anti-phishing footer note so the email
+/// template layer only has to render a ready string (or nothing).
 pub fn get_email_branding(conn: &mut DbConnection, base_url: &str) -> EmailBranding {
     site_settings::get_site_settings(conn)
         .map(|settings| {
-            EmailBranding::new(
+            let security_note = resolve_security_note(&settings, base_url);
+            let mut branding = EmailBranding::new(
                 settings.app_name,
                 settings.logo_url,
                 settings.primary_color,
                 base_url.to_string(),
-            )
+            );
+            branding.security_note = security_note;
+            branding
         })
         .unwrap_or_else(|_| EmailBranding {
             app_name: "Nosdesk".to_string(),
             logo_url: None,
             primary_color: "#2563eb".to_string(),
             base_url: base_url.to_string(),
+            security_note: None,
         })
+}
+
+/// Resolve the anti-phishing footer note into a ready-to-render
+/// string, or `None` when the workspace has it turned off.
+///
+/// Custom admin templates use `{{app_name}}` / `{{domain}}` (the
+/// same `{{var}}` shape as auto-ack); the built-in default is the
+/// localized `email-security-note-default` FTL value. `{{domain}}`
+/// resolves to the address the workspace sends mail from, since
+/// that's what the recipient verifies against.
+fn resolve_security_note(settings: &SiteSettings, base_url: &str) -> Option<String> {
+    if !settings.email_security_note_enabled {
+        return None;
+    }
+
+    let domain = outbound_email_domain().unwrap_or_else(|| host_from_url(base_url));
+
+    let note = match settings.email_security_note_template.as_deref() {
+        Some(custom) if !custom.trim().is_empty() => crate::utils::template_variables::substitute(
+            custom,
+            &[
+                ("app_name", settings.app_name.as_str()),
+                ("domain", domain.as_str()),
+            ],
+        ),
+        _ => {
+            // The note is fixed boilerplate, so the workspace default
+            // locale is good enough; we don't thread the recipient
+            // locale through branding for a single footer line.
+            let locale = crate::utils::locale::effective_locale(None, &settings.default_locale);
+            crate::utils::i18n::tr_with(
+                &locale,
+                "email-security-note-default",
+                &[
+                    ("app_name", settings.app_name.clone().into()),
+                    ("domain", domain.clone().into()),
+                ],
+            )
+        }
+    };
+
+    Some(note)
+}
+
+/// The domain the workspace sends mail from, taken from the outbound
+/// "from" address. Mirrors `SMTP_FROM_EMAIL` / `RESEND_FROM_EMAIL`
+/// resolution in `EmailConfig::from_env`. `None` when neither is set,
+/// so the caller can fall back to the app host.
+fn outbound_email_domain() -> std::option::Option<String> {
+    std::env::var("SMTP_FROM_EMAIL")
+        .or_else(|_| std::env::var("RESEND_FROM_EMAIL"))
+        .ok()
+        .and_then(|addr| addr.rsplit_once('@').map(|(_, d)| d.trim().to_string()))
+        .filter(|d| !d.is_empty())
+}
+
+/// Best-effort host extraction from a base URL, used only as the
+/// fallback for `{{domain}}` when no outbound from-address is set.
+/// `https://desk.acme.com/app` -> `desk.acme.com`.
+fn host_from_url(url: &str) -> String {
+    let without_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    without_scheme
+        .split(['/', ':', '?', '#'])
+        .next()
+        .unwrap_or(without_scheme)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_from_url;
+
+    #[test]
+    fn host_from_url_strips_scheme_port_and_path() {
+        assert_eq!(host_from_url("https://desk.acme.com/app"), "desk.acme.com");
+        assert_eq!(host_from_url("http://localhost:3000"), "localhost");
+        assert_eq!(host_from_url("desk.acme.com"), "desk.acme.com");
+    }
 }

--- a/backend/src/utils/template_variables.rs
+++ b/backend/src/utils/template_variables.rs
@@ -55,6 +55,12 @@ pub const AUTO_ACK_VARIABLES: &[&str] = &[
     "app_name",
 ];
 
+/// Variables the email footer security note substitutes. Scoped to
+/// the workspace identity an anti-phishing line needs: the app name
+/// and the domain the workspace sends mail from. No ticket- or
+/// recipient-scoped tokens since the note is fixed boilerplate.
+pub const SECURITY_NOTE_VARIABLES: &[&str] = &["app_name", "domain"];
+
 /// Variables the rules engine substitutes in a `reply` action's body
 /// when a rule is applied. Mirrors `CANNED_RESPONSE_VARIABLES` plus
 /// `agent_name` as an alias for `tech_name`: the synthesis (Phase 1

--- a/fly.hosted-test.toml
+++ b/fly.hosted-test.toml
@@ -1,0 +1,66 @@
+# Hosted-mode TEST product instance for the nosdesk.au dev environment.
+#
+# Unlike fly.dev.toml / fly.rc.toml this deploys the PREBUILT public ghcr
+# image (pinned below) rather than building from source, so the deploy is
+# simply:
+#
+#   fly deploy -c fly.hosted-test.toml
+#
+# Runs in production mode + hosted (multi-tenant) so the control plane can
+# provision tenants via /api/internal/v1/*. Personal fly org. Throwaway:
+# `fly apps destroy nosdesk-au` when done so it stops billing.
+#
+# Secrets are NOT in this file — set them with `fly secrets set` (see the
+# staging runbook): JWT_SECRET, MFA_KEK_V1, DATABASE_URL, REDIS_URL,
+# PLATFORM_PUBLIC_KEY, PLATFORM_ISSUER.
+app = "nosdesk-au"
+primary_region = "syd"
+
+[build]
+  # Prebuilt RC image from GitHub Container Registry (public; fly runs the
+  # linux/amd64 variant). Bump the tag to redeploy a newer RC.
+  image = "ghcr.io/nosdesk/nosdesk:0.1.0-rc.5"
+
+[env]
+  HOST = "0.0.0.0"
+  PORT = "8080"
+  # Validate the real launch posture (secret gates, MFA, plugin trust
+  # root baked into the image at build).
+  ENVIRONMENT = "production"
+  # Hosted multi-tenant: control-plane provisioning surface is live and
+  # the bootstrap-workspace lookup is skipped.
+  NOSDESK_DEPLOYMENT_MODE = "hosted"
+  # Tenant-domain suffix for hosted-mode CORS. Working assumption for the
+  # .au env; finalised in Phase B when tenant DNS goes up. Phase A doesn't
+  # route tenants publicly, so this only pre-seeds the CORS allowlist.
+  NOSDESK_TENANT_DOMAIN = "nosdesk.com.au"
+  # The app's own origin: drives CORS + the WebSocket origin check.
+  FRONTEND_URL = "https://nosdesk-au.fly.dev"
+  # Single machine for the test, so local disk is fine (no cross-machine
+  # consistency need). Switch to s3/Tigris if this ever scales past one.
+  STORAGE_TYPE = "local"
+  # No email for the test: password resets / invitations won't send.
+  SMTP_ENABLED = "false"
+  RUST_LOG = "info"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  # Single machine for the test. WebSocket can't tolerate a cold start,
+  # so don't auto-stop the one machine we run.
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    # /readiness is 200 only when Postgres + Redis are reachable. Generous
+    # grace: first boot runs the full migration set against an empty DB.
+    interval = "30s"
+    timeout = "10s"
+    grace_period = "120s"
+    method = "get"
+    path = "/readiness"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"

--- a/frontend/src/services/brandingService.ts
+++ b/frontend/src/services/brandingService.ts
@@ -26,6 +26,16 @@ export interface BrandingConfig {
    * back to `null`.
    */
   channel_auto_ack_template: string | null
+  /**
+   * Whether the anti-phishing security note renders in the email
+   * footer. Off by default until an admin enables it.
+   */
+  email_security_note_enabled: boolean
+  /**
+   * Admin-overridden security-note body. `null` = use the built-in
+   * localized default. Empty string is sent to clear back to `null`.
+   */
+  email_security_note_template: string | null
 }
 
 export interface UpdateBrandingRequest {
@@ -34,6 +44,8 @@ export interface UpdateBrandingRequest {
   signature_default?: string | null
   channel_auto_ack_enabled?: boolean
   channel_auto_ack_template?: string | null
+  email_security_note_enabled?: boolean
+  email_security_note_template?: string | null
 }
 
 class BrandingService {
@@ -59,7 +71,9 @@ class BrandingService {
         updated_at: null,
         signature_default: null,
         channel_auto_ack_enabled: true,
-        channel_auto_ack_template: null
+        channel_auto_ack_template: null,
+        email_security_note_enabled: false,
+        email_security_note_template: null
       }
     }
   }

--- a/frontend/src/stores/branding.ts
+++ b/frontend/src/stores/branding.ts
@@ -55,7 +55,9 @@ export const useBrandingStore = defineStore('branding', () => {
     updated_at: null,
     signature_default: null,
     channel_auto_ack_enabled: true,
-    channel_auto_ack_template: null
+    channel_auto_ack_template: null,
+    email_security_note_enabled: false,
+    email_security_note_template: null
   })
 
   // Loading state
@@ -178,7 +180,9 @@ export const useBrandingStore = defineStore('branding', () => {
       updated_at: null,
       signature_default: null,
       channel_auto_ack_enabled: true,
-      channel_auto_ack_template: null
+      channel_auto_ack_template: null,
+      email_security_note_enabled: false,
+      email_security_note_template: null
     }
     // Clear the cache
     try {

--- a/frontend/src/views/ChannelsEmailSettingsView.vue
+++ b/frontend/src/views/ChannelsEmailSettingsView.vue
@@ -307,6 +307,54 @@
             </Button>
           </div>
         </form>
+
+        <!-- Anti-phishing security note. Workspace-wide (site_settings),
+             off by default. Renders in the footer of transactional
+             emails, so it lives here next to the other email-facing
+             copy. Shown regardless of channel since password-reset and
+             invitation mail send without an inbound channel. -->
+        <form
+          class="bg-surface border border-default rounded-xl p-6 flex flex-col gap-6"
+          @submit.prevent="saveSecurityNote"
+        >
+          <div class="flex flex-col gap-1">
+            <h2 class="text-lg font-semibold text-primary">
+              {{ $t('admin-channels-email-security-note-heading') }}
+            </h2>
+            <p class="text-sm text-secondary">
+              {{ $t('admin-channels-email-security-note-subtitle') }}
+            </p>
+          </div>
+
+          <ToggleSwitch
+            v-model="securityNoteEnabled"
+            :label="$t('admin-channels-email-security-note-toggle-label')"
+            :description="$t('admin-channels-email-security-note-toggle-description')"
+          />
+
+          <div class="flex flex-col gap-2">
+            <FormTextarea
+              v-model="securityNoteTemplate"
+              :label="$t('admin-channels-email-security-note-template-label')"
+              :placeholder="$t('admin-channels-email-security-note-template-placeholder')"
+              :description="$t('admin-channels-email-security-note-template-hint')"
+              :rows="4"
+              mono
+              :disabled="!securityNoteEnabled"
+            />
+            <p class="text-xs text-tertiary">
+              {{ $t('admin-channels-email-security-note-variables-hint') }}
+              <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;app_name&#125;&#125;</code>,
+              <code class="text-[10px] bg-surface-alt px-1 rounded">&#123;&#123;domain&#125;&#125;</code>
+            </p>
+          </div>
+
+          <div class="flex justify-end border-t border-default pt-4">
+            <Button type="submit" :loading="savingSecurityNote" :disabled="!securityNoteIsDirty">
+              {{ savingSecurityNote ? $t('admin-channels-email-security-note-saving') : $t('admin-channels-email-security-note-save') }}
+            </Button>
+          </div>
+        </form>
       </div>
     </div>
 
@@ -449,9 +497,12 @@ const testing = ref(false);
 const deleting = ref(false);
 const clearing = ref(false);
 const savingAutoAck = ref(false);
+const savingSecurityNote = ref(false);
 const form = ref<FormState>(emptyForm());
 const autoAckEnabled = ref(true);
 const autoAckTemplate = ref('');
+const securityNoteEnabled = ref(false);
+const securityNoteTemplate = ref('');
 const testResult = ref<'idle' | 'ok' | 'failed'>('idle');
 const testErrorMessage = ref('');
 const errorMessage = ref('');
@@ -481,6 +532,8 @@ watch(
     if (!data || autoAckSeeded.value) return;
     autoAckEnabled.value = data.channel_auto_ack_enabled;
     autoAckTemplate.value = data.channel_auto_ack_template ?? '';
+    securityNoteEnabled.value = data.email_security_note_enabled;
+    securityNoteTemplate.value = data.email_security_note_template ?? '';
     autoAckSeeded.value = true;
   },
   { immediate: true },
@@ -580,6 +633,15 @@ const autoAckIsDirty = computed(() => {
   return (
     autoAckEnabled.value !== cfg.channel_auto_ack_enabled ||
     autoAckTemplate.value !== (cfg.channel_auto_ack_template ?? '')
+  );
+});
+
+const securityNoteIsDirty = computed(() => {
+  const cfg = brandingConfig.value;
+  if (!cfg) return false;
+  return (
+    securityNoteEnabled.value !== cfg.email_security_note_enabled ||
+    securityNoteTemplate.value !== (cfg.email_security_note_template ?? '')
   );
 });
 
@@ -705,6 +767,25 @@ async function saveAutoAck() {
     errorMessage.value = createErrorFromResponse(e).getUserMessage();
   } finally {
     savingAutoAck.value = false;
+  }
+}
+
+async function saveSecurityNote() {
+  if (!securityNoteIsDirty.value) return;
+  clearMessages();
+  savingSecurityNote.value = true;
+  try {
+    const updated = await brandingService.updateBrandingConfig({
+      email_security_note_enabled: securityNoteEnabled.value,
+      // Empty string clears back to the built-in localized default.
+      email_security_note_template: securityNoteTemplate.value,
+    });
+    queryCache.setQueryData(BRANDING_KEY, updated);
+    flashSuccess('admin-channels-email-security-note-success-saved');
+  } catch (e: unknown) {
+    errorMessage.value = createErrorFromResponse(e).getUserMessage();
+  } finally {
+    savingSecurityNote.value = false;
   }
 }
 

--- a/i18n/locales/en-AU/main.ftl
+++ b/i18n/locales/en-AU/main.ftl
@@ -5092,11 +5092,6 @@ email-link-fallback-prompt = Or copy and paste this link into your browser:
 email-footer-rights = All rights reserved.
 email-footer-automated = This is an automated message. Please don't reply directly.
 email-footer-help = Help
-# Anti-phishing trust line in the email footer. Carries inline markup:
-# the domain is wrapped in <span class="nd-strong"> for subtle emphasis
-# and the security address is a mailto link. Translators preserve the
-# tags and the literal addresses (nosdesk.com / security@nosdesk.com).
-email-trust-notice = Nosdesk only ever emails you from <span class="nd-strong" style="color:#5b5349;font-weight:600;">nosdesk.com</span>. We'll never ask for your password or login code by email. If a message looks off, forward it to <a class="nd-link" href="mailto:security@nosdesk.com" style="color:#8c8378;font-weight:600;">security@nosdesk.com</a> and delete it.
 markdown-embed-depth-limit = [Embed depth limit reached]
 markdown-embed-circular = [Circular embed detected]
 markdown-embed-reference = Embedded: { $title }

--- a/i18n/locales/en-AU/main.ftl
+++ b/i18n/locales/en-AU/main.ftl
@@ -5091,6 +5091,12 @@ email-notice-success = Success
 email-link-fallback-prompt = Or copy and paste this link into your browser:
 email-footer-rights = All rights reserved.
 email-footer-automated = This is an automated message. Please don't reply directly.
+email-footer-help = Help
+# Anti-phishing trust line in the email footer. Carries inline markup:
+# the domain is wrapped in <span class="nd-strong"> for subtle emphasis
+# and the security address is a mailto link. Translators preserve the
+# tags and the literal addresses (nosdesk.com / security@nosdesk.com).
+email-trust-notice = Nosdesk only ever emails you from <span class="nd-strong" style="color:#5b5349;font-weight:600;">nosdesk.com</span>. We'll never ask for your password or login code by email. If a message looks off, forward it to <a class="nd-link" href="mailto:security@nosdesk.com" style="color:#8c8378;font-weight:600;">security@nosdesk.com</a> and delete it.
 markdown-embed-depth-limit = [Embed depth limit reached]
 markdown-embed-circular = [Circular embed detected]
 markdown-embed-reference = Embedded: { $title }

--- a/i18n/locales/en-GB/main.ftl
+++ b/i18n/locales/en-GB/main.ftl
@@ -5079,6 +5079,12 @@ email-notice-success = Success
 email-link-fallback-prompt = Or copy and paste this link into your browser:
 email-footer-rights = All rights reserved.
 email-footer-automated = This is an automated message. Please do not reply directly to this email.
+email-footer-help = Help
+# Anti-phishing trust line in the email footer. Carries inline markup:
+# the domain is wrapped in <span class="nd-strong"> for subtle emphasis
+# and the security address is a mailto link. Translators preserve the
+# tags and the literal addresses (nosdesk.com / security@nosdesk.com).
+email-trust-notice = Nosdesk only ever emails you from <span class="nd-strong" style="color:#5b5349;font-weight:600;">nosdesk.com</span>. We'll never ask for your password or login code by email. If a message looks off, forward it to <a class="nd-link" href="mailto:security@nosdesk.com" style="color:#8c8378;font-weight:600;">security@nosdesk.com</a> and delete it.
 markdown-embed-depth-limit = [Embed depth limit reached]
 markdown-embed-circular = [Circular embed detected]
 markdown-embed-reference = Embedded: { $title }

--- a/i18n/locales/en-GB/main.ftl
+++ b/i18n/locales/en-GB/main.ftl
@@ -5080,11 +5080,6 @@ email-link-fallback-prompt = Or copy and paste this link into your browser:
 email-footer-rights = All rights reserved.
 email-footer-automated = This is an automated message. Please do not reply directly to this email.
 email-footer-help = Help
-# Anti-phishing trust line in the email footer. Carries inline markup:
-# the domain is wrapped in <span class="nd-strong"> for subtle emphasis
-# and the security address is a mailto link. Translators preserve the
-# tags and the literal addresses (nosdesk.com / security@nosdesk.com).
-email-trust-notice = Nosdesk only ever emails you from <span class="nd-strong" style="color:#5b5349;font-weight:600;">nosdesk.com</span>. We'll never ask for your password or login code by email. If a message looks off, forward it to <a class="nd-link" href="mailto:security@nosdesk.com" style="color:#8c8378;font-weight:600;">security@nosdesk.com</a> and delete it.
 markdown-embed-depth-limit = [Embed depth limit reached]
 markdown-embed-circular = [Circular embed detected]
 markdown-embed-reference = Embedded: { $title }

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -1795,6 +1795,17 @@ admin-channels-email-auto-ack-variables-hint = Variables (filled in per ticket):
 admin-channels-email-auto-ack-saving = Saving…
 admin-channels-email-auto-ack-save = Save auto-ack
 admin-channels-email-auto-ack-success-saved = Auto-acknowledgement updated
+admin-channels-email-security-note-heading = Security note
+admin-channels-email-security-note-subtitle = Add an anti-phishing line to the footer of transactional emails (password resets, invitations) so recipients can tell a genuine message from a spoof.
+admin-channels-email-security-note-toggle-label = Show security note
+admin-channels-email-security-note-toggle-description = Off by default. Turn it on once your sending domain and branding are set.
+admin-channels-email-security-note-template-label = Custom note
+admin-channels-email-security-note-template-placeholder = {"{{"}app_name{"}}"} will only ever email you from {"{{"}domain{"}}"}. We will never ask for your password by email.
+admin-channels-email-security-note-template-hint = Leave blank to use the default wording. Plain text only.
+admin-channels-email-security-note-variables-hint = Variables:
+admin-channels-email-security-note-saving = Saving…
+admin-channels-email-security-note-save = Save security note
+admin-channels-email-security-note-success-saved = Security note updated
 
 # Admin: Microsoft Graph (data import)
 admin-msgraph-back = Back to Data Import
@@ -5710,11 +5721,11 @@ email-link-fallback-prompt = Or copy and paste this link into your browser:
 email-footer-rights = All rights reserved.
 email-footer-automated = This is an automated message. Please do not reply directly to this email.
 email-footer-help = Help
-# Anti-phishing trust line in the email footer. Carries inline markup:
-# the domain is wrapped in <span class="nd-strong"> for subtle emphasis
-# and the security address is a mailto link. Translators preserve the
-# tags and the literal addresses (nosdesk.com / security@nosdesk.com).
-email-trust-notice = Nosdesk only ever emails you from <span class="nd-strong" style="color:#5b5349;font-weight:600;">nosdesk.com</span>. We'll never ask for your password or login code by email. If a message looks off, forward it to <a class="nd-link" href="mailto:security@nosdesk.com" style="color:#8c8378;font-weight:600;">security@nosdesk.com</a> and delete it.
+# Built-in default for the opt-in anti-phishing footer note. Rendered
+# as plain text (escaped), so no markup. { $app_name } is the workspace
+# name and { $domain } is the address it sends mail from. Admins can
+# override this wording per workspace.
+email-security-note-default = { $app_name } will only ever email you from { $domain }. We will never ask for your password or a login code by email. If a message looks suspicious, do not click any links and report it to your IT team.
 markdown-embed-depth-limit = [Embed depth limit reached]
 markdown-embed-circular = [Circular embed detected]
 markdown-embed-reference = Embedded: { $title }

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -5709,6 +5709,12 @@ email-notice-success = Success
 email-link-fallback-prompt = Or copy and paste this link into your browser:
 email-footer-rights = All rights reserved.
 email-footer-automated = This is an automated message. Please do not reply directly to this email.
+email-footer-help = Help
+# Anti-phishing trust line in the email footer. Carries inline markup:
+# the domain is wrapped in <span class="nd-strong"> for subtle emphasis
+# and the security address is a mailto link. Translators preserve the
+# tags and the literal addresses (nosdesk.com / security@nosdesk.com).
+email-trust-notice = Nosdesk only ever emails you from <span class="nd-strong" style="color:#5b5349;font-weight:600;">nosdesk.com</span>. We'll never ask for your password or login code by email. If a message looks off, forward it to <a class="nd-link" href="mailto:security@nosdesk.com" style="color:#8c8378;font-weight:600;">security@nosdesk.com</a> and delete it.
 markdown-embed-depth-limit = [Embed depth limit reached]
 markdown-embed-circular = [Circular embed detected]
 markdown-embed-reference = Embedded: { $title }

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -1693,6 +1693,18 @@ admin-channels-email-auto-ack-variables-hint = Variables (remplies pour chaque t
 admin-channels-email-auto-ack-saving = Enregistrement…
 admin-channels-email-auto-ack-save = Enregistrer l'accusé
 admin-channels-email-auto-ack-success-saved = Accusé de réception mis à jour
+# Note de sécurité (machine, à relire par un locuteur natif).
+admin-channels-email-security-note-heading = Note de sécurité
+admin-channels-email-security-note-subtitle = Ajoutez une ligne anti-hameçonnage au pied des e-mails transactionnels (réinitialisations de mot de passe, invitations) pour que les destinataires distinguent un message authentique d'une usurpation.
+admin-channels-email-security-note-toggle-label = Afficher la note de sécurité
+admin-channels-email-security-note-toggle-description = Désactivée par défaut. Activez-la une fois votre domaine d'envoi et votre image de marque configurés.
+admin-channels-email-security-note-template-label = Note personnalisée
+admin-channels-email-security-note-template-placeholder = {"{{"}app_name{"}}"} ne vous enverra jamais d'e-mail que depuis {"{{"}domain{"}}"}. Nous ne vous demanderons jamais votre mot de passe par e-mail.
+admin-channels-email-security-note-template-hint = Laissez vide pour utiliser le texte par défaut. Texte brut uniquement.
+admin-channels-email-security-note-variables-hint = Variables :
+admin-channels-email-security-note-saving = Enregistrement…
+admin-channels-email-security-note-save = Enregistrer la note de sécurité
+admin-channels-email-security-note-success-saved = Note de sécurité mise à jour
 
 # Admin : Microsoft Graph (import de données)
 admin-msgraph-back = Retour à l'import de données
@@ -5512,9 +5524,9 @@ email-footer-automated = Ceci est un message automatique. Veuillez ne pas y rép
 email-footer-help = Help
 # Anti-phishing trust line in the email footer. Carries inline markup
 # (emphasis span + mailto link); preserve the tags and the literal
-# addresses (nosdesk.com / security@nosdesk.com).
-# TODO: translate
-email-trust-notice = Nosdesk only ever emails you from <span class="nd-strong" style="color:#5b5349;font-weight:600;">nosdesk.com</span>. We'll never ask for your password or login code by email. If a message looks off, forward it to <a class="nd-link" href="mailto:security@nosdesk.com" style="color:#8c8378;font-weight:600;">security@nosdesk.com</a> and delete it.
+# Note anti-hameçonnage par défaut du pied de page (machine, à relire
+# par un locuteur natif). { $app_name } et { $domain } sont substitués.
+email-security-note-default = { $app_name } ne vous enverra jamais d'e-mail que depuis { $domain }. Nous ne vous demanderons jamais votre mot de passe ni de code de connexion par e-mail. Si un message vous semble suspect, ne cliquez sur aucun lien et signalez-le à votre service informatique.
 markdown-embed-depth-limit = [Limite de profondeur d'intégration atteinte]
 markdown-embed-circular = [Intégration circulaire détectée]
 markdown-embed-reference = Intégré : { $title }

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -5508,6 +5508,13 @@ email-notice-success = Succès
 email-link-fallback-prompt = Ou copiez et collez ce lien dans votre navigateur :
 email-footer-rights = Tous droits réservés.
 email-footer-automated = Ceci est un message automatique. Veuillez ne pas y répondre directement.
+# TODO: translate
+email-footer-help = Help
+# Anti-phishing trust line in the email footer. Carries inline markup
+# (emphasis span + mailto link); preserve the tags and the literal
+# addresses (nosdesk.com / security@nosdesk.com).
+# TODO: translate
+email-trust-notice = Nosdesk only ever emails you from <span class="nd-strong" style="color:#5b5349;font-weight:600;">nosdesk.com</span>. We'll never ask for your password or login code by email. If a message looks off, forward it to <a class="nd-link" href="mailto:security@nosdesk.com" style="color:#8c8378;font-weight:600;">security@nosdesk.com</a> and delete it.
 markdown-embed-depth-limit = [Limite de profondeur d'intégration atteinte]
 markdown-embed-circular = [Intégration circulaire détectée]
 markdown-embed-reference = Intégré : { $title }

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -1690,6 +1690,18 @@ admin-channels-email-auto-ack-variables-hint = Variabelen (per ticket ingevuld):
 admin-channels-email-auto-ack-saving = Opslaan…
 admin-channels-email-auto-ack-save = Ontvangstbevestiging opslaan
 admin-channels-email-auto-ack-success-saved = Ontvangstbevestiging bijgewerkt
+# Beveiligingsnotitie (machine, na te kijken door een moedertaalspreker).
+admin-channels-email-security-note-heading = Beveiligingsnotitie
+admin-channels-email-security-note-subtitle = Voeg een anti-phishingregel toe aan de voettekst van transactionele e-mails (wachtwoordherstel, uitnodigingen) zodat ontvangers een echt bericht van een vervalsing kunnen onderscheiden.
+admin-channels-email-security-note-toggle-label = Beveiligingsnotitie tonen
+admin-channels-email-security-note-toggle-description = Standaard uit. Schakel in zodra uw verzenddomein en huisstijl zijn ingesteld.
+admin-channels-email-security-note-template-label = Aangepaste notitie
+admin-channels-email-security-note-template-placeholder = {"{{"}app_name{"}}"} stuurt u alleen ooit e-mail vanaf {"{{"}domain{"}}"}. We vragen u nooit om uw wachtwoord per e-mail.
+admin-channels-email-security-note-template-hint = Laat leeg om de standaardtekst te gebruiken. Alleen platte tekst.
+admin-channels-email-security-note-variables-hint = Variabelen:
+admin-channels-email-security-note-saving = Opslaan…
+admin-channels-email-security-note-save = Beveiligingsnotitie opslaan
+admin-channels-email-security-note-success-saved = Beveiligingsnotitie bijgewerkt
 
 # Admin: Microsoft Graph (gegevensimport)
 admin-msgraph-back = Terug naar gegevensimport
@@ -5503,9 +5515,10 @@ email-footer-automated = Dit is een geautomatiseerd bericht. Reageer hier niet r
 email-footer-help = Help
 # Anti-phishing trust line in the email footer. Carries inline markup
 # (emphasis span + mailto link); preserve the tags and the literal
-# addresses (nosdesk.com / security@nosdesk.com).
-# TODO: translate
-email-trust-notice = Nosdesk only ever emails you from <span class="nd-strong" style="color:#5b5349;font-weight:600;">nosdesk.com</span>. We'll never ask for your password or login code by email. If a message looks off, forward it to <a class="nd-link" href="mailto:security@nosdesk.com" style="color:#8c8378;font-weight:600;">security@nosdesk.com</a> and delete it.
+# Standaard anti-phishingnotitie in de e-mailvoettekst (machine, na te
+# kijken door een moedertaalspreker). { $app_name } en { $domain }
+# worden ingevuld.
+email-security-note-default = { $app_name } stuurt u alleen ooit e-mail vanaf { $domain }. We vragen u nooit om uw wachtwoord of inlogcode per e-mail. Als een bericht verdacht lijkt, klik dan op geen enkele link en meld het bij uw IT-afdeling.
 markdown-embed-depth-limit = [Limiet voor insluitdiepte bereikt]
 markdown-embed-circular = [Circulaire insluiting gedetecteerd]
 markdown-embed-reference = Ingesloten: { $title }

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -5499,6 +5499,13 @@ email-notice-success = Geslaagd
 email-link-fallback-prompt = Of kopieer en plak deze link in uw browser:
 email-footer-rights = Alle rechten voorbehouden.
 email-footer-automated = Dit is een geautomatiseerd bericht. Reageer hier niet rechtstreeks op.
+# TODO: translate
+email-footer-help = Help
+# Anti-phishing trust line in the email footer. Carries inline markup
+# (emphasis span + mailto link); preserve the tags and the literal
+# addresses (nosdesk.com / security@nosdesk.com).
+# TODO: translate
+email-trust-notice = Nosdesk only ever emails you from <span class="nd-strong" style="color:#5b5349;font-weight:600;">nosdesk.com</span>. We'll never ask for your password or login code by email. If a message looks off, forward it to <a class="nd-link" href="mailto:security@nosdesk.com" style="color:#8c8378;font-weight:600;">security@nosdesk.com</a> and delete it.
 markdown-embed-depth-limit = [Limiet voor insluitdiepte bereikt]
 markdown-embed-circular = [Circulaire insluiting gedetecteerd]
 markdown-embed-reference = Ingesloten: { $title }


### PR DESCRIPTION
## What

Replaces the hardcoded `nosdesk.com` anti-phishing line in the transactional email footer with an opt-in, admin-configurable security note. Off by default. The agent's v3 "stationery" email redesign rides along in `email.rs` (it was uncommitted and intermingled with the note render hook).

## Changes

**Storage**
- `site_settings`: `email_security_note_enabled` (bool, default false) + `email_security_note_template` (nullable text). Migration `2026-06-14-040000_add_email_security_note`.

**Render**
- `EmailBranding.security_note: Option<String>` resolved upstream in `email_branding`: toggle check, `{{app_name}}`/`{{domain}}` substitution for custom text, localized `email-security-note-default` fallback. `{{domain}}` comes from `SMTP_FROM_EMAIL`/`RESEND_FROM_EMAIL` with an app-host fallback.
- `email.rs` renders the note only when present; the hardcoded `email-trust-notice` lookup is gone.

**API**
- Branding endpoint validates custom templates against `SECURITY_NOTE_VARIABLES` (`app_name`, `domain`); empty string clears back to the built-in default.

**Admin UI**
- Security-note toggle + template editor in `ChannelsEmailSettingsView`, beside auto-ack.

**i18n**
- `email-security-note-default` + admin keys (en, machine fr/nl pending native review); dead `email-trust-notice` removed from all locales.

## Notes

- The default note localizes to the workspace `default_locale`, not the recipient's locale (one boilerplate footer line). Custom notes are verbatim.
- Custom templates use `{{var}}`; the default uses Fluent `{ $var }`, mirroring the auto-ack pattern.

## Verification

- `cargo check --lib --tests` clean; 174 email tests pass (incl. updated preview render + new `host_from_url` test).
- Frontend `vue-tsc` clean.