### PR TITLE
ci: on-demand dev image builds + faster Docker build

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -67,9 +67,13 @@ jobs:
             NOSDESK_ROOT_PUBKEY=${{ secrets.NOSDESK_ROOT_PUBKEY }}
             NOSDESK_VERSION=dev-${{ steps.vars.outputs.sha }}
             VITE_BUILD_SHA=${{ steps.vars.outputs.sha }}
+            CARGO_PROFILE=fast
           provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Registry cache (no 10 GB GHA-cache cap, so the heavy Rust target
+          # actually survives between runs). Dedicated dev ref: the fast
+          # profile cooks different artifacts than release.
+          cache-from: type=registry,ref=ghcr.io/nosdesk/nosdesk:buildcache-dev
+          cache-to: type=registry,ref=ghcr.io/nosdesk/nosdesk:buildcache-dev,mode=max
 
       - name: Deploy hint
         run: |

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,84 @@
+name: Dev image
+
+# On-demand PRIVATE dev build for staging testing, WITHOUT cutting a version
+# tag. Builds the chosen branch/SHA and pushes to GHCR only, tagged
+# `dev-<short-sha>` plus the floating `dev`. No Docker Hub, no GitHub Release,
+# so the in-app updater (stable-only /releases/latest) never sees it.
+#
+# Deploy the result:
+#   fly deploy -a nosdesk-dev --image ghcr.io/nosdesk/nosdesk:dev-<short-sha>
+#
+# Trigger it (the workflow must be on the default branch to be dispatchable;
+# the `ref` input picks what to BUILD, which can be any branch):
+#   gh workflow run dev-build.yml -f ref=feat/tenant-origin-awareness
+#
+# Required repository secret: NOSDESK_ROOT_PUBKEY (same as Release). GHCR uses
+# the built-in GITHUB_TOKEN via the packages: write permission below.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to build (defaults to the ref this run was dispatched from)'
+        required: false
+        type: string
+
+concurrency:
+  # One dev build per target ref at a time; a newer dispatch supersedes it.
+  group: dev-build-${{ inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image:
+    name: Build & push dev image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Short commit SHA
+        id: vars
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/nosdesk/nosdesk:dev-${{ steps.vars.outputs.sha }}
+            ghcr.io/nosdesk/nosdesk:dev
+          build-args: |
+            NOSDESK_ROOT_PUBKEY=${{ secrets.NOSDESK_ROOT_PUBKEY }}
+            NOSDESK_VERSION=dev-${{ steps.vars.outputs.sha }}
+            VITE_BUILD_SHA=${{ steps.vars.outputs.sha }}
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy hint
+        run: |
+          {
+            echo "### Dev image pushed"
+            echo ""
+            echo "Built \`${{ inputs.ref || github.ref }}\` @ \`${{ steps.vars.outputs.sha }}\`"
+            echo ""
+            echo '```sh'
+            echo "fly deploy -a nosdesk-dev --image ghcr.io/nosdesk/nosdesk:dev-${{ steps.vars.outputs.sha }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,12 @@ jobs:
             NOSDESK_VERSION=${{ steps.meta.outputs.version }}
             VITE_BUILD_SHA=${{ steps.vars.outputs.sha }}
           provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Registry cache instead of GHA cache: the heavy Rust target dir
+          # exceeds GitHub's 10 GB per-repo cache cap and gets evicted, so GHA
+          # cache effectively cold-builds each time. A GHCR cache image has no
+          # such cap. Dedicated release ref (the dev-image workflow uses its own).
+          cache-from: type=registry,ref=ghcr.io/nosdesk/nosdesk:buildcache-release
+          cache-to: type=registry,ref=ghcr.io/nosdesk/nosdesk:buildcache-release,mode=max
 
       # Publish the GitHub Release once the image is up. Prerelease tags
       # (anything with a `-`, e.g. -rc.5/-beta) are marked prerelease, so the

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -231,3 +231,14 @@ tempfile = "3"
 # (the only debug info CI uses) while shrinking target and cache.
 [profile.dev]
 debug = "line-tables-only"
+
+# Fast-compiling unoptimised profile for throwaway dev/staging images (the
+# dev-image CI workflow passes --profile fast). Inherits release config but
+# drops optimisation: opt-level 0 + many codegen units compiles far faster
+# than a real release build. The binary is larger and slower at runtime, which
+# is fine for staging. Output dir is target/fast.
+[profile.fast]
+inherits = "release"
+opt-level = 0
+codegen-units = 256
+debug = false

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,48 +1,66 @@
 # syntax=docker/dockerfile:1.7
-# Multi-stage build with optimized dependency caching
-# Stage 1: Compute a recipe file for dependencies
-FROM rust:1.95-slim-bookworm AS planner
+# Multi-stage build with cargo-chef dependency caching.
+#
+# The Rust stages share a PREBUILT cargo-chef base image (cargo-chef already
+# installed), so nothing compiles cargo-chef from source. cargo-chef splits the
+# dependency build into its own layer, cached unless Cargo.toml/lock change, so
+# a source-only edit skips the heavy dep compile.
 
-# Install cargo-chef for dependency caching
-RUN cargo install cargo-chef --locked
+# Rust build profile. `release` (default) for published images; the dev-image
+# workflow passes `fast` (opt-level 0, output dir target/fast) for quick staging
+# builds. Declared before the first stage so each stage can re-`ARG` it; the
+# `release` path runs the identical `--release` command as before.
+ARG CARGO_PROFILE=release
 
+# Prebuilt cargo-chef on rust 1.95 slim-bookworm (matches the prior base image).
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.95.0-slim-bookworm AS chef
 WORKDIR /app
+
+# Stage 1: compute the dependency recipe.
+FROM chef AS planner
 COPY backend/Cargo.toml backend/Cargo.lock ./
 RUN cargo chef prepare --recipe-path recipe.json
 
-# Stage 2: Build dependencies (this layer will be cached)
-FROM rust:1.95-slim-bookworm AS cacher
-
-# Install build dependencies
+# Stage 2: build dependencies (this layer caches unless deps change).
+FROM chef AS cacher
+ARG CARGO_PROFILE
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
+COPY --from=planner /app/recipe.json recipe.json
+# `--release` (default) is the exact command used before; `fast` and any other
+# named profile go through `--profile`.
+RUN if [ "$CARGO_PROFILE" = "release" ]; then \
+      cargo chef cook --release --recipe-path recipe.json; \
+    else \
+      cargo chef cook --profile "$CARGO_PROFILE" --recipe-path recipe.json; \
+    fi
 
-# Install cargo-chef and diesel CLI
-RUN cargo install cargo-chef --locked
+# Stage 2b: diesel CLI, shipped for manual operator migrations
+# (`docker compose exec backend diesel ...`). Built postgres-only to match the
+# runtime's libpq. Its own stage so the compile runs in PARALLEL with the
+# dependency cook above instead of blocking it.
+FROM chef AS tools
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
 RUN cargo install diesel_cli --no-default-features --features postgres --locked
 
-WORKDIR /app
-COPY --from=planner /app/recipe.json recipe.json
-
-# Build dependencies - this layer will be cached unless dependencies change
-RUN cargo chef cook --release --recipe-path recipe.json
-
-# Stage 3: Build the application
-FROM rust:1.95-slim-bookworm AS builder
-
-# Install build dependencies
+# Stage 3: build the application.
+FROM chef AS builder
+ARG CARGO_PROFILE
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
-# Copy the compiled dependencies from cacher stage
+# Compiled dependencies + cargo caches from the cacher stage.
 COPY --from=cacher /app/target target
 COPY --from=cacher /usr/local/cargo /usr/local/cargo
 
@@ -96,7 +114,11 @@ ARG NOSDESK_VERSION=""
 # secrets discipline tidy by convention.
 RUN NOSDESK_ROOT_PUBKEY="$NOSDESK_ROOT_PUBKEY" \
     NOSDESK_VERSION="$NOSDESK_VERSION" \
-    cargo build --release --bin backend --bin nosdesk-cli
+    sh -c 'if [ "$CARGO_PROFILE" = "release" ]; then \
+      cargo build --release --bin backend --bin nosdesk-cli; \
+    else \
+      cargo build --profile "$CARGO_PROFILE" --bin backend --bin nosdesk-cli; \
+    fi'
 
 # Stage 4: Build frontend
 FROM node:24-bookworm-slim AS frontend-builder
@@ -131,6 +153,7 @@ RUN npm run build-only
 
 # Stage 5: Runtime image
 FROM debian:bookworm-slim AS runtime
+ARG CARGO_PROFILE
 
 # Install only runtime dependencies
 RUN apt-get update && apt-get install -y \
@@ -171,12 +194,13 @@ WORKDIR /app
 
 # Copy the compiled binaries from builder stage. `nosdesk-cli` is
 # placed on PATH so admins can `docker compose exec backend
-# nosdesk-cli ...` without caring about its location.
-COPY --from=builder /app/target/release/backend ./backend
-COPY --from=builder /app/target/release/nosdesk-cli /usr/local/bin/nosdesk-cli
+# nosdesk-cli ...` without caring about its location. The profile dir
+# matches CARGO_PROFILE (release -> target/release, fast -> target/fast).
+COPY --from=builder /app/target/${CARGO_PROFILE}/backend ./backend
+COPY --from=builder /app/target/${CARGO_PROFILE}/nosdesk-cli /usr/local/bin/nosdesk-cli
 
-# Copy diesel CLI from builder stage
-COPY --from=builder /usr/local/cargo/bin/diesel /usr/local/bin/diesel
+# Copy diesel CLI from the tools stage
+COPY --from=tools /usr/local/cargo/bin/diesel /usr/local/bin/diesel
 
 # Copy migrations for automatic migration on startup
 COPY --from=builder /app/migrations ./migrations
@@ -205,4 +229,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
 # Run the application directly (backend handles database initialization)
-CMD ["./backend"] 
+CMD ["./backend"]


### PR DESCRIPTION
## What

Adds an on-demand private dev-image build and cuts the Docker build time.

### Dev-image workflow (`dev-build.yml`)
A `workflow_dispatch` workflow that builds a chosen branch/SHA and pushes to GHCR only as `dev-<short-sha>` + the floating `dev` tag. No Docker Hub push, no GitHub Release, so the in-app updater never sees it. Lets staging iterate with `fly deploy -a nosdesk-dev --image ghcr.io/nosdesk/nosdesk:dev-<sha>` without cutting a version tag per build.

```
gh workflow run dev-build.yml -f ref=<branch>
```

### Build speedups (against the ~22 min build)
- **Prebuilt cargo-chef base** — both from-source `cargo install cargo-chef` compiles (planner + cacher) gone.
- **Diesel in its own stage** — its compile now runs in parallel with the dependency cook instead of blocking it (kept postgres-only to match the runtime's libpq).
- **Registry cache** — both workflows moved off the GHA cache (10 GB cap, evicted on this dep tree, so effectively cold each run) to a GHCR cache image with no cap, on separate `buildcache-release` / `buildcache-dev` refs.
- **`fast` cargo profile** (opt-level 0) via a `CARGO_PROFILE` build-arg; the dev-image workflow uses it. The **release path is byte-identical** (`--release` → `target/release`).

## Validation

- `buildx --check` passed; the `cargo-chef:0.1.77-rust-1.95.0-slim-bookworm` image pulls.
- Full local `--build-arg CARGO_PROFILE=fast` build succeeded end to end; the resulting image runs (`nosdesk-cli --help`, `diesel 2.3.10`), confirming the `target/fast` runtime copy and the parallel diesel stage.
- First registry-cache build is cold (it populates the cache); the speedup shows from the second build on.