### PR TITLE
Hosted-mode OIDC sign-in (platform IdP, per-tenant callbacks)

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -251,12 +251,31 @@ pub(crate) fn build_auth_cookie_response(
 const MAX_LOGIN_ATTEMPTS: u32 = 5;
 const LOCKOUT_DURATION_SECONDS: u64 = 900; // 15 minutes
 
+/// True when local credential auth (password + passkey) must be refused.
+///
+/// In hosted mode the platform OIDC is the only identity source for tenant
+/// users; the static-RP passkey model also only fits self-hosted's single
+/// origin. Login, recovery, and passkey-login handlers short-circuit on
+/// this so the local paths can't be driven directly.
+pub(crate) fn hosted_local_auth_disabled() -> bool {
+    crate::middleware::DeploymentMode::current() == crate::middleware::DeploymentMode::Hosted
+}
+
 // Authentication handlers
 pub async fn login(
     db_pool: web::Data<crate::db::Pool>,
     login_data: web::Json<LoginRequest>,
     request: HttpRequest,
 ) -> impl Responder {
+    // Hosted mode authenticates tenant users exclusively through the
+    // platform OIDC; there is no local product password. Reject local
+    // sign-in even if the endpoint is reached directly.
+    if hosted_local_auth_disabled() {
+        return errors::forbidden(
+            "Password sign-in is disabled. Sign in with your organisation account.",
+        );
+    }
+
     let redis_url = get_redis_url();
     let client_ip = crate::utils::client_ip::from_http_request(&request);
     let lockout_key = RateLimiter::login_attempt_key(&login_data.email, client_ip);
@@ -872,6 +891,7 @@ pub async fn check_setup_status(
                 microsoft_auth_enabled,
                 oidc_enabled,
                 oidc_display_name,
+                local_auth_disabled: hosted_local_auth_disabled(),
             };
 
             // Security headers now applied globally by SecurityHeaders middleware

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -127,33 +127,43 @@ pub async fn get_auth_providers(db_pool: web::Data<Pool>, req: HttpRequest) -> i
 
 // Get enabled authentication providers (for login page) - now environment-based
 pub async fn get_enabled_auth_providers(_db_pool: web::Data<Pool>) -> impl Responder {
-    // Return enabled providers based on environment configuration
-    let mut providers = vec![json!({
-        "id": 1,
-        "provider_type": "local",
-        "name": "Local",
-        "is_default": true
-    })];
+    // Hosted mode trusts exactly one identity source: the platform OIDC.
+    // Local password + Microsoft are never offered, so the login page
+    // shows only single sign-on (and the frontend can auto-initiate it).
+    let hosted =
+        crate::middleware::DeploymentMode::current() == crate::middleware::DeploymentMode::Hosted;
 
-    // Check if Microsoft is configured
-    if std::env::var("MICROSOFT_CLIENT_ID").is_ok()
-        && std::env::var("MICROSOFT_CLIENT_SECRET").is_ok()
-    {
+    let mut providers = Vec::new();
+
+    if !hosted {
         providers.push(json!({
-            "id": 2,
-            "provider_type": "microsoft",
-            "name": "Microsoft",
-            "is_default": false
+            "id": 1,
+            "provider_type": "local",
+            "name": "Local",
+            "is_default": true
         }));
+
+        // Check if Microsoft is configured
+        if std::env::var("MICROSOFT_CLIENT_ID").is_ok()
+            && std::env::var("MICROSOFT_CLIENT_SECRET").is_ok()
+        {
+            providers.push(json!({
+                "id": 2,
+                "provider_type": "microsoft",
+                "name": "Microsoft",
+                "is_default": false
+            }));
+        }
     }
 
-    // Check if OIDC is configured
+    // Check if OIDC is configured. In hosted mode it is the default (and
+    // only) provider, so the client can redirect straight to it.
     if config_utils::is_oidc_enabled() {
         providers.push(json!({
             "id": 3,
             "provider_type": "oidc",
             "name": crate::oidc::get_display_name_cached(),
-            "is_default": false
+            "is_default": hosted
         }));
     }
 
@@ -292,10 +302,16 @@ pub async fn oauth_authorize(
             "state": state
         }))
     } else if provider.provider_type == "oidc" {
+        // Per-tenant OAuth callback (hosted mode): each tenant authenticates
+        // on its own subdomain. Bind it into the signed state so the token
+        // exchange in the callback presents the identical redirect_uri.
+        let callback_redirect = oauth_callback_redirect_uri(&req);
+
         // Generate OIDC authorization URL with PKCE
         match oidc::generate_auth_url(
             oauth_request.redirect_uri.clone(),
             oauth_request.user_connection,
+            callback_redirect.clone(),
         )
         .await
         {
@@ -308,6 +324,7 @@ pub async fn oauth_authorize(
                     Some(auth_data.pkce_verifier),
                     Some(auth_data.nonce),
                     initiation_workspace,
+                    callback_redirect,
                 ) {
                     Ok(token) => token,
                     Err(e) => {
@@ -637,9 +654,13 @@ pub async fn oauth_callback(
                         Ok(id) => id,
                         Err(resp) => return resp,
                     };
-                    let user_result =
-                        find_or_create_oauth_user(&user_info, &provider, &mut conn, workspace_id)
-                            .await;
+                    let user_result = find_or_create_oauth_user(
+                        &user_info,
+                        &provider.provider_type,
+                        &mut conn,
+                        workspace_id,
+                    )
+                    .await;
 
                     match user_result {
                         Ok(user) => {
@@ -693,8 +714,11 @@ pub async fn oauth_callback(
             nonce,
         };
 
-        // Exchange code for tokens and get user info
-        match oidc::exchange_code(code, &auth_data).await {
+        // Exchange code for tokens and get user info. The redirect_uri must
+        // match the one bound at initiation (the tenant's own callback in
+        // hosted mode); it travels in the signed state, tamper-proof.
+        match oidc::exchange_code(code, &auth_data, state_data.callback_redirect_uri.clone()).await
+        {
             Ok(user_info) => {
                 // Check if this is a user connection request (vs. a standard login)
                 if is_connection {
@@ -835,7 +859,7 @@ pub async fn oauth_callback(
                     };
                     let user_result = find_or_create_oauth_user(
                         &oidc_user_info,
-                        &provider,
+                        &oidc_identity_issuer(),
                         &mut conn,
                         workspace_id,
                     )
@@ -977,10 +1001,12 @@ fn create_oauth_state(
         None,
         None,
         workspace_id,
+        None,
     )
 }
 
 // Create a signed state JWT for OAuth/OIDC flow with optional PKCE and nonce
+#[allow(clippy::too_many_arguments)]
 fn create_oauth_state_with_oidc(
     provider_type: &str,
     redirect_uri: Option<String>,
@@ -988,6 +1014,7 @@ fn create_oauth_state_with_oidc(
     pkce_verifier: Option<String>,
     nonce: Option<String>,
     workspace_id: Option<i32>,
+    callback_redirect_uri: Option<String>,
 ) -> Result<String, String> {
     // Get the JWT secret from environment or configuration
     let secret = JWT_SECRET.clone();
@@ -1010,6 +1037,7 @@ fn create_oauth_state_with_oidc(
         pkce_verifier,
         nonce,
         workspace_id,
+        callback_redirect_uri,
     };
 
     // Create the token
@@ -1188,6 +1216,44 @@ fn resolve_request_workspace(request: &HttpRequest) -> Option<i32> {
     workspace_for_login(ctx, crate::middleware::DeploymentMode::current())
 }
 
+/// The OAuth callback `redirect_uri` for THIS request, or `None` to use the
+/// statically configured `OIDC_REDIRECT_URI`.
+///
+/// In hosted mode one app serves every tenant subdomain, so a single static
+/// redirect can't work: each tenant authenticates on its own origin. We
+/// build the callback from the request `Host` (the same header the tenant
+/// middleware resolves the workspace from) over `https` (hosted is always
+/// TLS-terminated). The control plane registers each tenant's callback on
+/// the Hydra client, and Hydra rejects any redirect_uri not in that set, so
+/// a spoofed `Host` can't redirect a code anywhere unregistered. In
+/// self-hosted mode there is one origin and one configured redirect, so we
+/// return `None`.
+fn oauth_callback_redirect_uri(request: &HttpRequest) -> Option<String> {
+    let host = request
+        .headers()
+        .get(actix_web::http::header::HOST)
+        .and_then(|h| h.to_str().ok());
+    callback_redirect_for(host, crate::middleware::DeploymentMode::current())
+}
+
+/// Pure decision behind [`oauth_callback_redirect_uri`], split out for unit
+/// tests. Strips any port and lowercases, matching the tenant middleware's
+/// host normalisation so the redirect host is exactly the resolved tenant.
+fn callback_redirect_for(
+    host: Option<&str>,
+    mode: crate::middleware::DeploymentMode,
+) -> Option<String> {
+    if mode != crate::middleware::DeploymentMode::Hosted {
+        return None;
+    }
+    let host = host?;
+    let host = host.split(':').next().unwrap_or(host).trim().to_lowercase();
+    if host.is_empty() {
+        return None;
+    }
+    Some(format!("https://{host}/api/auth/oauth/callback"))
+}
+
 /// Pure decision behind [`resolve_request_workspace`], split out so the
 /// fail-closed rule is unit-testable without an `HttpRequest` or the
 /// process-wide deployment-mode `OnceLock`.
@@ -1308,9 +1374,52 @@ fn workspace_unresolved_redirect(redirect_uri: &str) -> HttpResponse {
 /// global role (which stays `User`). Owner / admin grants come from
 /// the eager-projection path during workspace provisioning, not
 /// from first-login.
+/// Identity key (`user_auth_identities.provider_type`) for an OIDC login.
+///
+/// In hosted mode this must be the platform issuer (`OIDC_ISSUER_URL`,
+/// e.g. `https://api.nosdesk.dev`), because the control plane projects
+/// each seat under `(iss, sub)`. Resolving a login by the literal
+/// `"oidc"` would miss that seat entirely. In discovery mode the token's
+/// `iss` is verified to equal `OIDC_ISSUER_URL`, so the configured value
+/// is the authoritative issuer.
+///
+/// In self-hosted mode we keep the legacy `"oidc"` key so identities
+/// written before this change (which all used `"oidc"`) still resolve.
+///
+/// The issuer is used verbatim (no normalisation): it must byte-match the
+/// `iss` the control plane stored at projection time, which is the same
+/// string operators set as `OIDC_ISSUER_URL`.
+fn oidc_identity_issuer() -> String {
+    issuer_for_identity(
+        crate::middleware::DeploymentMode::current(),
+        config_utils::get_oidc_issuer_url().ok(),
+    )
+}
+
+/// Pure decision behind [`oidc_identity_issuer`], split out for unit tests
+/// (the process-wide `DeploymentMode::current()` is cached, so the mode is
+/// passed in).
+fn issuer_for_identity(
+    mode: crate::middleware::DeploymentMode,
+    configured_issuer: Option<String>,
+) -> String {
+    use crate::middleware::DeploymentMode;
+    match mode {
+        DeploymentMode::Hosted => configured_issuer
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "oidc".to_string()),
+        DeploymentMode::SelfHosted => "oidc".to_string(),
+    }
+}
+
 async fn find_or_create_oauth_user(
     user_info: &serde_json::Value,
-    provider: &AuthProvider,
+    // Identity issuer for `user_auth_identities.provider_type`. For
+    // Microsoft this is `"microsoft"`; for OIDC it must be the real
+    // issuer (the platform `iss`) so a login resolves the seat the
+    // control plane projected under `(iss, sub)`, not the literal
+    // string `"oidc"`. See `oidc_identity_issuer`.
+    iss: &str,
     conn: &mut DbConnection,
     workspace_id: i32,
 ) -> Result<crate::models::User, String> {
@@ -1358,7 +1467,7 @@ async fn find_or_create_oauth_user(
         .map_err(|e| format!("Failed to hash password: {e}"))?;
 
     let input = ProjectedUserInput {
-        iss: provider.provider_type.clone(),
+        iss: iss.to_string(),
         sub: provider_user_id,
         email,
         name: Some(name),
@@ -1762,6 +1871,81 @@ mod workspace_for_login_tests {
         assert_eq!(
             callback_workspace_decision(None, None, DeploymentMode::SelfHosted),
             Ok(BOOTSTRAP_WORKSPACE_ID)
+        );
+    }
+}
+
+#[cfg(test)]
+mod hosted_auth_tests {
+    use super::{callback_redirect_for, issuer_for_identity};
+    use crate::middleware::DeploymentMode;
+
+    #[test]
+    fn hosted_identity_uses_configured_issuer_verbatim() {
+        // The issuer must byte-match what the control plane stored as
+        // `(iss, sub)`; no trailing-slash normalisation.
+        assert_eq!(
+            issuer_for_identity(
+                DeploymentMode::Hosted,
+                Some("https://api.nosdesk.dev".to_string())
+            ),
+            "https://api.nosdesk.dev"
+        );
+        assert_eq!(
+            issuer_for_identity(
+                DeploymentMode::Hosted,
+                Some("https://api.nosdesk.dev/".to_string())
+            ),
+            "https://api.nosdesk.dev/"
+        );
+    }
+
+    #[test]
+    fn hosted_identity_falls_back_when_issuer_absent_or_empty() {
+        assert_eq!(issuer_for_identity(DeploymentMode::Hosted, None), "oidc");
+        assert_eq!(
+            issuer_for_identity(DeploymentMode::Hosted, Some(String::new())),
+            "oidc"
+        );
+    }
+
+    #[test]
+    fn self_hosted_identity_keeps_legacy_oidc_key() {
+        // Preserves resolution of identities written before this change.
+        assert_eq!(
+            issuer_for_identity(
+                DeploymentMode::SelfHosted,
+                Some("https://idp.example".to_string())
+            ),
+            "oidc"
+        );
+    }
+
+    #[test]
+    fn callback_redirect_is_per_tenant_in_hosted_mode() {
+        assert_eq!(
+            callback_redirect_for(Some("mercury.nosdesk.dev"), DeploymentMode::Hosted),
+            Some("https://mercury.nosdesk.dev/api/auth/oauth/callback".to_string())
+        );
+        // Port stripped, host lowercased.
+        assert_eq!(
+            callback_redirect_for(Some("Venus.Nosdesk.Dev:8080"), DeploymentMode::Hosted),
+            Some("https://venus.nosdesk.dev/api/auth/oauth/callback".to_string())
+        );
+    }
+
+    #[test]
+    fn callback_redirect_is_none_when_unusable_or_self_hosted() {
+        // Self-hosted uses the statically configured OIDC_REDIRECT_URI.
+        assert_eq!(
+            callback_redirect_for(Some("mercury.nosdesk.dev"), DeploymentMode::SelfHosted),
+            None
+        );
+        // Hosted but no/empty Host: fail to None rather than emit a bad URI.
+        assert_eq!(callback_redirect_for(None, DeploymentMode::Hosted), None);
+        assert_eq!(
+            callback_redirect_for(Some(""), DeploymentMode::Hosted),
+            None
         );
     }
 }

--- a/backend/src/handlers/passkeys.rs
+++ b/backend/src/handlers/passkeys.rs
@@ -376,6 +376,14 @@ pub async fn start_passkey_login(
     pool: web::Data<Pool>,
     body: web::Json<StartLoginRequest>,
 ) -> impl Responder {
+    // Passkeys are off in hosted mode (the static-RP model only fits a
+    // single self-hosted origin); tenant users authenticate via OIDC.
+    if crate::handlers::auth::hosted_local_auth_disabled() {
+        return errors::forbidden(
+            "Passkey sign-in is disabled. Sign in with your organisation account.",
+        );
+    }
+
     // Rate limiting based on IP for discoverable auth, email for non-discoverable
     let redis_url = get_redis_url();
 
@@ -469,6 +477,12 @@ pub async fn finish_passkey_login(
     pool: web::Data<Pool>,
     body: web::Json<FinishLoginRequest>,
 ) -> impl Responder {
+    if crate::handlers::auth::hosted_local_auth_disabled() {
+        return errors::forbidden(
+            "Passkey sign-in is disabled. Sign in with your organisation account.",
+        );
+    }
+
     let mut conn = match helpers::db_conn(&pool) {
         Ok(c) => c,
         Err(e) => return e,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -2810,6 +2810,15 @@ pub struct OAuthState {
     /// <=10-minute transition window).
     #[serde(default)]
     pub workspace_id: Option<i32>,
+    /// OAuth `redirect_uri` (the IdP callback) used for THIS flow, bound
+    /// at initiation so the token exchange presents the identical value.
+    /// In hosted mode each tenant authenticates on its own subdomain, so
+    /// this is `https://<tenant-host>/api/auth/oauth/callback`, derived
+    /// from the initiating request's `Host`. `None` means "use the
+    /// statically configured `OIDC_REDIRECT_URI`" (self-hosted, and legacy
+    /// in-flight tokens minted before this field existed).
+    #[serde(default)]
+    pub callback_redirect_uri: Option<String>,
 }
 
 // OAuth Authentication request
@@ -3097,6 +3106,10 @@ pub struct OnboardingStatus {
     pub microsoft_auth_enabled: bool,
     pub oidc_enabled: bool,
     pub oidc_display_name: Option<String>,
+    /// True when local credential auth (password + passkey) is disabled and
+    /// the platform OIDC is the only sign-in path (hosted mode). The login
+    /// UI hides the password/passkey forms and auto-initiates SSO.
+    pub local_auth_disabled: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/backend/src/oidc.rs
+++ b/backend/src/oidc.rs
@@ -24,6 +24,7 @@ use openidconnect::{
     RedirectUrl, Scope, TokenResponse, TokenUrl, UserInfoUrl,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
@@ -290,29 +291,43 @@ impl OidcClientKind {
         &self,
         code: AuthorizationCode,
         pkce_verifier: PkceCodeVerifier,
+        // Per-request redirect override. OAuth requires the token-exchange
+        // redirect_uri to equal the one used at authorize time. In hosted
+        // mode that's the tenant's own subdomain callback; `None` keeps the
+        // client's statically configured redirect.
+        redirect_override: Option<RedirectUrl>,
     ) -> Result<CoreTokenResponse, String> {
         match self {
             Self::Discovered(c) => {
-                let req = c
+                let mut req = c
                     .exchange_code(code)
-                    .map_err(|e| format!("Token endpoint not configured: {e}"))?;
-                req.set_pkce_verifier(pkce_verifier)
-                    .request_async(&*OIDC_HTTP_CLIENT)
+                    .map_err(|e| format!("Token endpoint not configured: {e}"))?
+                    .set_pkce_verifier(pkce_verifier);
+                if let Some(r) = redirect_override {
+                    req = req.set_redirect_uri(Cow::Owned(r));
+                }
+                req.request_async(&*OIDC_HTTP_CLIENT)
                     .await
                     .map_err(|e| format!("Token exchange failed: {e}"))
             }
-            Self::ManualWithUserInfo(c) => c
-                .exchange_code(code)
-                .set_pkce_verifier(pkce_verifier)
-                .request_async(&*OIDC_HTTP_CLIENT)
-                .await
-                .map_err(|e| format!("Token exchange failed: {e}")),
-            Self::ManualNoUserInfo(c) => c
-                .exchange_code(code)
-                .set_pkce_verifier(pkce_verifier)
-                .request_async(&*OIDC_HTTP_CLIENT)
-                .await
-                .map_err(|e| format!("Token exchange failed: {e}")),
+            Self::ManualWithUserInfo(c) => {
+                let mut req = c.exchange_code(code).set_pkce_verifier(pkce_verifier);
+                if let Some(r) = redirect_override {
+                    req = req.set_redirect_uri(Cow::Owned(r));
+                }
+                req.request_async(&*OIDC_HTTP_CLIENT)
+                    .await
+                    .map_err(|e| format!("Token exchange failed: {e}"))
+            }
+            Self::ManualNoUserInfo(c) => {
+                let mut req = c.exchange_code(code).set_pkce_verifier(pkce_verifier);
+                if let Some(r) = redirect_override {
+                    req = req.set_redirect_uri(Cow::Owned(r));
+                }
+                req.request_async(&*OIDC_HTTP_CLIENT)
+                    .await
+                    .map_err(|e| format!("Token exchange failed: {e}"))
+            }
         }
     }
 }
@@ -474,6 +489,10 @@ pub fn generate_nonce() -> Nonce {
 pub async fn generate_auth_url(
     _redirect_uri: Option<String>,
     _user_connection: Option<bool>,
+    // Per-tenant OAuth callback override (hosted mode). Must equal the
+    // redirect_uri later presented at token exchange. `None` uses the
+    // client's configured `OIDC_REDIRECT_URI`.
+    callback_redirect: Option<String>,
 ) -> Result<(String, OidcAuthData), String> {
     let client = get_oidc_client().await?;
     let config = OidcConfig::from_env()?;
@@ -493,6 +512,11 @@ pub async fn generate_auth_url(
         }
     }
 
+    if let Some(r) = callback_redirect {
+        let redirect_url = RedirectUrl::new(r).map_err(|e| format!("Invalid redirect URI: {e}"))?;
+        auth_request = auth_request.set_redirect_uri(Cow::Owned(redirect_url));
+    }
+
     let (auth_url, _csrf_token, _nonce) = auth_request.url();
 
     let auth_data = OidcAuthData {
@@ -506,15 +530,30 @@ pub async fn generate_auth_url(
 }
 
 /// Exchange authorization code for tokens and extract user info
-pub async fn exchange_code(code: &str, auth_data: &OidcAuthData) -> Result<OidcUserInfo, String> {
+pub async fn exchange_code(
+    code: &str,
+    auth_data: &OidcAuthData,
+    // Per-tenant OAuth callback override (hosted mode); must equal the
+    // redirect_uri used at authorize time. `None` uses the configured one.
+    callback_redirect: Option<String>,
+) -> Result<OidcUserInfo, String> {
     let client = get_oidc_client().await?;
     let config = OidcConfig::from_env()?;
 
     let pkce_verifier = PkceCodeVerifier::new(auth_data.pkce_verifier.clone());
 
+    let redirect_override = match callback_redirect {
+        Some(r) => Some(RedirectUrl::new(r).map_err(|e| format!("Invalid redirect URI: {e}"))?),
+        None => None,
+    };
+
     debug!("OIDC: Exchanging authorization code for tokens");
     let token_response = client
-        .exchange_code(AuthorizationCode::new(code.to_string()), pkce_verifier)
+        .exchange_code(
+            AuthorizationCode::new(code.to_string()),
+            pkce_verifier,
+            redirect_override,
+        )
         .await?;
 
     let id_token = token_response

--- a/backend/src/repository/csp_reports.rs
+++ b/backend/src/repository/csp_reports.rs
@@ -51,7 +51,11 @@ pub fn upsert(conn: &mut DbConnection, report: NewCspReport) -> Result<CspReport
 
     diesel::insert_into(csp_reports)
         .values(&report)
-        .on_conflict(dedup_hash)
+        // Conflict target must match the unique index, which is composite
+        // `(workspace_id, dedup_hash)` (dedup is per-tenant). Targeting
+        // `dedup_hash` alone errors: "no unique or exclusion constraint
+        // matching the ON CONFLICT specification".
+        .on_conflict((workspace_id, dedup_hash))
         .do_update()
         .set((
             occurrence_count.eq(occurrence_count + 1),

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -8,6 +8,10 @@ export interface OnboardingStatus {
   microsoft_auth_enabled: boolean;
   oidc_enabled: boolean;
   oidc_display_name?: string;
+  /** Local credential auth (password + passkey) is disabled and the
+   * platform OIDC is the only sign-in path (hosted mode). The login view
+   * hides the local forms and auto-initiates SSO. */
+  local_auth_disabled?: boolean;
 }
 
 /// Mirrors the JSON shape returned by `GET /api/auth/sessions`

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -54,6 +54,10 @@ const showForgotPasswordModal = ref(false);
 const microsoftAuthEnabled = ref(false);
 const oidcEnabled = ref(false);
 const oidcDisplayName = ref("SSO");
+// Hosted mode: local password + passkey are disabled and the platform
+// OIDC is the only sign-in path. The local forms are hidden and SSO is
+// auto-initiated on mount.
+const ssoOnly = ref(false);
 
 // MFA state
 const mfaToken = ref("");
@@ -80,6 +84,16 @@ onMounted(async () => {
     microsoftAuthEnabled.value = setupStatus.microsoft_auth_enabled || false;
     oidcEnabled.value = setupStatus.oidc_enabled || false;
     oidcDisplayName.value = setupStatus.oidc_display_name || "SSO";
+    ssoOnly.value = setupStatus.local_auth_disabled || false;
+
+    // Hosted mode with OIDC configured: the platform OIDC is the only way
+    // in, so go straight there instead of rendering a sign-in form the
+    // user can't use. The local forms stay hidden (ssoOnly) as a fallback
+    // if the redirect is blocked.
+    if (ssoOnly.value && oidcEnabled.value) {
+      void handleOidcLoginClick();
+      return;
+    }
   } catch {
     // Continue to show login page if check fails
   }
@@ -652,7 +666,7 @@ const handleOidcLogoutClick = async () => {
       </div>
 
       <!-- Login Form -->
-      <form v-else @submit.prevent="handleLogin" class="flex flex-col gap-5">
+      <form v-else-if="!ssoOnly" @submit.prevent="handleLogin" class="flex flex-col gap-5">
         <header class="flex flex-col gap-1.5">
           <h1 class="text-2xl sm:text-3xl font-semibold tracking-tight text-primary">
             {{ $t('login-title') }}
@@ -828,6 +842,36 @@ const handleOidcLogoutClick = async () => {
           </div>
         </div>
       </form>
+
+      <!-- SSO-only (hosted mode): the platform OIDC is the only sign-in
+           path. onMounted auto-initiates the redirect; this is the visible
+           state during it, with a manual fallback if it was blocked. -->
+      <div v-else class="flex flex-col gap-5">
+        <header class="flex flex-col gap-1.5">
+          <h1 class="text-2xl sm:text-3xl font-semibold tracking-tight text-primary">
+            {{ $t('login-title') }}
+          </h1>
+          <p class="text-base text-secondary">{{ $t('login-subtitle') }}</p>
+        </header>
+
+        <div
+          v-if="errorMessage"
+          class="bg-status-error/10 border border-status-error/50 text-status-error px-4 py-3 rounded-lg text-sm"
+        >
+          {{ errorMessage }}
+        </div>
+
+        <button
+          type="button"
+          @click="handleOidcLoginClick"
+          :disabled="loadingAction === 'oidc'"
+          class="flex-1 flex gap-1 justify-center items-center py-2 px-4 border border-default rounded-lg shadow-sm text-sm font-medium text-secondary bg-surface hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Spinner v-if="loadingAction === 'oidc'" size="md" class="mr-2" />
+          <span v-if="loadingAction === 'oidc'">{{ $t("login-oidc-connecting") }}</span>
+          <span v-else>{{ $t("login-oidc-cta", { provider: oidcDisplayName }) }}</span>
+        </button>
+      </div>
 
       <!-- Forgot Password Modal -->
       <ForgotPasswordModal


### PR DESCRIPTION
Authenticates hosted tenant users through the platform OIDC and disables local product login. Targets the v1.0.2 image for `nosdesk-au`.

## Backend
- **`(iss, sub)` login resolution.** `find_or_create_oauth_user` takes an explicit `iss`; OIDC passes `OIDC_ISSUER_URL` **verbatim** so it byte-matches the seat the control plane projects under `(iss, sub)`. Previously it passed the literal `"oidc"` and never matched a projected seat. Self-hosted keeps the legacy `"oidc"` key so existing identities still resolve.
- **Local auth off in hosted mode.** `login` + passkey-login return 403; `/auth/providers` lists only OIDC (marked default); `check_setup_status` reports `local_auth_disabled`.
- **Per-tenant callback.** One app serves all tenant subdomains, so the OAuth `redirect_uri` is derived from the request `Host`, bound into the signed state, and replayed at token exchange (authorize and exchange match). Self-hosted uses the static `OIDC_REDIRECT_URI`.
- **csp_reports** upsert `on_conflict` now targets the composite `(workspace_id, dedup_hash)` unique index (fixes the "no matching constraint" error). No migration.

## Frontend
- Login view auto-initiates SSO when `local_auth_disabled` + OIDC configured; local forms stay hidden behind an SSO-only fallback panel.

## Tests
New unit tests for issuer selection and per-tenant redirect derivation; full lib suite + projection integration test pass.

## Config (must byte-match)
Set on `nosdesk-au` (only after this image is deployed): `OIDC_ISSUER_URL=https://api.nosdesk.dev` (issuer only, no manual `*_URI`), `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_REDIRECT_URI`, `OIDC_DISPLAY_NAME=Nosdesk`, `OIDC_SCOPES="openid profile email"`. `OIDC_ISSUER_URL` must byte-match the `iss` the control plane stores (no trailing-slash drift).

## Sequencing
Don't set the product OIDC secrets until this image (v1.0.2) is live — on the old code `is_oidc_enabled()` would flip true and create mismatched identities. Order: tag v1.0.2 → CI image → register Hydra client + set secrets → deploy `nosdesk-au` on :1.0.2.

Out of scope: the OIDC connect (link-account) flow keeps the `"oidc"` key (self-hosted only).