### PR TITLE
Redirect browser into the app after OAuth/OIDC login

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -150,13 +150,45 @@ pub(crate) fn complete_login(
     request: &HttpRequest,
     conn: &mut DbConnection,
 ) -> HttpResponse {
+    match establish_login_session(user, request, conn) {
+        Ok((response, tokens)) => build_auth_cookie_response(response, &tokens),
+        Err(error_response) => error_response,
+    }
+}
+
+/// Finish a login by setting the auth cookies and **redirecting** the
+/// browser to `location` (302 Found), instead of returning JSON.
+///
+/// The OAuth/OIDC browser flow lands the user agent directly on the backend
+/// callback, so it must redirect onward into the app; a JSON body would
+/// dead-end the user on an API URL. (The XHR login path uses
+/// [`complete_login`], which returns JSON for the SPA to consume.)
+pub(crate) fn complete_login_redirect(
+    user: crate::models::User,
+    request: &HttpRequest,
+    conn: &mut DbConnection,
+    location: &str,
+) -> HttpResponse {
+    match establish_login_session(user, request, conn) {
+        Ok((_response, tokens)) => build_auth_cookie_redirect(&tokens, location),
+        Err(error_response) => error_response,
+    }
+}
+
+/// Create the session record, log the success event, and mint the login
+/// tokens. Shared by the JSON and redirect login finishers.
+fn establish_login_session(
+    user: crate::models::User,
+    request: &HttpRequest,
+    conn: &mut DbConnection,
+) -> Result<(crate::models::LoginResponse, jwt_helpers::LoginTokens), HttpResponse> {
     let user_uuid = user.uuid;
 
     let session = match create_session_record(&user_uuid, request, conn) {
         Ok(s) => s,
         Err(e) => {
             tracing::error!("Failed to create session for user {}: {}", user_uuid, e);
-            return errors::internal("Failed to create authentication session");
+            return Err(errors::internal("Failed to create authentication session"));
         }
     };
     let family_id = Uuid::new_v4();
@@ -176,10 +208,7 @@ pub(crate) fn complete_login(
         },
     );
 
-    match jwt_helpers::create_login_response(user, &session.session_id, &family_id, conn) {
-        Ok((response, tokens)) => build_auth_cookie_response(response, &tokens),
-        Err(error_response) => error_response,
-    }
+    jwt_helpers::create_login_response(user, &session.session_id, &family_id, conn)
 }
 
 /// Create a session + MFA token pair, returning an HttpResponse with auth cookies set.
@@ -245,6 +274,26 @@ pub(crate) fn build_auth_cookie_response(
             &tokens.csrf_token,
         ))
         .json(body)
+}
+
+/// Set the auth cookies and redirect (302) to `location`. The browser
+/// OAuth/OIDC callback finishes here so the user lands in the app.
+pub(crate) fn build_auth_cookie_redirect(
+    tokens: &jwt_helpers::LoginTokens,
+    location: &str,
+) -> HttpResponse {
+    HttpResponse::Found()
+        .cookie(crate::utils::cookies::create_access_token_cookie(
+            &tokens.access_token,
+        ))
+        .cookie(crate::utils::cookies::create_refresh_token_cookie(
+            &tokens.refresh_token,
+        ))
+        .cookie(crate::utils::cookies::create_csrf_token_cookie(
+            &tokens.csrf_token,
+        ))
+        .append_header(("Location", location))
+        .finish()
 }
 
 // Account lockout configuration (IP rate limiting handled by middleware)

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -676,7 +676,12 @@ pub async fn oauth_callback(
                                     user.uuid,
                                 );
                             }
-                            crate::handlers::auth::complete_login(user, &request, &mut conn)
+                            crate::handlers::auth::complete_login_redirect(
+                                user,
+                                &request,
+                                &mut conn,
+                                &safe_post_login_location(&state_data.redirect_uri),
+                            )
                         }
                         Err(e) => {
                             error!(error = ?e, "Failed to find or create user");
@@ -876,7 +881,12 @@ pub async fn oauth_callback(
                                     user.uuid,
                                 );
                             }
-                            crate::handlers::auth::complete_login(user, &request, &mut conn)
+                            crate::handlers::auth::complete_login_redirect(
+                                user,
+                                &request,
+                                &mut conn,
+                                &safe_post_login_location(&state_data.redirect_uri),
+                            )
                         }
                         Err(e) => {
                             error!(error = ?e, "Failed to find or create user from OIDC");
@@ -1374,6 +1384,20 @@ fn workspace_unresolved_redirect(redirect_uri: &str) -> HttpResponse {
 /// global role (which stays `User`). Owner / admin grants come from
 /// the eager-projection path during workspace provisioning, not
 /// from first-login.
+/// Sanitise the post-login redirect target before bouncing the browser to
+/// it. `redirect_uri` is client-supplied at initiation (carried through the
+/// signed state), so an unchecked absolute URL would be an open redirect we
+/// could be phished through. Only same-origin relative paths are honoured;
+/// anything else (absolute URL, protocol-relative `//host`, or empty) falls
+/// back to the app root.
+fn safe_post_login_location(redirect_uri: &str) -> String {
+    if redirect_uri.starts_with('/') && !redirect_uri.starts_with("//") {
+        redirect_uri.to_string()
+    } else {
+        "/".to_string()
+    }
+}
+
 /// Identity key (`user_auth_identities.provider_type`) for an OIDC login.
 ///
 /// In hosted mode this must be the platform issuer (`OIDC_ISSUER_URL`,
@@ -1877,8 +1901,21 @@ mod workspace_for_login_tests {
 
 #[cfg(test)]
 mod hosted_auth_tests {
-    use super::{callback_redirect_for, issuer_for_identity};
+    use super::{callback_redirect_for, issuer_for_identity, safe_post_login_location};
     use crate::middleware::DeploymentMode;
+
+    #[test]
+    fn post_login_location_allows_relative_blocks_absolute() {
+        // Same-origin relative paths pass through.
+        assert_eq!(safe_post_login_location("/"), "/");
+        assert_eq!(safe_post_login_location("/tickets/42"), "/tickets/42");
+        // Absolute, protocol-relative, scheme, or empty fall back to root
+        // (no open redirect after authentication).
+        assert_eq!(safe_post_login_location("https://evil.example"), "/");
+        assert_eq!(safe_post_login_location("//evil.example"), "/");
+        assert_eq!(safe_post_login_location("javascript:alert(1)"), "/");
+        assert_eq!(safe_post_login_location(""), "/");
+    }
 
     #[test]
     fn hosted_identity_uses_configured_issuer_verbatim() {


### PR DESCRIPTION
On staging the full OIDC chain succeeds but the browser is shown the raw login JSON instead of entering the helpdesk.

## Fix
The provider redirects the browser straight to `/api/auth/oauth/callback`, but `complete_login` returned a JSON body — dead-ending the user on an API URL. Adds `complete_login_redirect` + `build_auth_cookie_redirect`: same auth cookies, but a **302** to the signed state's `redirect_uri` (defaults to `/`). Both the Microsoft and OIDC browser callbacks now redirect; the XHR login path keeps returning JSON via `complete_login`.

The redirect target is sanitised to same-origin relative paths only (`safe_post_login_location`), so the client-supplied `redirect_uri` can't become an open redirect after authentication.

## On the second item (login-view auto-initiate)
Already shipped in v1.0.2 (PR #19): the login view reads `local_auth_disabled` from `check_setup_status` (the hosted-mode signal) and, when set with OIDC configured, auto-POSTs `/oauth/authorize` and redirects to `auth_url`, never rendering the password/passkey form. No further change here.

## Tests
New unit test for the open-redirect guard; full lib suite (1316) + clippy clean.

Ships as v1.0.3 (v1.0.2 already tagged with the dead-end).