### PR TITLE
Reliably create workspace_members on projection + role change

### DIFF
--- a/backend/src/handlers/internal_workspaces.rs
+++ b/backend/src/handlers/internal_workspaces.rs
@@ -497,6 +497,14 @@ fn valid_settable_role(role: &str) -> bool {
     matches!(role, "admin" | "agent" | "member")
 }
 
+/// Result of the membership upsert in [`set_member_role`]: the role was
+/// applied (updated an existing row or created a missing one), or the
+/// change was refused because it would demote the workspace's only owner.
+enum SetMemberRoleOutcome {
+    Applied,
+    LastOwner,
+}
+
 pub async fn set_member_role(
     _: PlatformAuth,
     pool: web::Data<Pool>,
@@ -540,33 +548,44 @@ pub async fn set_member_role(
             }
         };
 
-    // `update_membership_role` writes `workspace_members` (a meta-table
-    // without RLS) but its audit trigger reads `app.workspace_id`; wrap
-    // in a bypass context like `set_seat_limit` so the actor GUCs are
-    // set. The seat-limit trigger surfaces as a DB error on the UPDATE,
-    // mapped to 403 below — mirrors `workspace_members::update_member_role`.
-    let actor = crate::sync::actor::ActorContext::system("workspace:set_member_role");
+    // Upsert the membership. `workspace_members` is RLS-enabled with a
+    // `WITH CHECK` isolation policy, and its audit trigger reads
+    // `app.workspace_id`; the bypass context both satisfies the policy for
+    // this control-plane write and sets the actor GUCs. The seat-limit
+    // trigger surfaces as a DB error, mapped to 403 below.
+    //
+    // CREATE-IF-ABSENT: if the user has no membership yet (e.g. the eager
+    // projection's grant didn't materialise, or the control plane promotes
+    // before projecting), UPDATE alone is a silent no-op. Fall through to
+    // an insert with the requested role so the promotion actually takes.
+    let actor = crate::sync::actor::ActorContext::system("workspace:set_member_role")
+        .with_workspace(workspace.id);
     let outcome = crate::sync::session::with_actor_bypass_context::<
-        UpdateMembershipRoleResult,
+        SetMemberRoleOutcome,
         diesel::result::Error,
-    >(&mut conn, &actor, |c| {
-        workspaces::update_membership_role(c, workspace.id, user_uuid, &role)
-    });
+    >(
+        &mut conn,
+        &actor,
+        |c| match workspaces::update_membership_role(c, workspace.id, user_uuid, &role)? {
+            UpdateMembershipRoleResult::Updated(_) => Ok(SetMemberRoleOutcome::Applied),
+            UpdateMembershipRoleResult::LastOwner => Ok(SetMemberRoleOutcome::LastOwner),
+            UpdateMembershipRoleResult::NotFound => {
+                workspaces::add_membership(c, workspace.id, user_uuid, &role)?;
+                Ok(SetMemberRoleOutcome::Applied)
+            }
+        },
+    );
 
     match outcome {
-        Ok(UpdateMembershipRoleResult::Updated(_)) => {
-            info!(workspace_id = workspace.id, %user_uuid, role = %role, "set_member_role: updated");
+        Ok(SetMemberRoleOutcome::Applied) => {
+            info!(workspace_id = workspace.id, %user_uuid, role = %role, "set_member_role: applied");
             HttpResponse::Ok().json(SetMemberRoleResponse {
                 user_uuid,
                 workspace_id: workspace.id,
                 role,
             })
         }
-        Ok(UpdateMembershipRoleResult::NotFound) => {
-            warn!(workspace_id = workspace.id, %user_uuid, "set_member_role: not a member");
-            errors::not_found_msg("member not found")
-        }
-        Ok(UpdateMembershipRoleResult::LastOwner) => HttpResponse::Conflict().json(json!({
+        Ok(SetMemberRoleOutcome::LastOwner) => HttpResponse::Conflict().json(json!({
             "error": "last_owner",
             "message": "cannot demote the only owner; promote another member first",
         })),

--- a/backend/src/services/oauth_provisioning.rs
+++ b/backend/src/services/oauth_provisioning.rs
@@ -255,8 +255,22 @@ pub fn find_or_create_projected_user(
     let user_uuid = match &outcome {
         ProjectionOutcome::Created(u) | ProjectionOutcome::Existed(u) => u.uuid,
     };
-    workspaces::add_membership(conn, workspace_id, user_uuid, &role)
-        .map_err(|e| format!("add workspace membership: {e:?}"))?;
+    // Grant membership under a BYPASSRLS context, with an EXPLICIT
+    // workspace_id. Membership is a privileged provisioning write: under
+    // the tenant `nosdesk_app` role it is subject to the workspace_members
+    // RLS `WITH CHECK`, the wrong policy surface for a control-plane grant
+    // (and the reason `set_member_role` already uses a bypass context for
+    // the same table). Passing the workspace_id explicitly (rather than
+    // leaning on the `app.workspace_id` column default) means the row can
+    // never silently land in, or be filtered against, the wrong workspace.
+    let membership_actor = crate::sync::actor::ActorContext::system("provisioning:add_membership")
+        .with_workspace(workspace_id);
+    crate::sync::session::with_actor_bypass_context::<usize, DieselError>(
+        conn,
+        &membership_actor,
+        |c| workspaces::add_membership(c, workspace_id, user_uuid, &role),
+    )
+    .map_err(|e| format!("add workspace membership: {e:?}"))?;
 
     Ok(outcome)
 }

--- a/backend/tests/internal_workspaces_set_member_role.rs
+++ b/backend/tests/internal_workspaces_set_member_role.rs
@@ -41,6 +41,33 @@ fn membership_role(pool: &backend::db::Pool, workspace_id: i32, user_uuid: uuid:
         .expect("load membership role")
 }
 
+/// Count the user's membership rows in a workspace (0 or 1).
+fn membership_count(pool: &backend::db::Pool, workspace_id: i32, user_uuid: uuid::Uuid) -> i64 {
+    use backend::schema::workspace_members;
+    let mut conn = pool.get().expect("conn");
+    workspace_members::table
+        .filter(workspace_members::workspace_id.eq(workspace_id))
+        .filter(workspace_members::user_uuid.eq(user_uuid))
+        .count()
+        .get_result(&mut conn)
+        .expect("count memberships")
+}
+
+/// Delete the user's membership row, simulating a projected user whose
+/// `workspace_members` row never materialised (the production bug
+/// set_member_role's create-if-absent path guards against).
+fn delete_membership(pool: &backend::db::Pool, workspace_id: i32, user_uuid: uuid::Uuid) {
+    use backend::schema::workspace_members;
+    let mut conn = pool.get().expect("conn");
+    diesel::delete(
+        workspace_members::table
+            .filter(workspace_members::workspace_id.eq(workspace_id))
+            .filter(workspace_members::user_uuid.eq(user_uuid)),
+    )
+    .execute(&mut conn)
+    .expect("delete membership");
+}
+
 /// Set the workspace's staff seat cap straight on the row. The seat
 /// trigger only fires on `workspace_members` changes, so this is a
 /// plain UPDATE; the test pool conn writes `workspaces` directly the
@@ -167,6 +194,37 @@ async fn set_member_role_full_contract() {
         membership_role(&pool, acme_id, member_uuid),
         "agent",
         "DB role must flip to agent"
+    );
+
+    // --- 1b: identity exists but membership row is missing -> create it ---
+    // The user was projected (so `(iss, sub)` resolves) but has no
+    // workspace_members row. set_member_role must UPSERT: create the row
+    // with the requested role rather than 404 on the absent membership.
+    delete_membership(&pool, acme_id, member_uuid);
+    assert_eq!(membership_count(&pool, acme_id, member_uuid), 0);
+    let mut resp = client
+        .post(&acme_url)
+        .insert_header(("Authorization", format!("Bearer {platform_token}")))
+        .insert_header(("Content-Type", "application/json"))
+        .send_json(&json!({
+            "iss": "https://idp.example/",
+            "sub": "acme-member-1",
+            "role": "admin",
+        }))
+        .await
+        .expect("send promote-missing-membership");
+    assert_eq!(
+        resp.status(),
+        200,
+        "promoting a projected user with no membership must create it, not 404"
+    );
+    let body: serde_json::Value =
+        serde_json::from_slice(&resp.body().await.expect("body")).expect("json");
+    assert_eq!(body["role"], "admin");
+    assert_eq!(
+        membership_role(&pool, acme_id, member_uuid),
+        "admin",
+        "the recreated membership carries the requested role"
     );
 
     // --- 2: member -> agent at seat_limit=1 (owner holds the seat) -> 403 ---


### PR DESCRIPTION
On the hosted instance `workspace_members` was empty across all workspaces despite users being projected, so the cookie-auth membership gate denied every authenticated user ("Not a member").

## Root cause
Provisioning granted membership through `with_actor_context` (the tenant `nosdesk_app` role), subjecting the `workspace_members` INSERT to that table's RLS `WITH CHECK` isolation policy — the wrong policy surface for a control-plane write. `set_member_role` already uses a **bypass** context for the same table precisely for this reason; provisioning was inconsistent.

## Fixes
1. **Projection (`find_or_create_projected_user`)** grants membership under a **BYPASSRLS** context with an **explicit `workspace_id`** (not the `app.workspace_id` column default), so the row can't be RLS-filtered or land in the wrong workspace. Covers both the eager projection and the lazy OIDC-login path.
2. **`set_member_role` upserts**: if the user has an identity but no membership row, it creates the row with the requested role instead of 404'ing — promoting a not-yet-materialised membership is no longer a no-op. The last-owner demotion guard and seat-limit 403 are preserved.
3. Corrected the stale "`workspace_members` is a meta-table without RLS" comment (it's RLS-enabled with a `WITH CHECK` policy).

**Owner membership (point 3 of the report):** `create_workspace` can't create it — the owner user doesn't exist until the control plane's subsequent `upsert_projected_user(role=owner)`, which fix 1 makes reliable.

## Tests
New regression: promoting a projected user whose membership row was deleted re-creates it with the requested role. Existing projection + set_member_role contracts and full lib suite (1316) pass; clippy clean on changed files.

Ships as v1.0.4.