### PR TITLE
fix(assets): treat a blank serial number as no serial (NULL), not '' (#24)

### DIFF
--- a/backend/migrations/2026-06-18-100000_asset_serial_blank_is_null/down.sql
+++ b/backend/migrations/2026-06-18-100000_asset_serial_blank_is_null/down.sql
@@ -1,0 +1,7 @@
+-- Revert the index predicate to the original NULL-only exemption. The blank ->
+-- NULL backfill is not reversed: the original empty strings are unrecoverable
+-- and were semantically "no serial" anyway.
+DROP INDEX IF EXISTS idx_asset_serial_unique;
+CREATE UNIQUE INDEX idx_asset_serial_unique
+    ON public.assets USING btree (workspace_id, serial_number)
+    WHERE (serial_number IS NOT NULL);

--- a/backend/migrations/2026-06-18-100000_asset_serial_blank_is_null/up.sql
+++ b/backend/migrations/2026-06-18-100000_asset_serial_blank_is_null/up.sql
@@ -1,0 +1,26 @@
+-- Issue #24: a blank serial number must mean "no serial" (NULL), never ''.
+--
+-- idx_asset_serial_unique is a PARTIAL unique index that exempts only NULL
+-- (Postgres treats each NULL as distinct). When "no serial" was stored as the
+-- empty string instead of NULL, a second serial-less asset in the same
+-- workspace collided on that index. The application now normalises blanks to
+-- NULL at the repository boundary; this migration cleans existing rows and
+-- widens the index predicate so a stray '' can never collide again.
+
+-- Backfill: collapse blank / whitespace-only serials to NULL. `assets` is
+-- audited (tr_audit_assets); its trigger inserts into audit_log using
+-- app.workspace_id, which is unset during a migration, so a bulk UPDATE would
+-- crash with a NOT NULL violation (NDX01). Disable the audit trigger for the
+-- backfill (migrations aren't app-level changes that need auditing), then
+-- re-enable it.
+ALTER TABLE public.assets DISABLE TRIGGER tr_audit_assets;
+UPDATE public.assets SET serial_number = NULL WHERE btrim(serial_number) = '';
+ALTER TABLE public.assets ENABLE TRIGGER tr_audit_assets;
+
+-- Harden the uniqueness predicate: only a non-blank serial is unique per
+-- workspace. NULL and '' are both "no serial" and exempt. btrim() is IMMUTABLE,
+-- so it is valid in a partial-index predicate.
+DROP INDEX IF EXISTS idx_asset_serial_unique;
+CREATE UNIQUE INDEX idx_asset_serial_unique
+    ON public.assets USING btree (workspace_id, serial_number)
+    WHERE (serial_number IS NOT NULL AND btrim(serial_number) <> '');

--- a/backend/src/repository/assets.rs
+++ b/backend/src/repository/assets.rs
@@ -351,7 +351,21 @@ pub fn get_device_by_microsoft_id(
         .first(conn)
 }
 
-pub fn create_device(conn: &mut DbConnection, new_device: NewAsset) -> QueryResult<Asset> {
+/// Canonicalise a serial number: trim surrounding whitespace and treat an
+/// empty / whitespace-only value as "no serial" (`None`). Storing "no serial"
+/// as NULL — never `""` — is what lets the partial unique index
+/// `idx_asset_serial_unique` exempt serial-less assets: Postgres treats each
+/// NULL as distinct, but `''` is a real value, so two empty-string serials in a
+/// workspace collide. The DB index also excludes blanks as a backstop, but
+/// normalising here keeps the data model clean at the source. See issue #24.
+fn normalize_serial(serial: Option<String>) -> Option<String> {
+    serial
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+pub fn create_device(conn: &mut DbConnection, mut new_device: NewAsset) -> QueryResult<Asset> {
+    new_device.serial_number = normalize_serial(new_device.serial_number);
     // Wrap the INSERT + sync emit in a single transaction so a
     // crash between the two never leaves the row inserted
     // without a corresponding sync_actions event.
@@ -371,6 +385,11 @@ pub fn update_device(
     device_update: AssetUpdate,
 ) -> QueryResult<Asset> {
     let mut update = device_update;
+    // Same canonicalisation as create: a blank serial means "no serial". With
+    // AsChangeset's `Option<String>`, `None` leaves the column unchanged, so a
+    // cleared serial collapses to "leave as-is" rather than writing `""` (which
+    // would risk a unique-index collision). See issue #24.
+    update.serial_number = normalize_serial(update.serial_number);
     update.updated_at = Some(Utc::now().naive_utc());
 
     // emit::record fires inside emit_asset_event.
@@ -524,6 +543,63 @@ mod tests {
 
         let fetched = get_device_by_id(&mut conn, dev.id).unwrap();
         assert_eq!(fetched.name, "TestDev");
+    }
+
+    #[test]
+    fn normalize_serial_blanks_become_none() {
+        assert_eq!(normalize_serial(None), None);
+        assert_eq!(normalize_serial(Some(String::new())), None);
+        assert_eq!(normalize_serial(Some("   ".into())), None);
+        assert_eq!(
+            normalize_serial(Some("  SN-1  ".into())),
+            Some("SN-1".to_string())
+        );
+        assert_eq!(
+            normalize_serial(Some("SN-2".into())),
+            Some("SN-2".to_string())
+        );
+    }
+
+    #[test]
+    fn blank_serials_do_not_collide_but_real_ones_still_do() {
+        let mut conn = setup_test_connection();
+        // Issue #24: two assets with no serial (empty / whitespace-only) must
+        // both create — normalised to NULL, which the partial unique index
+        // exempts. Before the fix the second collided on idx_asset_serial_unique.
+        let a = NewAsset {
+            serial_number: Some(String::new()),
+            ..minimal_device("Blank A")
+        };
+        let b = NewAsset {
+            serial_number: Some("   ".into()),
+            ..minimal_device("Blank B")
+        };
+        let a = create_device(&mut conn, a).unwrap();
+        let b = create_device(&mut conn, b).unwrap();
+        assert_eq!(a.serial_number, None, "a blank serial is stored as NULL");
+        assert_eq!(b.serial_number, None);
+
+        // A real serial is still unique per workspace, and two serials that
+        // differ only by surrounding whitespace are the same after trimming.
+        create_device(
+            &mut conn,
+            NewAsset {
+                serial_number: Some("SN-DUP".into()),
+                ..minimal_device("Real 1")
+            },
+        )
+        .unwrap();
+        let dup = create_device(
+            &mut conn,
+            NewAsset {
+                serial_number: Some(" SN-DUP ".into()),
+                ..minimal_device("Real 2")
+            },
+        );
+        assert!(
+            dup.is_err(),
+            "a duplicate non-blank serial (after trim) must still collide"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #24.

## Problem
Creating a second asset with no serial number returns a generic 500:

```
POST /api/assets
Database error creating device error=DatabaseError(UniqueViolation,
"duplicate key value violates unique constraint \"idx_asset_serial_unique\"")
```

`idx_asset_serial_unique` is a **partial** unique index on `(workspace_id, serial_number)` that exempts only `NULL` (Postgres treats each NULL as distinct). "No serial" was being stored as the **empty string `''`**, which is a real value, so two serial-less assets in the same workspace collided.

## Fix (root cause + DB backstop)
1. **Normalise at the repository boundary** — `create_device` and `update_device` trim `serial_number` and map empty/whitespace-only to `None`. Every create path (UI, Intune import, CSV/JSON import) funnels through `create_device`, so "no serial" is now canonically `NULL`, never `''`.
2. **Migration** — backfill existing blank serials to `NULL` (with `tr_audit_assets` disabled during the bulk `UPDATE`, per the known NDX01 backfill gotcha), and widen the unique-index predicate to `WHERE serial_number IS NOT NULL AND btrim(serial_number) <> ''` so a stray `''` from any future path can never collide.

This keeps the data model clean (`NULL` = no serial) and makes the constraint correct-by-design, rather than spot-patching one call site.

## Tests
- `normalize_serial` unit test (trim + blank→None).
- DB-backed `blank_serials_do_not_collide_but_real_ones_still_do`: two blank-serial assets both create (the #24 repro), and a duplicate non-blank serial (after trim) still collides. Migration auto-applies via the test harness.
- Full backend lib suite green; `schema.rs` unchanged (index-only migration).

## Self-host note
The migration backfills `''`→`NULL` and is non-reversible for that data (the blanks were semantically "no serial"). No config change required.