### PR TITLE
feat: cloud-hosted v1.1 — Model C, central session, email, customer portal

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -96,6 +96,14 @@ SMTP_FROM_NAME=Nosdesk
 # From email address (defaults to SMTP_USERNAME if not set)
 SMTP_FROM_EMAIL=noreply@yourdomain.com
 
+# VERP bounce correlation (Optional). Hex-encoded secret that signs the
+# per-message Return-Path token so inbound bounces link to the originating
+# row without relying on the remote MTA echoing the Message-ID. Unset =
+# disabled (default From-derived envelope). Enable only after confirming
+# the channel mailbox accepts plus-addressed delivery. Generate with
+# `openssl rand -hex 32`.
+# SMTP_VERP_SECRET=
+
 # Session Geolocation (Optional)
 # Path to a MaxMind-format .mmdb database used to show a coarse
 # "City, Country" for each active session. Fully offline: no IP ever

--- a/backend/migrations/2026-06-18-120000_outbound_emails_mail_class/down.sql
+++ b/backend/migrations/2026-06-18-120000_outbound_emails_mail_class/down.sql
@@ -1,0 +1,2 @@
+-- Dropping the column removes its check constraint too.
+ALTER TABLE public.outbound_emails DROP COLUMN IF EXISTS mail_class;

--- a/backend/migrations/2026-06-18-120000_outbound_emails_mail_class/up.sql
+++ b/backend/migrations/2026-06-18-120000_outbound_emails_mail_class/up.sql
@@ -1,0 +1,22 @@
+-- Outbound mail class: notification vs transactional.
+--
+-- Deliverability features branch on this. List-Unsubscribe + One-Click (B2)
+-- goes only on notification mail (ticket-update notifications, the opt-out-able
+-- class), never on transactional mail (password reset, invitation, the agent's
+-- reply, auto-ack). It is a distinct axis from sender_identity: a conversation
+-- reply is workspace-identity but transactional; a notification is
+-- workspace-identity but notification. The two classes are otherwise
+-- indistinguishable in the queue (notifications carry no ticket/channel/comment
+-- id either), so record the policy explicitly at enqueue and let the worker and
+-- the B-items branch on it rather than re-deriving it.
+--
+-- ADD COLUMN ... DEFAULT is metadata-only in PG11+ (no row rewrite, no per-row
+-- audit-trigger fire). 'transactional' is the safe default: it omits
+-- List-Unsubscribe, so an unclassified row is never treated as opt-out-able.
+
+ALTER TABLE public.outbound_emails
+    ADD COLUMN mail_class character varying(16) NOT NULL DEFAULT 'transactional';
+
+ALTER TABLE public.outbound_emails
+    ADD CONSTRAINT outbound_emails_mail_class_check
+    CHECK (mail_class::text = ANY (ARRAY['transactional'::text, 'notification'::text]));

--- a/backend/src/extractors/auth_context.rs
+++ b/backend/src/extractors/auth_context.rs
@@ -106,6 +106,7 @@ impl AuthContext {
                 platform_role: platform_role.as_str().to_string(),
                 scope: "full".into(),
                 sid: None,
+                workspace_uuid: None,
                 exp: 9999999999,
                 iat: 0,
             },

--- a/backend/src/extractors/workspace_context.rs
+++ b/backend/src/extractors/workspace_context.rs
@@ -52,30 +52,17 @@ impl WorkspaceContext {
     /// OIDC). A verified `custom_domain` wins; otherwise
     /// `<slug>.<NOSDESK_TENANT_DOMAIN>`. Returns `None` in self-hosted mode or
     /// when no tenant base domain is configured, the caller then falls back to
-    /// `FRONTEND_URL` or the request host.
+    /// `FRONTEND_URL` or the request host. Delegates to `utils::tenant_origin`,
+    /// the single source of truth shared with the `Workspace`-keyed callers.
     pub fn canonical_origin(&self) -> Option<String> {
-        let tenant_domain = std::env::var("NOSDESK_TENANT_DOMAIN").ok();
-        canonical_origin_for(
+        use crate::utils::tenant_origin;
+        let host = tenant_origin::canonical_host_for(
             &self.slug,
             self.custom_domain.as_deref(),
-            tenant_domain.as_deref(),
-        )
+            tenant_origin::tenant_domain().as_deref(),
+        );
+        tenant_origin::origin_from_host(host)
     }
-}
-
-/// Pure origin builder behind [`WorkspaceContext::canonical_origin`]. A
-/// non-empty `custom_domain` wins; else `<slug>.<tenant_domain>` when a
-/// non-empty `tenant_domain` is given; else `None`.
-pub(crate) fn canonical_origin_for(
-    slug: &str,
-    custom_domain: Option<&str>,
-    tenant_domain: Option<&str>,
-) -> Option<String> {
-    if let Some(domain) = custom_domain.map(str::trim).filter(|s| !s.is_empty()) {
-        return Some(format!("https://{domain}"));
-    }
-    let tenant_domain = tenant_domain.map(str::trim).filter(|s| !s.is_empty())?;
-    Some(format!("https://{slug}.{tenant_domain}"))
 }
 
 /// Error type for `WorkspaceContext` extraction failures.
@@ -123,40 +110,3 @@ impl FromRequest for WorkspaceContext {
 // T: FromRequest`: extraction failure yields `Ok(None)`. Apex-
 // domain routes (signup, marketing) take `Option<_>` and the
 // handler branches on `Some` / `None`.
-
-#[cfg(test)]
-mod tests {
-    use super::canonical_origin_for;
-
-    #[test]
-    fn custom_domain_wins_over_slug() {
-        assert_eq!(
-            canonical_origin_for("acme", Some("help.acme.com"), Some("nosdesk.dev")),
-            Some("https://help.acme.com".to_string())
-        );
-    }
-
-    #[test]
-    fn slug_plus_tenant_domain_when_no_custom_domain() {
-        assert_eq!(
-            canonical_origin_for("acme", None, Some("nosdesk.dev")),
-            Some("https://acme.nosdesk.dev".to_string())
-        );
-    }
-
-    #[test]
-    fn none_without_custom_domain_or_tenant_domain() {
-        assert_eq!(canonical_origin_for("acme", None, None), None);
-    }
-
-    #[test]
-    fn empty_values_are_treated_as_unset() {
-        // Blank custom domain falls through to the tenant-domain form.
-        assert_eq!(
-            canonical_origin_for("acme", Some("  "), Some("nosdesk.dev")),
-            Some("https://acme.nosdesk.dev".to_string())
-        );
-        // Blank tenant domain with no custom domain yields None.
-        assert_eq!(canonical_origin_for("acme", None, Some("")), None);
-    }
-}

--- a/backend/src/extractors/workspace_context.rs
+++ b/backend/src/extractors/workspace_context.rs
@@ -29,17 +29,53 @@ use uuid::Uuid;
 
 /// Resolved workspace for the current request. Cloned from the
 /// request extensions on extraction (the middleware stuffs it
-/// there). Cheap to clone — small struct with one short
-/// `String`.
+/// there). Cheap to clone — small struct with a couple of short
+/// `String`s.
 #[derive(Debug, Clone)]
 pub struct WorkspaceContext {
     pub workspace_id: i32,
     pub workspace_uuid: Uuid,
     pub slug: String,
     pub name: String,
+    /// Verified custom domain (`workspaces.custom_domain`) if the tenant set
+    /// one. Drives `canonical_origin`: a custom domain is the workspace's
+    /// browser host instead of `<slug>.<tenant_domain>`.
+    pub custom_domain: Option<String>,
     /// Nullable seam for a future org-as-parent-of-workspaces
     /// tier. NULL on every workspace today.
     pub organisation_id: Option<i32>,
+}
+
+impl WorkspaceContext {
+    /// The workspace's canonical browser origin (`https://<host>`), for
+    /// building tenant-facing URLs (password-reset / invite links, WebAuthn,
+    /// OIDC). A verified `custom_domain` wins; otherwise
+    /// `<slug>.<NOSDESK_TENANT_DOMAIN>`. Returns `None` in self-hosted mode or
+    /// when no tenant base domain is configured, the caller then falls back to
+    /// `FRONTEND_URL` or the request host.
+    pub fn canonical_origin(&self) -> Option<String> {
+        let tenant_domain = std::env::var("NOSDESK_TENANT_DOMAIN").ok();
+        canonical_origin_for(
+            &self.slug,
+            self.custom_domain.as_deref(),
+            tenant_domain.as_deref(),
+        )
+    }
+}
+
+/// Pure origin builder behind [`WorkspaceContext::canonical_origin`]. A
+/// non-empty `custom_domain` wins; else `<slug>.<tenant_domain>` when a
+/// non-empty `tenant_domain` is given; else `None`.
+pub(crate) fn canonical_origin_for(
+    slug: &str,
+    custom_domain: Option<&str>,
+    tenant_domain: Option<&str>,
+) -> Option<String> {
+    if let Some(domain) = custom_domain.map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(format!("https://{domain}"));
+    }
+    let tenant_domain = tenant_domain.map(str::trim).filter(|s| !s.is_empty())?;
+    Some(format!("https://{slug}.{tenant_domain}"))
 }
 
 /// Error type for `WorkspaceContext` extraction failures.
@@ -87,3 +123,40 @@ impl FromRequest for WorkspaceContext {
 // T: FromRequest`: extraction failure yields `Ok(None)`. Apex-
 // domain routes (signup, marketing) take `Option<_>` and the
 // handler branches on `Some` / `None`.
+
+#[cfg(test)]
+mod tests {
+    use super::canonical_origin_for;
+
+    #[test]
+    fn custom_domain_wins_over_slug() {
+        assert_eq!(
+            canonical_origin_for("acme", Some("help.acme.com"), Some("nosdesk.dev")),
+            Some("https://help.acme.com".to_string())
+        );
+    }
+
+    #[test]
+    fn slug_plus_tenant_domain_when_no_custom_domain() {
+        assert_eq!(
+            canonical_origin_for("acme", None, Some("nosdesk.dev")),
+            Some("https://acme.nosdesk.dev".to_string())
+        );
+    }
+
+    #[test]
+    fn none_without_custom_domain_or_tenant_domain() {
+        assert_eq!(canonical_origin_for("acme", None, None), None);
+    }
+
+    #[test]
+    fn empty_values_are_treated_as_unset() {
+        // Blank custom domain falls through to the tenant-domain form.
+        assert_eq!(
+            canonical_origin_for("acme", Some("  "), Some("nosdesk.dev")),
+            Some("https://acme.nosdesk.dev".to_string())
+        );
+        // Blank tenant domain with no custom domain yields None.
+        assert_eq!(canonical_origin_for("acme", None, Some("")), None);
+    }
+}

--- a/backend/src/handlers/app_config.rs
+++ b/backend/src/handlers/app_config.rs
@@ -1,0 +1,25 @@
+//! Public, instance-level frontend bootstrap config.
+//!
+//! Served unauthenticated and fetched once at app startup so the SPA can pick
+//! its routing topology before it builds the router. This is instance-global
+//! (identical for every workspace); per-workspace config lives behind auth.
+
+use actix_web::{HttpResponse, Responder};
+use serde_json::json;
+
+/// GET /api/config — instance-level config the frontend needs before auth.
+///
+/// `workspace_routing` tells the SPA where the workspace lives in the URL:
+/// `"path"` for the single-origin agent app (slug in the path, Model C) and
+/// `"host"` for the subdomain / self-hosted model. Derived from the same
+/// selection-resolution switch the backend auth gate reads, so the client's
+/// routing and the server's workspace resolution never disagree.
+pub async fn get_public_config() -> impl Responder {
+    let workspace_routing = if crate::middleware::workspace_context::selection_resolution_enabled()
+    {
+        "path"
+    } else {
+        "host"
+    };
+    HttpResponse::Ok().json(json!({ "workspace_routing": workspace_routing }))
+}

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -220,17 +220,23 @@ pub async fn oauth_authorize(
         }
     };
 
-    // Bind the workspace into the signed state NOW, while the request
-    // context authoritatively identifies the tenant (the user is on their
-    // own workspace subdomain). The callback reads this back rather than
-    // re-deriving the tenant from its own `Host`, so a first-login user is
-    // provisioned into the workspace they actually started from. Hosted
-    // mode fails closed when initiation didn't resolve to a tenant.
-    // User-connection flows don't provision membership, so they carry no
-    // workspace.
+    // Which workspace (if any) to bind into the signed state. The callback
+    // reads this back rather than re-deriving the tenant from its own `Host`.
     let initiation_workspace = if is_user_connection {
+        // User-connection flows don't provision membership, so they carry no
+        // workspace.
+        None
+    } else if crate::middleware::workspace_context::selection_resolution_enabled() {
+        // Model C: central-origin agent login is workspace-agnostic. The agent
+        // authenticates into the central identity and SELECTS a workspace
+        // post-login, so nothing is bound here; the callback resolves an
+        // existing seat instead of provisioning from the login origin.
         None
     } else {
+        // Model B (per-tenant origin) / self-hosted: bind the request-resolved
+        // workspace while the request context authoritatively identifies the
+        // tenant, so a first-login user is provisioned into the workspace they
+        // started from. Fail closed when the tenant can't be determined.
         match resolve_request_workspace(&req) {
             Some(id) => Some(id),
             None => {
@@ -649,45 +655,35 @@ pub async fn oauth_callback(
                     }
                 } else {
                     // Regular login/signup flow
-                    // Find or create user based on OAuth identity
-                    let workspace_id = match resolve_callback_workspace(&state_data, &request) {
-                        Ok(id) => id,
-                        Err(resp) => return resp,
-                    };
-                    let user_result = find_or_create_oauth_user(
+                    let user = match resolve_login_user(
                         &user_info,
                         &provider.provider_type,
+                        &state_data,
+                        &request,
                         &mut conn,
-                        workspace_id,
                     )
-                    .await;
-
-                    match user_result {
-                        Ok(user) => {
-                            info!(user_uuid = %user.uuid, "OAuth: Completing login");
-                            // OAuth provisioning mints users with no search
-                            // observer, so this reindex both indexes a
-                            // first-login user and refreshes the workspace
-                            // tags when a login grants membership in a new
-                            // workspace.
-                            if let Some(search_service) = &search_service {
-                                indexing_tasks::spawn_reindex_user(
-                                    search_service.get_ref().clone(),
-                                    user.uuid,
-                                );
-                            }
-                            crate::handlers::auth::complete_login_redirect(
-                                user,
-                                &request,
-                                &mut conn,
-                                &safe_post_login_location(&state_data.redirect_uri),
-                            )
-                        }
-                        Err(e) => {
-                            error!(error = ?e, "Failed to find or create user");
-                            errors::internal("Failed to authenticate user")
-                        }
+                    .await
+                    {
+                        Ok(user) => user,
+                        Err(resp) => return resp,
+                    };
+                    info!(user_uuid = %user.uuid, "OAuth: Completing login");
+                    // OAuth provisioning mints users with no search observer, so
+                    // this reindex both indexes a first-login user and refreshes
+                    // the workspace tags when a login grants membership in a new
+                    // workspace.
+                    if let Some(search_service) = &search_service {
+                        indexing_tasks::spawn_reindex_user(
+                            search_service.get_ref().clone(),
+                            user.uuid,
+                        );
                     }
+                    crate::handlers::auth::complete_login_redirect(
+                        user,
+                        &request,
+                        &mut conn,
+                        &safe_post_login_location(&state_data.redirect_uri),
+                    )
                 }
             }
             Err(e) => {
@@ -858,41 +854,33 @@ pub async fn oauth_callback(
                         "surname": user_info.family_name,
                     });
 
-                    let workspace_id = match resolve_callback_workspace(&state_data, &request) {
-                        Ok(id) => id,
-                        Err(resp) => return resp,
-                    };
-                    let user_result = find_or_create_oauth_user(
+                    let user = match resolve_login_user(
                         &oidc_user_info,
                         &oidc_identity_issuer(),
+                        &state_data,
+                        &request,
                         &mut conn,
-                        workspace_id,
                     )
-                    .await;
-
-                    match user_result {
-                        Ok(user) => {
-                            info!(user_uuid = %user.uuid, "OIDC: Completing login");
-                            // Index / refresh the user's search doc with
-                            // current workspace memberships (see above).
-                            if let Some(search_service) = &search_service {
-                                indexing_tasks::spawn_reindex_user(
-                                    search_service.get_ref().clone(),
-                                    user.uuid,
-                                );
-                            }
-                            crate::handlers::auth::complete_login_redirect(
-                                user,
-                                &request,
-                                &mut conn,
-                                &safe_post_login_location(&state_data.redirect_uri),
-                            )
-                        }
-                        Err(e) => {
-                            error!(error = ?e, "Failed to find or create user from OIDC");
-                            errors::internal("Failed to authenticate user")
-                        }
+                    .await
+                    {
+                        Ok(user) => user,
+                        Err(resp) => return resp,
+                    };
+                    info!(user_uuid = %user.uuid, "OIDC: Completing login");
+                    // Index / refresh the user's search doc with current
+                    // workspace memberships (see above).
+                    if let Some(search_service) = &search_service {
+                        indexing_tasks::spawn_reindex_user(
+                            search_service.get_ref().clone(),
+                            user.uuid,
+                        );
                     }
+                    crate::handlers::auth::complete_login_redirect(
+                        user,
+                        &request,
+                        &mut conn,
+                        &safe_post_login_location(&state_data.redirect_uri),
+                    )
                 }
             }
             Err(e) => {
@@ -1357,19 +1345,28 @@ fn resolve_callback_workspace(
     }
 }
 
-/// Redirect response for a login that couldn't be tied to a workspace
-/// (hosted mode, unresolved tenant). Mirrors the existing auth-error
-/// redirect shape so the frontend surfaces it the same way.
-fn workspace_unresolved_redirect(redirect_uri: &str) -> HttpResponse {
+/// Build the standard auth-error redirect: bounce to the login redirect target
+/// with an `?auth_error=<message>` the frontend surfaces. Strips any existing
+/// query so the error is the only param.
+fn auth_error_redirect(redirect_uri: &str, message: &str) -> HttpResponse {
     let redirect_path = redirect_uri.split('?').next().unwrap_or("/");
     let error_url = format!(
         "{}?auth_error={}",
         redirect_path,
-        urlencoding::encode("Could not determine the workspace for this sign-in")
+        urlencoding::encode(message)
     );
     HttpResponse::Found()
         .append_header(("Location", error_url))
         .finish()
+}
+
+/// Redirect response for a login that couldn't be tied to a workspace
+/// (Model B / self-hosted, unresolved tenant).
+fn workspace_unresolved_redirect(redirect_uri: &str) -> HttpResponse {
+    auth_error_redirect(
+        redirect_uri,
+        "Could not determine the workspace for this sign-in",
+    )
 }
 
 // Helper function to find or create a user from OAuth profile
@@ -1436,6 +1433,99 @@ fn issuer_for_identity(
     }
 }
 
+/// Extract the login email from an OAuth/OIDC `user_info` blob. MS Graph uses
+/// `mail` for cloud accounts and `userPrincipalName` for hybrid AD; the OIDC
+/// path normalises its claims into the same `mail` field.
+fn oauth_user_email(user_info: &serde_json::Value) -> Result<String, String> {
+    user_info
+        .get("mail")
+        .or_else(|| user_info.get("userPrincipalName"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| "No email in user info".to_string())
+}
+
+/// Extract the provider subject (OIDC `sub` / MS Graph object id) from a
+/// `user_info` blob; stored in `user_auth_identities.external_id`.
+fn oauth_user_sub(user_info: &serde_json::Value) -> Result<String, String> {
+    user_info
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| "No id in user info".to_string())
+}
+
+/// Resolve the local user for a completing OAuth/OIDC login.
+///
+/// - **Model C (selection mode):** resolve an EXISTING seat only, by identity
+///   then email-link. An unknown identity is denied, because the seat and its
+///   workspace membership are provisioned upstream by the control plane, not at
+///   the login origin. No workspace is involved, and the resolve touches only
+///   non-audited, non-RLS identity tables, so it needs no workspace pin.
+/// - **Model B / self-hosted:** resolve the workspace bound at initiation (or
+///   the request's own context) and find-or-create the user as a member of it.
+///
+/// Returns the resolved user, or an `HttpResponse` (auth-error redirect / 500)
+/// the caller should return directly.
+async fn resolve_login_user(
+    user_info: &serde_json::Value,
+    iss: &str,
+    state: &OAuthState,
+    request: &HttpRequest,
+    conn: &mut DbConnection,
+) -> Result<crate::models::User, HttpResponse> {
+    if crate::middleware::workspace_context::selection_resolution_enabled() {
+        return resolve_existing_seat_user(user_info, iss, state, conn);
+    }
+    let workspace_id = resolve_callback_workspace(state, request)?;
+    find_or_create_oauth_user(user_info, iss, conn, workspace_id)
+        .await
+        .map_err(|e| {
+            error!(error = ?e, "Failed to find or create user during login");
+            errors::internal("Failed to authenticate user")
+        })
+}
+
+/// Model C central login: resolve an existing seat without ever creating a user
+/// or granting membership from the login origin. Unknown identity is denied.
+fn resolve_existing_seat_user(
+    user_info: &serde_json::Value,
+    iss: &str,
+    state: &OAuthState,
+    conn: &mut DbConnection,
+) -> Result<crate::models::User, HttpResponse> {
+    let email = oauth_user_email(user_info).map_err(|e| {
+        error!(error = %e, "Central-origin login: cannot read email from user_info");
+        auth_error_redirect(&state.redirect_uri, CENTRAL_LOGIN_NO_SEAT_MSG)
+    })?;
+    let sub = oauth_user_sub(user_info).map_err(|e| {
+        error!(error = %e, "Central-origin login: cannot read subject from user_info");
+        auth_error_redirect(&state.redirect_uri, CENTRAL_LOGIN_NO_SEAT_MSG)
+    })?;
+    // Resolve-only: pass no metadata / password_hash since we never create here.
+    match crate::services::oauth_provisioning::resolve_user_by_identity_or_email(
+        conn, iss, &sub, &email, &None, &None,
+    ) {
+        Ok(Some(user)) => Ok(user),
+        Ok(None) => {
+            warn!(%email, "Central-origin login denied: no seat for this identity");
+            Err(auth_error_redirect(
+                &state.redirect_uri,
+                CENTRAL_LOGIN_NO_SEAT_MSG,
+            ))
+        }
+        Err(e) => {
+            error!(error = %e, "Seat resolution failed during central-origin login");
+            Err(errors::internal("Failed to authenticate user"))
+        }
+    }
+}
+
+/// Shown when a central-origin login resolves a valid identity that holds no
+/// workspace seat (membership is provisioned upstream, not at login).
+const CENTRAL_LOGIN_NO_SEAT_MSG: &str =
+    "No workspace access for this account. Ask your administrator to invite you.";
+
 async fn find_or_create_oauth_user(
     user_info: &serde_json::Value,
     // Identity issuer for `user_auth_identities.provider_type`. For
@@ -1449,18 +1539,7 @@ async fn find_or_create_oauth_user(
 ) -> Result<crate::models::User, String> {
     use crate::services::oauth_provisioning::{find_or_create_projected_user, ProjectedUserInput};
 
-    // Extract email from user info (MS Graph uses `mail` for cloud
-    // accounts, `userPrincipalName` for hybrid AD)
-    let email = match user_info
-        .get("mail")
-        .or_else(|| user_info.get("userPrincipalName"))
-    {
-        Some(email) => match email.as_str() {
-            Some(e) => e.to_string(),
-            None => return Err("Invalid email format".to_string()),
-        },
-        None => return Err("No email in user info".to_string()),
-    };
+    let email = oauth_user_email(user_info)?;
 
     let name = match user_info.get("displayName") {
         Some(name) => match name.as_str() {
@@ -1470,16 +1549,9 @@ async fn find_or_create_oauth_user(
         None => return Err("No name in user info".to_string()),
     };
 
-    // MS Graph object id maps onto OIDC `sub`. We're storing it in
-    // `user_auth_identities.external_id`; same value as the OIDC
-    // sub claim would be for a true OIDC client.
-    let provider_user_id = match user_info.get("id") {
-        Some(id) => match id.as_str() {
-            Some(i) => i.to_string(),
-            None => return Err("Invalid id format".to_string()),
-        },
-        None => return Err("No id in user info".to_string()),
-    };
+    // MS Graph object id maps onto OIDC `sub`, stored in
+    // `user_auth_identities.external_id`.
+    let provider_user_id = oauth_user_sub(user_info)?;
 
     // Random password lands on the identity row so the legacy
     // password-fallback path doesn't see a NULL hash. Eager path
@@ -1809,6 +1881,48 @@ mod connect_redirect_tests {
         );
         // Unrelated query: preserved.
         assert_eq!(strip_query_param("/p?foo=1", "user_uuid"), "/p?foo=1");
+    }
+}
+
+#[cfg(test)]
+mod login_resolution_tests {
+    use super::{auth_error_redirect, oauth_user_email, oauth_user_sub};
+    use serde_json::json;
+
+    #[test]
+    fn email_reads_mail_then_upn() {
+        // OIDC-normalised claims + MS Graph cloud accounts use `mail`.
+        assert_eq!(
+            oauth_user_email(&json!({"mail": "a@x.com"})).unwrap(),
+            "a@x.com"
+        );
+        // Hybrid AD falls back to userPrincipalName.
+        assert_eq!(
+            oauth_user_email(&json!({"userPrincipalName": "b@x.com"})).unwrap(),
+            "b@x.com"
+        );
+        // `mail` wins when both present.
+        assert_eq!(
+            oauth_user_email(&json!({"mail": "a@x.com", "userPrincipalName": "b@x.com"})).unwrap(),
+            "a@x.com"
+        );
+        // Neither present -> error (never silently log in without an email).
+        assert!(oauth_user_email(&json!({"id": "1"})).is_err());
+    }
+
+    #[test]
+    fn sub_reads_id() {
+        assert_eq!(oauth_user_sub(&json!({"id": "abc"})).unwrap(), "abc");
+        assert!(oauth_user_sub(&json!({"mail": "a@x.com"})).is_err());
+    }
+
+    #[test]
+    fn auth_error_redirect_strips_query_and_encodes_message() {
+        let resp = auth_error_redirect("/login?next=/x", "No seat here");
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FOUND);
+        let loc = resp.headers().get("location").unwrap().to_str().unwrap();
+        // Existing query stripped; message percent-encoded onto the clean path.
+        assert_eq!(loc, "/login?auth_error=No%20seat%20here");
     }
 }
 

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -1511,16 +1511,35 @@ async fn resolve_login_user(
     request: &HttpRequest,
     conn: &mut DbConnection,
 ) -> Result<crate::models::User, HttpResponse> {
+    let email_verified = oauth_email_verified(&state.provider_type, user_info);
     if crate::middleware::workspace_context::selection_resolution_enabled() {
-        return resolve_existing_seat_user(user_info, iss, state, conn);
+        return resolve_existing_seat_user(user_info, iss, state, email_verified, conn);
     }
     let workspace_id = resolve_callback_workspace(state, request)?;
-    find_or_create_oauth_user(user_info, iss, conn, workspace_id)
+    find_or_create_oauth_user(user_info, iss, email_verified, conn, workspace_id)
         .await
         .map_err(|e| {
             error!(error = ?e, "Failed to find or create user during login");
             errors::internal("Failed to authenticate user")
         })
+}
+
+/// Whether the provider vouches that the login email is verified, gating the
+/// email-fallback account link (see `resolve_user_by_identity_or_email`).
+///
+/// - Microsoft/Entra: the user authenticated against the directory that owns
+///   the address, so it is provider-verified. Graph `/me` carries no
+///   `email_verified` claim, so trust the directory.
+/// - OIDC: trust only an explicit `email_verified == true`. Absent or false is
+///   NOT verified, so the email-fallback link is refused.
+fn oauth_email_verified(provider_type: &str, user_info: &serde_json::Value) -> bool {
+    match provider_type {
+        "microsoft" => true,
+        _ => user_info
+            .get("email_verified")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    }
 }
 
 /// Model C central login: resolve an existing seat without ever creating a user
@@ -1529,6 +1548,7 @@ fn resolve_existing_seat_user(
     user_info: &serde_json::Value,
     iss: &str,
     state: &OAuthState,
+    email_verified: bool,
     conn: &mut DbConnection,
 ) -> Result<crate::models::User, HttpResponse> {
     let email = oauth_user_email(user_info).map_err(|e| {
@@ -1541,7 +1561,13 @@ fn resolve_existing_seat_user(
     })?;
     // Resolve-only: pass no metadata / password_hash since we never create here.
     match crate::services::oauth_provisioning::resolve_user_by_identity_or_email(
-        conn, iss, &sub, &email, &None, &None,
+        conn,
+        iss,
+        &sub,
+        &email,
+        email_verified,
+        &None,
+        &None,
     ) {
         Ok(Some(user)) => Ok(user),
         Ok(None) => {
@@ -1571,6 +1597,7 @@ async fn find_or_create_oauth_user(
     // control plane projected under `(iss, sub)`, not the literal
     // string `"oidc"`. See `oidc_identity_issuer`.
     iss: &str,
+    email_verified: bool,
     conn: &mut DbConnection,
     workspace_id: i32,
 ) -> Result<crate::models::User, String> {
@@ -1603,6 +1630,7 @@ async fn find_or_create_oauth_user(
         iss: iss.to_string(),
         sub: provider_user_id,
         email,
+        email_verified,
         name: Some(name),
         role: "member".to_string(),
         workspace_id,
@@ -1962,7 +1990,7 @@ mod connect_redirect_tests {
 
 #[cfg(test)]
 mod login_resolution_tests {
-    use super::{auth_error_redirect, oauth_user_email, oauth_user_sub};
+    use super::{auth_error_redirect, oauth_email_verified, oauth_user_email, oauth_user_sub};
     use serde_json::json;
 
     #[test]
@@ -1990,6 +2018,27 @@ mod login_resolution_tests {
     fn sub_reads_id() {
         assert_eq!(oauth_user_sub(&json!({"id": "abc"})).unwrap(), "abc");
         assert!(oauth_user_sub(&json!({"mail": "a@x.com"})).is_err());
+    }
+
+    #[test]
+    fn email_verified_trusts_microsoft_and_explicit_oidc_claim() {
+        // Entra directory emails are provider-verified; Graph sends no claim.
+        assert!(oauth_email_verified("microsoft", &json!({})));
+        // OIDC: only an explicit true counts as verified.
+        assert!(oauth_email_verified(
+            "oidc",
+            &json!({"email_verified": true})
+        ));
+        assert!(!oauth_email_verified(
+            "oidc",
+            &json!({"email_verified": false})
+        ));
+        // Absent or non-bool claim is NOT verified (refuses the email link).
+        assert!(!oauth_email_verified("oidc", &json!({})));
+        assert!(!oauth_email_verified(
+            "oidc",
+            &json!({"email_verified": "true"})
+        ));
     }
 
     #[test]

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -220,33 +220,11 @@ pub async fn oauth_authorize(
         }
     };
 
-    // Which workspace (if any) to bind into the signed state. The callback
-    // reads this back rather than re-deriving the tenant from its own `Host`.
-    let initiation_workspace = if is_user_connection {
-        // User-connection flows don't provision membership, so they carry no
-        // workspace.
-        None
-    } else if crate::middleware::workspace_context::selection_resolution_enabled() {
-        // Model C: central-origin agent login is workspace-agnostic. The agent
-        // authenticates into the central identity and SELECTS a workspace
-        // post-login, so nothing is bound here; the callback resolves an
-        // existing seat instead of provisioning from the login origin.
-        None
-    } else {
-        // Model B (per-tenant origin) / self-hosted: bind the request-resolved
-        // workspace while the request context authoritatively identifies the
-        // tenant, so a first-login user is provisioned into the workspace they
-        // started from. Fail closed when the tenant can't be determined.
-        match resolve_request_workspace(&req) {
-            Some(id) => Some(id),
-            None => {
-                warn!(
-                    "OAuth initiation rejected: request did not resolve to a workspace (hosted mode)"
-                );
-                return errors::bad_request("Could not determine the workspace for this sign-in");
-            }
-        }
-    };
+    // Login no longer binds a workspace into the signed state. Hosted agent
+    // login is workspace-agnostic (Model C: resolve an existing seat at the
+    // callback, select a workspace post-login); self-hosted has one workspace
+    // (the bootstrap), resolved at the callback. The Model B per-tenant binding
+    // was retired with per-tenant federation.
 
     // For Microsoft Entra, generate the authorization URL
     if provider.provider_type == "microsoft" {
@@ -289,7 +267,6 @@ pub async fn oauth_authorize(
             "microsoft",
             oauth_request.redirect_uri.clone(),
             oauth_request.user_connection,
-            initiation_workspace,
         ) {
             Ok(pair) => pair,
             Err(e) => {
@@ -332,7 +309,6 @@ pub async fn oauth_authorize(
                     oauth_request.user_connection,
                     Some(auth_data.pkce_verifier),
                     Some(auth_data.nonce),
-                    initiation_workspace,
                     callback_redirect,
                 ) {
                     Ok(pair) => pair,
@@ -688,7 +664,6 @@ pub async fn oauth_callback(
                         &user_info,
                         &provider.provider_type,
                         &state_data,
-                        &request,
                         &mut conn,
                     )
                     .await
@@ -887,7 +862,6 @@ pub async fn oauth_callback(
                         &oidc_user_info,
                         &oidc_identity_issuer(),
                         &state_data,
-                        &request,
                         &mut conn,
                     )
                     .await
@@ -1022,7 +996,6 @@ fn create_oauth_state(
     provider_type: &str,
     redirect_uri: Option<String>,
     user_connection: Option<bool>,
-    workspace_id: Option<i32>,
 ) -> Result<(String, String), String> {
     create_oauth_state_with_oidc(
         provider_type,
@@ -1030,7 +1003,6 @@ fn create_oauth_state(
         user_connection,
         None,
         None,
-        workspace_id,
         None,
     )
 }
@@ -1044,7 +1016,6 @@ fn create_oauth_state_with_oidc(
     user_connection: Option<bool>,
     pkce_verifier: Option<String>,
     nonce: Option<String>,
-    workspace_id: Option<i32>,
     callback_redirect_uri: Option<String>,
 ) -> Result<(String, String), String> {
     // Get the JWT secret from environment or configuration
@@ -1070,7 +1041,6 @@ fn create_oauth_state_with_oidc(
         user_connection,
         pkce_verifier,
         nonce,
-        workspace_id,
         callback_redirect_uri,
         binding: Some(state.clone()),
     };
@@ -1232,25 +1202,6 @@ async fn get_microsoft_user_info(access_token: &str) -> Result<serde_json::Value
     }
 }
 
-/// Resolve the workspace an OAuth/OIDC login is being INITIATED for,
-/// from the `WorkspaceContext` the workspace middleware attaches to the
-/// request. The result is bound into the signed state so the callback
-/// can trust it; see [`OAuthState::workspace_id`].
-///
-/// In HOSTED mode a missing context means the request didn't resolve to
-/// a tenant (apex domain, unknown subdomain, or a transient resolve
-/// failure). We MUST fail closed: returning `None` rejects initiation
-/// rather than starting a login that would later have to guess a
-/// workspace. In SELF-HOSTED mode there is exactly one workspace, so the
-/// bootstrap workspace is the correct and only answer.
-fn resolve_request_workspace(request: &HttpRequest) -> Option<i32> {
-    let ctx = request
-        .extensions()
-        .get::<crate::extractors::WorkspaceContext>()
-        .map(|w| w.workspace_id);
-    workspace_for_login(ctx, crate::middleware::DeploymentMode::current())
-}
-
 /// The OAuth callback `redirect_uri` for THIS request, or `None` to use the
 /// statically configured `OIDC_REDIRECT_URI`.
 ///
@@ -1289,99 +1240,6 @@ fn callback_redirect_for(
     Some(format!("https://{host}/api/auth/oauth/callback"))
 }
 
-/// Pure decision behind [`resolve_request_workspace`], split out so the
-/// fail-closed rule is unit-testable without an `HttpRequest` or the
-/// process-wide deployment-mode `OnceLock`.
-fn workspace_for_login(
-    resolved: Option<i32>,
-    mode: crate::middleware::DeploymentMode,
-) -> Option<i32> {
-    use crate::middleware::DeploymentMode;
-    match resolved {
-        Some(id) => Some(id),
-        None => match mode {
-            DeploymentMode::SelfHosted => Some(crate::sync::actor::BOOTSTRAP_WORKSPACE_ID),
-            DeploymentMode::Hosted => None,
-        },
-    }
-}
-
-/// Why a callback couldn't settle on a workspace to provision into.
-#[derive(Debug, PartialEq, Eq)]
-enum WorkspaceBindingError {
-    /// The workspace bound into the (signed) state at initiation
-    /// disagrees with the one the callback request resolved to. That
-    /// means a state minted for one tenant is being completed against
-    /// another (replay / cross-tenant), so we refuse.
-    Mismatch { state_ws: i32, ctx_ws: i32 },
-    /// Neither the state nor the request yields a workspace: a legacy
-    /// in-flight token (minted before workspace binding) completing on an
-    /// unresolved host. Fail closed.
-    Unresolved,
-}
-
-/// Pure decision for the CALLBACK: which workspace to provision a
-/// first-login user into.
-///
-/// The workspace bound into the signed state at initiation
-/// (`state_ws`) is authoritative — it was captured where the tenant was
-/// unambiguous and is integrity-protected by the state's signature. The
-/// callback request's own resolved context (`ctx_ws`) is used only as a
-/// defense-in-depth cross-check, never as the primary source, so the
-/// callback's `Host` header can't redirect a login into another tenant.
-///
-/// `state_ws == None` is the transitional path for tokens minted before
-/// this field existed; it falls back to the same fail-closed request
-/// resolution as initiation and goes dead once those tokens expire.
-fn callback_workspace_decision(
-    state_ws: Option<i32>,
-    ctx_ws: Option<i32>,
-    mode: crate::middleware::DeploymentMode,
-) -> Result<i32, WorkspaceBindingError> {
-    match state_ws {
-        Some(state_ws) => match ctx_ws {
-            Some(ctx_ws) if ctx_ws != state_ws => {
-                Err(WorkspaceBindingError::Mismatch { state_ws, ctx_ws })
-            }
-            _ => Ok(state_ws),
-        },
-        None => workspace_for_login(ctx_ws, mode).ok_or(WorkspaceBindingError::Unresolved),
-    }
-}
-
-/// Resolve the workspace to provision a first-login user into at the
-/// OAuth/OIDC callback, authoritatively from the signed state with a
-/// defense-in-depth cross-check against the callback request's context.
-/// On any failure returns the same auth-error redirect the rest of the
-/// callback uses, so the caller can `return` it directly.
-fn resolve_callback_workspace(
-    state: &OAuthState,
-    request: &HttpRequest,
-) -> Result<i32, HttpResponse> {
-    let ctx_ws = request
-        .extensions()
-        .get::<crate::extractors::WorkspaceContext>()
-        .map(|w| w.workspace_id);
-    match callback_workspace_decision(
-        state.workspace_id,
-        ctx_ws,
-        crate::middleware::DeploymentMode::current(),
-    ) {
-        Ok(id) => Ok(id),
-        Err(WorkspaceBindingError::Mismatch { state_ws, ctx_ws }) => {
-            warn!(
-                state_ws,
-                ctx_ws, "OAuth callback rejected: state/context workspace mismatch (replay?)"
-            );
-            Err(workspace_unresolved_redirect(&state.redirect_uri))
-        }
-        Err(WorkspaceBindingError::Unresolved) => {
-            warn!("OAuth callback rejected: no workspace bound in state and request did not resolve one");
-            Err(workspace_unresolved_redirect(&state.redirect_uri))
-        }
-    }
-}
-
 /// Build the standard auth-error redirect: bounce to the login redirect target
 /// with an `?auth_error=<message>` the frontend surfaces. Strips any existing
 /// query so the error is the only param.
@@ -1395,15 +1253,6 @@ fn auth_error_redirect(redirect_uri: &str, message: &str) -> HttpResponse {
     HttpResponse::Found()
         .append_header(("Location", error_url))
         .finish()
-}
-
-/// Redirect response for a login that couldn't be tied to a workspace
-/// (Model B / self-hosted, unresolved tenant).
-fn workspace_unresolved_redirect(redirect_uri: &str) -> HttpResponse {
-    auth_error_redirect(
-        redirect_uri,
-        "Could not determine the workspace for this sign-in",
-    )
 }
 
 // Helper function to find or create a user from OAuth profile
@@ -1499,8 +1348,10 @@ fn oauth_user_sub(user_info: &serde_json::Value) -> Result<String, String> {
 ///   workspace membership are provisioned upstream by the control plane, not at
 ///   the login origin. No workspace is involved, and the resolve touches only
 ///   non-audited, non-RLS identity tables, so it needs no workspace pin.
-/// - **Model B / self-hosted:** resolve the workspace bound at initiation (or
-///   the request's own context) and find-or-create the user as a member of it.
+/// - **Self-hosted:** one workspace (the bootstrap); find-or-create the user as
+///   a member of it. Reaching here in HOSTED mode means selection mode is off on
+///   a hosted deployment, unsupported since per-tenant federation was retired
+///   (hosted login is Model C). Fail closed.
 ///
 /// Returns the resolved user, or an `HttpResponse` (auth-error redirect / 500)
 /// the caller should return directly.
@@ -1508,14 +1359,19 @@ async fn resolve_login_user(
     user_info: &serde_json::Value,
     iss: &str,
     state: &OAuthState,
-    request: &HttpRequest,
     conn: &mut DbConnection,
 ) -> Result<crate::models::User, HttpResponse> {
     let email_verified = oauth_email_verified(&state.provider_type, user_info);
     if crate::middleware::workspace_context::selection_resolution_enabled() {
         return resolve_existing_seat_user(user_info, iss, state, email_verified, conn);
     }
-    let workspace_id = resolve_callback_workspace(state, request)?;
+    let workspace_id = match crate::middleware::DeploymentMode::current() {
+        crate::middleware::DeploymentMode::SelfHosted => crate::sync::actor::BOOTSTRAP_WORKSPACE_ID,
+        crate::middleware::DeploymentMode::Hosted => {
+            error!("hosted OAuth login reached without selection mode; per-tenant federation is retired");
+            return Err(errors::internal("Authentication is misconfigured"));
+        }
+    };
     find_or_create_oauth_user(user_info, iss, email_verified, conn, workspace_id)
         .await
         .map_err(|e| {
@@ -1891,7 +1747,6 @@ pub async fn oauth_connect(
             &provider.provider_type,
             Some(actual_redirect_uri),
             Some(true),
-            None,
         ) {
             Ok(pair) => pair,
             Err(e) => {
@@ -1936,7 +1791,7 @@ mod oauth_state_binding_tests {
     #[test]
     fn state_embeds_binding_and_round_trips() {
         ensure_jwt_secret();
-        let (token, binding) = create_oauth_state("oidc", None, None, None).unwrap();
+        let (token, binding) = create_oauth_state("oidc", None, None).unwrap();
         assert!(
             !binding.is_empty(),
             "binding must be a non-empty random value"
@@ -1950,8 +1805,8 @@ mod oauth_state_binding_tests {
     #[test]
     fn two_flows_get_distinct_bindings() {
         ensure_jwt_secret();
-        let (_, b1) = create_oauth_state("oidc", None, None, None).unwrap();
-        let (_, b2) = create_oauth_state("oidc", None, None, None).unwrap();
+        let (_, b1) = create_oauth_state("oidc", None, None).unwrap();
+        let (_, b2) = create_oauth_state("oidc", None, None).unwrap();
         assert_ne!(b1, b2, "each flow must bind to a fresh random value");
     }
 }
@@ -2048,93 +1903,6 @@ mod login_resolution_tests {
         let loc = resp.headers().get("location").unwrap().to_str().unwrap();
         // Existing query stripped; message percent-encoded onto the clean path.
         assert_eq!(loc, "/login?auth_error=No%20seat%20here");
-    }
-}
-
-#[cfg(test)]
-mod workspace_for_login_tests {
-    use super::{callback_workspace_decision, workspace_for_login, WorkspaceBindingError};
-    use crate::middleware::DeploymentMode;
-    use crate::sync::actor::BOOTSTRAP_WORKSPACE_ID;
-
-    // --- initiation-side resolution (bound into the signed state) ---
-
-    #[test]
-    fn resolved_context_is_used_in_either_mode() {
-        assert_eq!(
-            workspace_for_login(Some(7), DeploymentMode::Hosted),
-            Some(7)
-        );
-        assert_eq!(
-            workspace_for_login(Some(7), DeploymentMode::SelfHosted),
-            Some(7)
-        );
-    }
-
-    #[test]
-    fn missing_context_fails_closed_in_hosted_mode() {
-        // P0.3: no silent fallback to the bootstrap workspace in hosted
-        // mode — initiation must be rejected.
-        assert_eq!(workspace_for_login(None, DeploymentMode::Hosted), None);
-    }
-
-    #[test]
-    fn missing_context_falls_back_to_bootstrap_in_self_hosted() {
-        // Self-hosted has exactly one workspace, so the bootstrap
-        // workspace is the correct answer.
-        assert_eq!(
-            workspace_for_login(None, DeploymentMode::SelfHosted),
-            Some(BOOTSTRAP_WORKSPACE_ID)
-        );
-    }
-
-    // --- callback-side resolution (state is authoritative) ---
-
-    #[test]
-    fn callback_trusts_the_state_bound_workspace() {
-        // No callback context at all: the signed state still decides,
-        // regardless of mode. This is the whole point — the callback
-        // Host can't override the tenant bound at initiation.
-        assert_eq!(
-            callback_workspace_decision(Some(42), None, DeploymentMode::Hosted),
-            Ok(42)
-        );
-        // Context agrees with the state: fine.
-        assert_eq!(
-            callback_workspace_decision(Some(42), Some(42), DeploymentMode::Hosted),
-            Ok(42)
-        );
-    }
-
-    #[test]
-    fn callback_rejects_state_context_mismatch() {
-        // State minted for workspace 42, but the callback resolved to 7:
-        // a replayed / cross-tenant state. Refuse.
-        assert_eq!(
-            callback_workspace_decision(Some(42), Some(7), DeploymentMode::Hosted),
-            Err(WorkspaceBindingError::Mismatch {
-                state_ws: 42,
-                ctx_ws: 7
-            })
-        );
-    }
-
-    #[test]
-    fn callback_legacy_token_falls_back_fail_closed() {
-        // Legacy token without a bound workspace (pre-deploy): falls back
-        // to the same fail-closed request resolution.
-        assert_eq!(
-            callback_workspace_decision(None, Some(7), DeploymentMode::Hosted),
-            Ok(7)
-        );
-        assert_eq!(
-            callback_workspace_decision(None, None, DeploymentMode::Hosted),
-            Err(WorkspaceBindingError::Unresolved)
-        );
-        assert_eq!(
-            callback_workspace_decision(None, None, DeploymentMode::SelfHosted),
-            Ok(BOOTSTRAP_WORKSPACE_ID)
-        );
     }
 }
 

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -285,13 +285,13 @@ pub async fn oauth_authorize(
         };
 
         // Generate a JWT state token
-        let state = match create_oauth_state(
+        let (state, binding) = match create_oauth_state(
             "microsoft",
             oauth_request.redirect_uri.clone(),
             oauth_request.user_connection,
             initiation_workspace,
         ) {
-            Ok(token) => token,
+            Ok(pair) => pair,
             Err(e) => {
                 error!(error = %e, "Failed to create OAuth state token");
                 return errors::internal("Failed to initiate authentication flow");
@@ -303,10 +303,13 @@ pub async fn oauth_authorize(
             "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize?client_id={client_id}&response_type=code&redirect_uri={redirect_uri_config}&response_mode=query&scope=User.Read&state={state}"
         );
 
-        HttpResponse::Ok().json(json!({
-            "auth_url": auth_url,
-            "state": state
-        }))
+        // Bind the flow to this user-agent (RFC 9700 §2.1).
+        HttpResponse::Ok()
+            .cookie(crate::utils::cookies::create_oauth_state_cookie(&binding))
+            .json(json!({
+                "auth_url": auth_url,
+                "state": state
+            }))
     } else if provider.provider_type == "oidc" {
         // Per-tenant OAuth callback (hosted mode): each tenant authenticates
         // on its own subdomain. Bind it into the signed state so the token
@@ -323,7 +326,7 @@ pub async fn oauth_authorize(
         {
             Ok((auth_url, auth_data)) => {
                 // Create state JWT with PKCE verifier and nonce
-                let state = match create_oauth_state_with_oidc(
+                let (state, binding) = match create_oauth_state_with_oidc(
                     "oidc",
                     oauth_request.redirect_uri.clone(),
                     oauth_request.user_connection,
@@ -332,7 +335,7 @@ pub async fn oauth_authorize(
                     initiation_workspace,
                     callback_redirect,
                 ) {
-                    Ok(token) => token,
+                    Ok(pair) => pair,
                     Err(e) => {
                         error!(error = %e, "Failed to create OAuth state token for OIDC");
                         return errors::internal("Failed to initiate authentication flow");
@@ -343,10 +346,13 @@ pub async fn oauth_authorize(
                 // Replace with JWT state
                 let auth_url_with_state = replace_state_in_url(&auth_url, &state);
 
-                HttpResponse::Ok().json(json!({
-                    "auth_url": auth_url_with_state,
-                    "state": state
-                }))
+                // Bind the flow to this user-agent (RFC 9700 §2.1).
+                HttpResponse::Ok()
+                    .cookie(crate::utils::cookies::create_oauth_state_cookie(&binding))
+                    .json(json!({
+                        "auth_url": auth_url_with_state,
+                        "state": state
+                    }))
             }
             Err(e) => {
                 error!(error = %e, "Failed to generate OIDC authorization URL");
@@ -423,6 +429,29 @@ pub async fn oauth_callback(
             return errors::bad_request("Invalid or expired state parameter");
         }
     };
+
+    // RFC 9700 §2.1: confirm this callback completes in the SAME user-agent that
+    // started the flow. The signed state has integrity but is not session-bound,
+    // so without this an attacker who runs their own flow could CSRF the
+    // resulting (code, state) onto a victim and swap them into the attacker's
+    // account. The `oauth_state` cookie was set at initiation; an attacker can't
+    // set it in the victim's browser.
+    if let Some(expected) = &state_data.binding {
+        let presented = request
+            .cookie(crate::utils::cookies::OAUTH_STATE_COOKIE)
+            .map(|c| c.value().to_string());
+        let matches = presented
+            .as_deref()
+            .map(|p| constant_time_eq::constant_time_eq(p.as_bytes(), expected.as_bytes()))
+            .unwrap_or(false);
+        if !matches {
+            warn!("OAuth callback rejected: state-binding cookie missing or mismatched");
+            return errors::bad_request("Invalid or expired state parameter");
+        }
+    }
+    // `binding == None` is a legacy in-flight state minted before this field
+    // existed; allowed transitionally, and such states expire within the
+    // 10-minute state lifetime, after which the binding check is mandatory.
 
     // Get the provider by type
     let provider_type = &state_data.provider_type;
@@ -986,12 +1015,15 @@ pub async fn oauth_logout(
 // JWT State Management
 
 // Create a signed state JWT for OAuth flow
+/// Returns `(state_jwt, binding)`. The caller MUST set the `binding` in the
+/// `oauth_state` cookie (RFC 9700 §2.1) so the callback can confirm the flow
+/// completes in the same user-agent that started it.
 fn create_oauth_state(
     provider_type: &str,
     redirect_uri: Option<String>,
     user_connection: Option<bool>,
     workspace_id: Option<i32>,
-) -> Result<String, String> {
+) -> Result<(String, String), String> {
     create_oauth_state_with_oidc(
         provider_type,
         redirect_uri,
@@ -1003,7 +1035,8 @@ fn create_oauth_state(
     )
 }
 
-// Create a signed state JWT for OAuth/OIDC flow with optional PKCE and nonce
+// Create a signed state JWT for OAuth/OIDC flow with optional PKCE and nonce.
+// Returns `(state_jwt, binding)` — see `create_oauth_state`.
 #[allow(clippy::too_many_arguments)]
 fn create_oauth_state_with_oidc(
     provider_type: &str,
@@ -1013,7 +1046,7 @@ fn create_oauth_state_with_oidc(
     nonce: Option<String>,
     workspace_id: Option<i32>,
     callback_redirect_uri: Option<String>,
-) -> Result<String, String> {
+) -> Result<(String, String), String> {
     // Get the JWT secret from environment or configuration
     let secret = JWT_SECRET.clone();
 
@@ -1024,7 +1057,10 @@ fn create_oauth_state_with_oidc(
         .as_secs() as usize;
     let exp = now + (10 * 60); // 10 minutes
 
-    // Create claims
+    // One 128-bit random value serves as both the (legacy) state value and the
+    // user-agent binding. It rides inside the signed, tamper-proof JWT AND is
+    // set in the `oauth_state` cookie by the caller; the callback requires the
+    // two to match.
     let state = format!("{:x}", rand::random::<u128>());
     let claims = OAuthState {
         state: state.clone(),
@@ -1036,6 +1072,7 @@ fn create_oauth_state_with_oidc(
         nonce,
         workspace_id,
         callback_redirect_uri,
+        binding: Some(state.clone()),
     };
 
     // Create the token
@@ -1044,7 +1081,7 @@ fn create_oauth_state_with_oidc(
         &claims,
         &jsonwebtoken::EncodingKey::from_secret(secret.as_bytes()),
     ) {
-        Ok(token) => Ok(token),
+        Ok(token) => Ok((token, state)),
         Err(e) => Err(format!("Failed to create state JWT: {e}")),
     }
 }
@@ -1822,13 +1859,13 @@ pub async fn oauth_connect(
         // Generate a JWT state token with user_connection=true. Connecting
         // an identity to an already-authenticated account doesn't
         // provision workspace membership, so no workspace is bound.
-        let state = match create_oauth_state(
+        let (state, binding) = match create_oauth_state(
             &provider.provider_type,
             Some(actual_redirect_uri),
             Some(true),
             None,
         ) {
-            Ok(token) => token,
+            Ok(pair) => pair,
             Err(e) => {
                 error!(error = %e, "Failed to create OAuth state token for connect");
                 return errors::internal("Failed to initiate authentication flow");
@@ -1840,15 +1877,54 @@ pub async fn oauth_connect(
             "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize?client_id={client_id}&response_type=code&redirect_uri={redirect_uri_config}&response_mode=query&scope=User.Read&state={state}"
         );
 
-        HttpResponse::Ok().json(json!({
-            "auth_url": auth_url,
-            "state": state
-        }))
+        // Bind the flow to this user-agent (RFC 9700 §2.1).
+        HttpResponse::Ok()
+            .cookie(crate::utils::cookies::create_oauth_state_cookie(&binding))
+            .json(json!({
+                "auth_url": auth_url,
+                "state": state
+            }))
     } else {
         errors::bad_request(format!(
             "{} authentication is not implemented",
             provider.name
         ))
+    }
+}
+
+#[cfg(test)]
+mod oauth_state_binding_tests {
+    use super::{create_oauth_state, verify_oauth_state};
+
+    /// The state JWT helpers read the process-global `JWT_SECRET` lazy-static,
+    /// which panics if unset. Ensure it's present before first access so these
+    /// tests pass in isolation, not just when another test set it first.
+    fn ensure_jwt_secret() {
+        if std::env::var("JWT_SECRET").is_err() {
+            std::env::set_var("JWT_SECRET", "test-jwt-secret-for-oauth-state-binding");
+        }
+    }
+
+    #[test]
+    fn state_embeds_binding_and_round_trips() {
+        ensure_jwt_secret();
+        let (token, binding) = create_oauth_state("oidc", None, None, None).unwrap();
+        assert!(
+            !binding.is_empty(),
+            "binding must be a non-empty random value"
+        );
+        let state = verify_oauth_state(&token).unwrap();
+        // The cookie value (binding) the caller sets must equal what the signed
+        // state carries, so the callback's constant-time compare can match them.
+        assert_eq!(state.binding.as_deref(), Some(binding.as_str()));
+    }
+
+    #[test]
+    fn two_flows_get_distinct_bindings() {
+        ensure_jwt_secret();
+        let (_, b1) = create_oauth_state("oidc", None, None, None).unwrap();
+        let (_, b2) = create_oauth_state("oidc", None, None, None).unwrap();
+        assert_ne!(b1, b2, "each flow must bind to a fresh random value");
     }
 }
 

--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -2651,6 +2651,14 @@ pub async fn ws_handler(
         // Pin so the accessor's role + visibility resolve under RLS (the
         // pool clears app.workspace_id on checkout); without it an admin is
         // downgraded to member document visibility.
+        //
+        // Safety invariant: the pin precedes the membership gate below, but
+        // everything read under it before the gate touches only the CALLER'S
+        // OWN data (their user row in validate_token_with_user_check, their
+        // own workspace_role in from_claims). No other tenant's content is
+        // read until after the gate denies non-members, so pinning a
+        // client-selected workspace here cannot leak. Keep any tenant-content
+        // read (the per-document resolve + visibility check) below the gate.
         crate::handlers::helpers::pin_workspace(&mut conn, workspace_id);
 
         use crate::utils::jwt::JwtUtils;

--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -2599,6 +2599,18 @@ pub async fn ws_handler(
             Ok((claims, user)) => {
                 let accessor = DocAccessor::from_claims(&claims, &mut conn)
                     .ok_or_else(|| actix_web::error::ErrorUnauthorized("Invalid token subject"))?;
+                // Membership gate. The collab WS bypasses the auth middleware and
+                // below only cross-checks the docId's workspace_uuid against the
+                // request workspace (both client-influenced once the workspace is
+                // a selection). The authenticated user must actually belong to the
+                // request workspace, or they could open another tenant's docs.
+                // Defense-in-depth today (Host-derived); load-bearing under
+                // Model C. See docs/plans/v1.1-scope.md.
+                crate::middleware::cookie_auth::require_workspace_membership(
+                    &mut conn,
+                    ws.workspace_id,
+                    user.uuid,
+                )?;
                 (user.uuid, accessor)
             }
             Err(_) => {

--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -2517,7 +2517,7 @@ pub async fn ws_handler(
     req: HttpRequest,
     body: web::Payload,
     app_state: web::Data<YjsAppState>,
-    ws: crate::extractors::WorkspaceContext,
+    ws: Option<crate::extractors::WorkspaceContext>,
     path: web::Path<String>,
 ) -> Result<HttpResponse, Error> {
     let doc_id = path.into_inner();
@@ -2581,37 +2581,93 @@ pub async fn ws_handler(
         .cookie(crate::utils::cookies::ACCESS_TOKEN_COOKIE)
         .ok_or_else(|| actix_web::error::ErrorUnauthorized("No authentication cookie"))?;
 
-    // Validate the token, extract the user UUID, and resolve the
+    // Parse the workspace-namespaced doc_id up front; its embedded
+    // workspace_uuid is the tenancy anchor. Rejects legacy bare ids
+    // ("ticket-N") so a stale client that didn't refresh after the
+    // namespace migration fails fast with a clear log line instead of
+    // silently sharing the workspace-1 doc.
+    let parsed = match DocumentType::from_namespaced_doc_id(&doc_id) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(doc_id = %doc_id, error = ?e, "WebSocket doc_id parse failed");
+            return Err(actix_web::error::ErrorBadRequest(
+                "doc_id must be in the workspace-namespaced format ws-{uuid}_{kind}-{id}",
+            ));
+        }
+    };
+
+    // Validate the token, resolve the connection's workspace, and build the
     // visibility context used to gate per-document access below.
-    let (user_uuid, accessor) = if let Some(pool) = req.app_data::<web::Data<crate::db::Pool>>() {
+    let (user_uuid, accessor, workspace_id) = if let Some(pool) =
+        req.app_data::<web::Data<crate::db::Pool>>()
+    {
         let mut conn = pool.get().map_err(|_| {
             actix_web::error::ErrorInternalServerError("Database connection failed")
         })?;
-        // Pin the request's workspace so the accessor's role + visibility
-        // resolve under RLS (the pool clears app.workspace_id on checkout).
-        // Without this an admin is downgraded to member document visibility.
-        crate::handlers::helpers::pin_request_workspace(&req, &mut conn);
 
-        // Use our centralized JWT validation
+        // Resolve the workspace. A Host-derived context (per-tenant-origin
+        // surface) wins, and the docId must match it — the cross-tenant
+        // guard against a tab cached on workspace A constructing a B docId.
+        // With no Host context (single-origin agent app), the docId's
+        // workspace_uuid IS the selection: the WS can't send the selection
+        // header, so the docId is the carrier (like the SSE token). The
+        // membership gate below is the authorization in both cases.
+        let workspace_id = match &ws {
+            Some(ws) => {
+                if parsed.workspace_uuid != ws.workspace_uuid {
+                    warn!(
+                        doc_id = %doc_id,
+                        requested_workspace_uuid = %parsed.workspace_uuid,
+                        request_workspace_id = ws.workspace_id,
+                        "WebSocket doc_id workspace mismatch — rejecting cross-tenant request"
+                    );
+                    return Err(actix_web::error::ErrorForbidden(
+                        "doc_id workspace does not match the request workspace",
+                    ));
+                }
+                ws.workspace_id
+            }
+            None => {
+                match crate::repository::workspaces::find_by_uuid(&mut conn, parsed.workspace_uuid)
+                {
+                    Ok(Some(w)) => w.id,
+                    // Unknown workspace collapses into the same denial a
+                    // non-member gets, so workspace existence does not leak.
+                    Ok(None) => {
+                        return Err(actix_web::error::ErrorForbidden(
+                            "Not a member of this workspace",
+                        ))
+                    }
+                    Err(e) => {
+                        error!(error = ?e, "WebSocket docId workspace resolution failed");
+                        return Err(actix_web::error::ErrorInternalServerError(
+                            "Workspace resolution failed",
+                        ));
+                    }
+                }
+            }
+        };
+
+        // Pin so the accessor's role + visibility resolve under RLS (the
+        // pool clears app.workspace_id on checkout); without it an admin is
+        // downgraded to member document visibility.
+        crate::handlers::helpers::pin_workspace(&mut conn, workspace_id);
+
         use crate::utils::jwt::JwtUtils;
-
         match JwtUtils::validate_token_with_user_check(token.value(), &mut conn).await {
             Ok((claims, user)) => {
                 let accessor = DocAccessor::from_claims(&claims, &mut conn)
                     .ok_or_else(|| actix_web::error::ErrorUnauthorized("Invalid token subject"))?;
-                // Membership gate. The collab WS bypasses the auth middleware and
-                // below only cross-checks the docId's workspace_uuid against the
-                // request workspace (both client-influenced once the workspace is
-                // a selection). The authenticated user must actually belong to the
-                // request workspace, or they could open another tenant's docs.
-                // Defense-in-depth today (Host-derived); load-bearing under
-                // Model C. See docs/plans/v1.1-scope.md.
+                // Membership gate: the collab WS bypasses the auth
+                // middleware, so the gate it runs for REST is invoked
+                // explicitly here. Load-bearing under Model C, where the
+                // workspace is client-selected (docId / Host).
                 crate::middleware::cookie_auth::require_workspace_membership(
                     &mut conn,
-                    ws.workspace_id,
+                    workspace_id,
                     user.uuid,
                 )?;
-                (user.uuid, accessor)
+                (user.uuid, accessor, workspace_id)
             }
             Err(_) => {
                 return Err(actix_web::error::ErrorUnauthorized(
@@ -2625,44 +2681,10 @@ pub async fn ws_handler(
         ));
     };
 
-    // Parse the workspace-namespaced doc_id and validate that its
-    // claimed workspace matches the WorkspaceContext the middleware
-    // resolved from this request. This is the cache-key + tenancy
-    // guard:
-    //
-    //   * Rejects legacy bare ids ("ticket-N"), so a stale client
-    //     that didn't refresh after the namespace migration fails
-    //     fast with a clear log line instead of silently sharing
-    //     the workspace-1 doc.
-    //   * Rejects cross-workspace requests under hosted multi-
-    //     tenancy: a tab cached against workspace A whose state
-    //     somehow constructs a `ws-{A_uuid}_...` docId after
-    //     navigating to workspace B can't accidentally read or
-    //     write workspace B's doc.
-    let parsed = match DocumentType::from_namespaced_doc_id(&doc_id) {
-        Ok(p) => p,
-        Err(e) => {
-            warn!(doc_id = %doc_id, error = ?e, "WebSocket doc_id parse failed");
-            return Err(actix_web::error::ErrorBadRequest(
-                "doc_id must be in the workspace-namespaced format ws-{uuid}_{kind}-{id}",
-            ));
-        }
-    };
-    if parsed.workspace_uuid != ws.workspace_uuid {
-        warn!(
-            doc_id = %doc_id,
-            requested_workspace_uuid = %parsed.workspace_uuid,
-            request_workspace_id = ws.workspace_id,
-            "WebSocket doc_id workspace mismatch — rejecting cross-tenant request"
-        );
-        return Err(actix_web::error::ErrorForbidden(
-            "doc_id workspace does not match the request workspace",
-        ));
-    }
     debug!(
         doc_id = %doc_id,
         user_uuid = %user_uuid,
-        workspace_id = ws.workspace_id,
+        workspace_id,
         "WebSocket authentication + workspace check successful"
     );
 
@@ -2689,7 +2711,7 @@ pub async fn ws_handler(
         // by `app.workspace_id`. On a raw connection that GUC is unset, so the
         // rows are filtered out and every doc 404s in hosted mode. The rest of
         // this handler already wraps its reads this way.
-        let actor = yjs_session_actor(ws.workspace_id);
+        let actor = yjs_session_actor(workspace_id);
         let resolved = session::with_actor_context(&mut conn, &actor, |conn| {
             let dt = match parsed.resolve(conn)? {
                 Some(dt) => dt,
@@ -2761,7 +2783,6 @@ pub async fn ws_handler(
         .max_continuation_size(1024 * 1024);
 
     let session_id = Uuid::now_v7().to_string();
-    let workspace_id = ws.workspace_id;
     let app_state_inner = app_state.get_ref().clone();
 
     actix_web::rt::spawn(session_task(

--- a/backend/src/handlers/email.rs
+++ b/backend/src/handlers/email.rs
@@ -74,9 +74,15 @@ pub async fn send_test_email(
     };
 
     // Get branding for test email. site_settings is workspace-scoped,
-    // so the lookup rides on TenantConn's RLS-primed transaction.
-    let base_url =
-        std::env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
+    // so the lookup rides on TenantConn's RLS-primed transaction. The link host
+    // is this workspace's canonical origin (the test send targets the current
+    // workspace), then FRONTEND_URL, then a local default.
+    let ws_origin = req
+        .extensions()
+        .get::<crate::extractors::WorkspaceContext>()
+        .and_then(|ws| ws.canonical_origin());
+    let base_url = crate::utils::tenant_origin::email_link_base(ws_origin)
+        .unwrap_or_else(|| "http://localhost:3000".to_string());
     let branding =
         match tc.run(|conn| Ok::<_, diesel::result::Error>(get_email_branding(conn, &base_url))) {
             Ok(b) => b,

--- a/backend/src/handlers/files.rs
+++ b/backend/src/handlers/files.rs
@@ -310,7 +310,8 @@ pub(crate) async fn serve_or_not_found(
 pub async fn upload_ticket_note_image(
     path: web::Path<i32>,
     mut payload: Multipart,
-    pool: web::Data<crate::db::Pool>,
+    mut tc: TenantConn,
+    auth: AuthContext,
     storage: ScopedStorage,
 ) -> Result<HttpResponse, actix_web::Error> {
     let ticket_id = path.into_inner();
@@ -319,15 +320,14 @@ pub async fn upload_ticket_note_image(
         "Received ticket note image upload request"
     );
 
-    // Verify ticket exists
-    let mut conn = pool.get().map_err(|e| {
-        error!(error = ?e, "Database connection error");
-        actix_web::error::ErrorInternalServerError("Database connection error")
-    })?;
-
-    // Check if ticket exists
-    crate::repository::tickets::get_ticket_by_id(&mut conn, ticket_id)
-        .map_err(|_| actix_web::error::ErrorNotFound("Ticket not found"))?;
+    // Workspace + ticket-visibility gate, mirroring the GET sibling
+    // (serve_ticket_note_image). TenantConn pins `app.workspace_id` so the
+    // lookup is scoped to the caller's membership-gated workspace and a
+    // cross-workspace ticket id 404s. The previous raw pooled connection left
+    // the GUC cleared (RLS-zero under the NOBYPASSRLS app role) and skipped the
+    // access check entirely, relying solely on RLS — which would leak under a
+    // misconfigured BYPASSRLS role.
+    authorize_ticket_access(&mut tc, &auth, ticket_id)?;
 
     let mut uploaded_files = Vec::new();
 

--- a/backend/src/handlers/internal_workspaces.rs
+++ b/backend/src/handlers/internal_workspaces.rs
@@ -645,6 +645,15 @@ fn looks_like_fqdn(s: &str) -> bool {
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-')
 }
 
+/// Set or clear a workspace's verified custom domain.
+///
+/// Passkey implication (C1 / tenant-origin): WebAuthn RP ID is the workspace's
+/// canonical host, so changing the custom domain changes the RP ID and
+/// **invalidates every existing passkey** for the workspace (the spec binds
+/// credentials to the RP ID; there is no rebind). The admin-facing flow must
+/// warn before changing it, and we must not delete the old credentials until
+/// users re-enrol on the new host. Slug is immutable, so this is the only
+/// passkey-invalidating event. See docs/plans/tenant-origin-awareness.md.
 pub async fn set_custom_domain(
     req: HttpRequest,
     _: PlatformAuth,

--- a/backend/src/handlers/internal_workspaces.rs
+++ b/backend/src/handlers/internal_workspaces.rs
@@ -368,6 +368,10 @@ pub async fn upsert_projected_user(
         iss,
         sub,
         email,
+        // The control plane provisions verified seat emails, so the
+        // email-fallback link is authorised here. The (iss, sub) is
+        // usually known too, in which case the identity match wins first.
+        email_verified: true,
         name,
         role: role.clone(),
         workspace_id: workspace.id,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -2,6 +2,7 @@
 pub mod admin_workspaces;
 pub mod analytics;
 pub mod api_tokens;
+pub mod app_config;
 pub mod asset_audits;
 pub mod asset_kinds;
 pub mod asset_lifecycle;

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -64,6 +64,7 @@ pub mod tags;
 pub mod ticket_merge;
 pub mod ticket_watchers;
 pub mod tickets;
+pub mod unsubscribe;
 pub mod users;
 pub mod webhooks;
 pub mod workflow_states;

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -51,6 +51,7 @@ pub mod password_reset;
 pub mod plugin_collections;
 pub mod plugin_events;
 pub mod plugins;
+pub mod portal;
 pub mod projects;
 pub mod rules;
 pub mod saved_views;

--- a/backend/src/handlers/passkeys.rs
+++ b/backend/src/handlers/passkeys.rs
@@ -19,7 +19,7 @@ use crate::utils::jwt::helpers as jwt_helpers;
 use crate::utils::locale::request_locale;
 use crate::utils::mfa;
 use crate::utils::rate_limit::{get_redis_url, RateLimiter};
-use crate::utils::webauthn::{self, credential_id_to_string, StoredPasskeyCredential, WEBAUTHN};
+use crate::utils::webauthn::{self, credential_id_to_string, StoredPasskeyCredential};
 
 // =============================================================================
 // Request/Response Types
@@ -184,7 +184,13 @@ pub async fn start_passkey_registration(
         .collect();
 
     // Create WebAuthn registration challenge
-    let webauthn = &*WEBAUTHN;
+    let webauthn = match webauthn::webauthn_for_request(&req) {
+        Ok(w) => w,
+        Err(e) => {
+            error!("Failed to build WebAuthn verifier: {:?}", e);
+            return errors::internal("WebAuthn is not configured for this workspace");
+        }
+    };
 
     let (ccr, reg_state) = match webauthn.start_passkey_registration(
         user_uuid,
@@ -297,7 +303,13 @@ pub async fn finish_passkey_registration(
     };
 
     // Complete registration with WebAuthn
-    let webauthn = &*WEBAUTHN;
+    let webauthn = match webauthn::webauthn_for_request(&req) {
+        Ok(w) => w,
+        Err(e) => {
+            error!("Failed to build WebAuthn verifier: {:?}", e);
+            return errors::internal("WebAuthn is not configured for this workspace");
+        }
+    };
     let passkey = match webauthn.finish_passkey_registration(&reg_response, &reg_state) {
         Ok(pk) => pk,
         Err(e) => {
@@ -419,7 +431,13 @@ pub async fn start_passkey_login(
         _ => {}
     }
 
-    let webauthn = &*WEBAUTHN;
+    let webauthn = match webauthn::webauthn_for_request(&req) {
+        Ok(w) => w,
+        Err(e) => {
+            error!("Failed to build WebAuthn verifier: {:?}", e);
+            return errors::internal("WebAuthn is not configured for this workspace");
+        }
+    };
 
     // AUD-007: every start_login takes the discoverable-auth
     // path, regardless of whether an email was supplied or
@@ -516,7 +534,13 @@ pub async fn finish_passkey_login(
         }
     };
 
-    let webauthn = &*WEBAUTHN;
+    let webauthn = match webauthn::webauthn_for_request(&req) {
+        Ok(w) => w,
+        Err(e) => {
+            error!("Failed to build WebAuthn verifier: {:?}", e);
+            return errors::internal("WebAuthn is not configured for this workspace");
+        }
+    };
 
     // Run the appropriate finish ceremony and capture the
     // AuthenticationResult so we can persist the bumped sign counter
@@ -1046,7 +1070,13 @@ pub async fn start_passkey_setup_login(
         .collect();
 
     // Create WebAuthn registration challenge
-    let webauthn = &*WEBAUTHN;
+    let webauthn = match webauthn::webauthn_for_request(&req) {
+        Ok(w) => w,
+        Err(e) => {
+            error!("Failed to build WebAuthn verifier: {:?}", e);
+            return errors::internal("WebAuthn is not configured for this workspace");
+        }
+    };
 
     let (ccr, reg_state) = match webauthn.start_passkey_registration(
         user.uuid,
@@ -1213,7 +1243,13 @@ pub async fn finish_passkey_setup_login(
     };
 
     // Complete registration with WebAuthn
-    let webauthn = &*WEBAUTHN;
+    let webauthn = match webauthn::webauthn_for_request(&req) {
+        Ok(w) => w,
+        Err(e) => {
+            error!("Failed to build WebAuthn verifier: {:?}", e);
+            return errors::internal("WebAuthn is not configured for this workspace");
+        }
+    };
     let passkey = match webauthn.finish_passkey_registration(&reg_response, &reg_state) {
         Ok(pk) => pk,
         Err(e) => {

--- a/backend/src/handlers/password_reset.rs
+++ b/backend/src/handlers/password_reset.rs
@@ -118,8 +118,6 @@ async fn issue_password_reset(
     )
     .map_err(|e| format!("create_reset_token: {e}"))?;
 
-    let base_url = std::env::var("FRONTEND_URL").unwrap_or_else(|_| format!("{scheme}://{host}"));
-
     let Some(user_email) =
         crate::repository::user_helpers::get_primary_email(&user.uuid, &mut conn)
     else {
@@ -138,22 +136,43 @@ async fn issue_password_reset(
         }
     };
 
-    // Resolve the recipient's workspace so the RLS-isolated branding read and
-    // outbound enqueue are scoped correctly. The lookup reads workspace_members
+    // Resolve the recipient's primary workspace so the RLS-isolated branding
+    // read and outbound enqueue are scoped correctly, and so the reset link is
+    // built on the tenant's own origin. The lookup reads workspace_members
     // (RLS-isolated) and is inherently cross-tenant here (we only have the
     // email, no request workspace), so it runs elevated. A user with no
     // membership gets no email rather than a NULL-workspace insert failure.
-    let workspace_id = match crate::sync::session::background_run(
+    let workspace = match crate::sync::session::background_run(
         &pool,
         "background:password_reset",
-        |c| repository::workspaces::primary_workspace_for_user(c, user.uuid),
+        |c| {
+            let id = repository::workspaces::primary_workspace_for_user(c, user.uuid)?;
+            repository::workspaces::find_by_id(c, id)
+        },
     ) {
-        Ok(id) => id,
+        Ok(Some(ws)) => ws,
+        Ok(None) => {
+            warn!(user_uuid = %user.uuid, "password-reset recipient workspace not found");
+            return Ok(());
+        }
         Err(e) => {
             warn!(user_uuid = %user.uuid, error = %e, "no workspace for password-reset recipient");
             return Ok(());
         }
     };
+    let workspace_id = workspace.id;
+
+    // Tenant-canonical link host: a verified custom domain or
+    // `<slug>.<NOSDESK_TENANT_DOMAIN>`, falling back to FRONTEND_URL or the
+    // request host for self-hosted single-tenant.
+    let tenant_domain = std::env::var("NOSDESK_TENANT_DOMAIN").ok();
+    let base_url = crate::extractors::workspace_context::canonical_origin_for(
+        &workspace.slug,
+        workspace.custom_domain.as_deref(),
+        tenant_domain.as_deref(),
+    )
+    .or_else(|| std::env::var("FRONTEND_URL").ok())
+    .unwrap_or_else(|| format!("{scheme}://{host}"));
 
     // Enqueue rather than fire-and-forget. The outbound worker retries with
     // backoff if SMTP burps, applies the suppression list, and respects the

--- a/backend/src/handlers/password_reset.rs
+++ b/backend/src/handlers/password_reset.rs
@@ -162,16 +162,12 @@ async fn issue_password_reset(
     };
     let workspace_id = workspace.id;
 
-    // Tenant-canonical link host: a verified custom domain or
-    // `<slug>.<NOSDESK_TENANT_DOMAIN>`, falling back to FRONTEND_URL or the
-    // request host for self-hosted single-tenant.
-    let tenant_domain = std::env::var("NOSDESK_TENANT_DOMAIN").ok();
-    let base_url = crate::extractors::workspace_context::canonical_origin_for(
-        &workspace.slug,
-        workspace.custom_domain.as_deref(),
-        tenant_domain.as_deref(),
+    // Tenant-canonical link host: the recipient workspace's canonical origin
+    // (custom domain or `<slug>.<NOSDESK_TENANT_DOMAIN>`), falling back to
+    // FRONTEND_URL or the request host for self-hosted single-tenant.
+    let base_url = crate::utils::tenant_origin::email_link_base(
+        crate::utils::tenant_origin::workspace_origin(&workspace),
     )
-    .or_else(|| std::env::var("FRONTEND_URL").ok())
     .unwrap_or_else(|| format!("{scheme}://{host}"));
 
     // Enqueue rather than fire-and-forget. The outbound worker retries with

--- a/backend/src/handlers/portal.rs
+++ b/backend/src/handlers/portal.rs
@@ -1,0 +1,137 @@
+//! Customer portal session: establishment and authorization.
+//!
+//! The portal is the authenticated surface for ticket SUBMITTERS (baseline
+//! `users` rows, role `Member`), served per-tenant on `<slug>.nosdesk.app`. It
+//! is a separate principal realm from the agent app: portal sessions carry the
+//! `portal` token scope (refused on the agent surface, see
+//! [`crate::middleware::cookie_auth::enforce_workspace_membership`]) and their
+//! own cookie names.
+//!
+//! This module owns the two security-critical primitives:
+//!
+//! - [`establish_portal_session`] mints a portal session (token + refresh +
+//!   CSRF, reusing the agent session machinery) and sets the portal cookies.
+//!   The magic-link callback calls it once email ownership is proven.
+//! - [`authorize_portal_request`] is the per-request gate: a valid portal token
+//!   whose bound workspace matches the request's resolved ORIGIN, for a user
+//!   who is a member of that workspace. Split out (like the agent gate) so it
+//!   is unit-testable independently of the actix middleware that will wrap it.
+
+use actix_web::dev::ServiceRequest;
+use actix_web::{Error, HttpMessage, HttpRequest, HttpResponse};
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::db::DbConnection;
+use crate::extractors::WorkspaceContext;
+use crate::middleware::cookie_auth::{require_workspace_membership, PORTAL_SCOPE};
+use crate::models::{Claims, User};
+
+/// The authenticated portal principal for a request: a customer (`user_uuid`)
+/// acting within one workspace (resolved from the portal origin and confirmed
+/// against the token's binding). Published into request extensions for portal
+/// handlers, the portal analogue of the agent `WorkspaceContext` + `Claims`.
+#[derive(Debug, Clone)]
+pub struct PortalContext {
+    pub user_uuid: Uuid,
+    pub workspace_id: i32,
+    pub workspace_uuid: Uuid,
+}
+
+/// Authorize a portal request from its validated token claims and the
+/// origin-resolved workspace context.
+///
+/// Fail-closed checks, all collapsing to 403 so nothing about workspace or
+/// membership existence leaks:
+///
+/// 1. The token is portal-scoped (an agent token must not act as a customer).
+/// 2. The token is workspace-bound and that binding equals the workspace the
+///    request's ORIGIN resolved to. This is what stops a portal token minted
+///    for tenant A from being replayed onto tenant B's portal origin.
+/// 3. The subject is a member of that workspace (the baseline `Member` row a
+///    customer holds; reuses the agent membership check, RLS-pinned).
+pub fn authorize_portal_request(
+    req: &ServiceRequest,
+    conn: &mut DbConnection,
+    claims: &Claims,
+) -> Result<PortalContext, Error> {
+    if claims.scope != PORTAL_SCOPE {
+        return Err(actix_web::error::ErrorForbidden("Not a portal session"));
+    }
+
+    let token_workspace = claims.workspace_uuid.ok_or_else(|| {
+        actix_web::error::ErrorForbidden("Portal session is not bound to a workspace")
+    })?;
+
+    let origin_ctx = req
+        .extensions()
+        .get::<WorkspaceContext>()
+        .cloned()
+        .ok_or_else(|| actix_web::error::ErrorForbidden("No workspace for this origin"))?;
+
+    if token_workspace != origin_ctx.workspace_uuid {
+        // Token minted for a different tenant than the origin serves.
+        return Err(actix_web::error::ErrorForbidden(
+            "Portal session does not match this workspace",
+        ));
+    }
+
+    let user_uuid = Uuid::parse_str(&claims.sub)
+        .map_err(|_| actix_web::error::ErrorForbidden("Not a member of this workspace"))?;
+    require_workspace_membership(conn, origin_ctx.workspace_id, user_uuid)?;
+
+    Ok(PortalContext {
+        user_uuid,
+        workspace_id: origin_ctx.workspace_id,
+        workspace_uuid: origin_ctx.workspace_uuid,
+    })
+}
+
+/// Establish a customer-portal session for `user` within `workspace_uuid`:
+/// create the session record, mint the portal token bundle, and return a JSON
+/// response carrying the portal cookies. Called once a login flow (magic-link)
+/// has proven the customer's email ownership.
+///
+/// Reuses the agent session machinery wholesale (`create_session_record`,
+/// refresh-token rotation, CSRF); only the access token's scope/binding and the
+/// cookie names are portal-specific.
+pub fn establish_portal_session(
+    user: &User,
+    workspace_uuid: Uuid,
+    request: &HttpRequest,
+    conn: &mut DbConnection,
+) -> Result<HttpResponse, HttpResponse> {
+    let session =
+        crate::handlers::auth::create_session_record(&user.uuid, request, conn).map_err(|e| {
+            tracing::error!(error = ?e, "portal session: failed to create session record");
+            HttpResponse::InternalServerError().json(json!({
+                "status": "error",
+                "message": "Failed to establish session"
+            }))
+        })?;
+
+    let family_id = Uuid::new_v4();
+    let tokens = crate::utils::jwt::helpers::create_portal_tokens(
+        user,
+        workspace_uuid,
+        &session.session_id,
+        &family_id,
+        conn,
+    )?;
+
+    Ok(HttpResponse::Ok()
+        .cookie(crate::utils::cookies::create_portal_access_cookie(
+            &tokens.access_token,
+        ))
+        .cookie(crate::utils::cookies::create_portal_refresh_cookie(
+            &tokens.refresh_token,
+        ))
+        .cookie(crate::utils::cookies::create_portal_csrf_cookie(
+            &tokens.csrf_token,
+        ))
+        .json(json!({
+            "success": true,
+            "csrf_token": tokens.csrf_token,
+            "workspace_uuid": workspace_uuid,
+        })))
+}

--- a/backend/src/handlers/portal.rs
+++ b/backend/src/handlers/portal.rs
@@ -18,6 +18,7 @@
 //!   is unit-testable independently of the actix middleware that will wrap it.
 
 use std::future::{ready, Ready};
+use std::sync::Arc;
 
 use actix_web::body::MessageBody;
 use actix_web::cookie::Cookie;
@@ -32,11 +33,12 @@ use crate::db::{DbConnection, Pool};
 use crate::extractors::{TenantConn, WorkspaceContext};
 use crate::handlers::errors;
 use crate::middleware::cookie_auth::{require_workspace_membership, PORTAL_SCOPE};
-use crate::models::{Claims, Ticket, User};
+use crate::models::{Claims, ContentFormat, NewComment, NewTicket, Ticket, User};
 use crate::repository::ticket_visibility::{
     can_view_ticket, visible_tickets_query, VisibilityContext,
 };
 use crate::schema::tickets;
+use crate::services::search::SearchService;
 use crate::utils::jwt::JwtUtils;
 use crate::utils::reset_tokens::{ResetTokenUtils, TokenType};
 use diesel::prelude::*;
@@ -470,6 +472,145 @@ pub async fn get_my_ticket(
         Err(e) => {
             tracing::error!(error = ?e, "portal: failed to load ticket");
             errors::internal("Failed to load ticket")
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct NewPortalTicket {
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+#[derive(Deserialize)]
+pub struct NewPortalReply {
+    pub content: String,
+}
+
+/// `POST /api/portal/tickets` — the customer opens a ticket. Requester is the
+/// portal user; the optional description lands as the first customer-visible
+/// comment. Created under the pinned actor, so the activity attributes it to
+/// the customer.
+pub async fn create_my_ticket(
+    mut tc: TenantConn,
+    portal: PortalContext,
+    search_service: web::Data<Arc<SearchService>>,
+    body: web::Json<NewPortalTicket>,
+) -> impl Responder {
+    let body = body.into_inner();
+    let title = body.title.trim().to_string();
+    if title.is_empty() {
+        return errors::bad_request("Title is required");
+    }
+    let description = body.description.trim().to_string();
+    let user_uuid = portal.user_uuid;
+    let search = Arc::clone(search_service.get_ref());
+
+    let result = tc.run(move |conn| {
+        let default_state = crate::repository::workflow_states::default_state(conn)?;
+        let new_ticket = NewTicket {
+            title: title.clone(),
+            workflow_state_id: default_state.id,
+            requester_uuid: Some(user_uuid),
+            submitted_via: Some("portal".to_string()),
+            ..Default::default()
+        };
+        let annotation = crate::repository::tickets::TicketCreationAnnotation {
+            source: Some("portal".to_string()),
+            subject: Some(title.clone()),
+            ..Default::default()
+        };
+        let ticket = crate::repository::tickets::create_ticket_with_annotation(
+            conn, new_ticket, annotation, None,
+        )?;
+
+        // First customer-visible comment carries the description. Non-fatal
+        // (mirrors the guest portal): the ticket is the primary artefact.
+        if !description.is_empty() {
+            let new_comment = NewComment {
+                content: description.clone(),
+                ticket_id: ticket.id,
+                user_uuid,
+                is_internal: false,
+                content_format: ContentFormat::Plaintext,
+                ..Default::default()
+            };
+            let annotation = crate::repository::comments::CommentCreationAnnotation {
+                source: Some("portal".to_string()),
+                ..Default::default()
+            };
+            if let Err(e) = crate::repository::comments::create_comment_with_annotation(
+                conn,
+                new_comment,
+                annotation,
+                Some(&search),
+            ) {
+                tracing::warn!(error = ?e, ticket_id = ticket.id, "portal: failed to persist initial comment");
+            }
+        }
+        Ok(ticket)
+    });
+
+    match result {
+        Ok(ticket) => HttpResponse::Created().json(ticket),
+        Err(e) => {
+            tracing::error!(error = ?e, "portal: failed to create ticket");
+            errors::internal("Failed to create ticket")
+        }
+    }
+}
+
+/// `POST /api/portal/tickets/{id}/comments` — the customer replies on one of
+/// their own tickets. Ownership is checked first (404 otherwise), and the reply
+/// is always a customer-visible (non-internal) comment authored by the customer.
+pub async fn reply_to_my_ticket(
+    mut tc: TenantConn,
+    portal: PortalContext,
+    search_service: web::Data<Arc<SearchService>>,
+    path: web::Path<i32>,
+    body: web::Json<NewPortalReply>,
+) -> impl Responder {
+    let ticket_id = path.into_inner();
+    let content = body.into_inner().content.trim().to_string();
+    if content.is_empty() {
+        return errors::bad_request("Reply cannot be empty");
+    }
+    let vis = VisibilityContext::requester_only(portal.user_uuid);
+    let user_uuid = portal.user_uuid;
+    let search = Arc::clone(search_service.get_ref());
+
+    let result = tc.run(move |conn| {
+        if !can_view_ticket(conn, &vis, ticket_id)? {
+            return Ok(None);
+        }
+        let new_comment = NewComment {
+            content,
+            ticket_id,
+            user_uuid,
+            is_internal: false,
+            content_format: ContentFormat::Plaintext,
+            ..Default::default()
+        };
+        let annotation = crate::repository::comments::CommentCreationAnnotation {
+            source: Some("portal".to_string()),
+            ..Default::default()
+        };
+        let comment = crate::repository::comments::create_comment_with_annotation(
+            conn,
+            new_comment,
+            annotation,
+            Some(&search),
+        )?;
+        Ok(Some(comment))
+    });
+
+    match result {
+        Ok(Some(comment)) => HttpResponse::Created().json(comment),
+        Ok(None) => errors::not_found("Ticket not found"),
+        Err(e) => {
+            tracing::error!(error = ?e, "portal: failed to post reply");
+            errors::internal("Failed to post reply")
         }
     }
 }

--- a/backend/src/handlers/portal.rs
+++ b/backend/src/handlers/portal.rs
@@ -17,15 +17,19 @@
 //!   who is a member of that workspace. Split out (like the agent gate) so it
 //!   is unit-testable independently of the actix middleware that will wrap it.
 
+use actix_web::cookie::Cookie;
 use actix_web::dev::ServiceRequest;
-use actix_web::{Error, HttpMessage, HttpRequest, HttpResponse};
+use actix_web::{web, Error, HttpMessage, HttpRequest, HttpResponse, Responder};
+use serde::Deserialize;
 use serde_json::json;
 use uuid::Uuid;
 
-use crate::db::DbConnection;
+use crate::db::{DbConnection, Pool};
 use crate::extractors::WorkspaceContext;
+use crate::handlers::errors;
 use crate::middleware::cookie_auth::{require_workspace_membership, PORTAL_SCOPE};
 use crate::models::{Claims, User};
+use crate::utils::reset_tokens::{ResetTokenUtils, TokenType};
 
 /// The authenticated portal principal for a request: a customer (`user_uuid`)
 /// acting within one workspace (resolved from the portal origin and confirmed
@@ -87,20 +91,27 @@ pub fn authorize_portal_request(
     })
 }
 
-/// Establish a customer-portal session for `user` within `workspace_uuid`:
-/// create the session record, mint the portal token bundle, and return a JSON
-/// response carrying the portal cookies. Called once a login flow (magic-link)
-/// has proven the customer's email ownership.
-///
-/// Reuses the agent session machinery wholesale (`create_session_record`,
-/// refresh-token rotation, CSRF); only the access token's scope/binding and the
-/// cookie names are portal-specific.
-pub fn establish_portal_session(
+/// The cookies + CSRF value that make up a freshly minted portal session,
+/// ready to attach to either a JSON response (XHR) or a redirect (the
+/// magic-link callback's top-level navigation).
+struct PortalSessionCookies {
+    access: Cookie<'static>,
+    refresh: Cookie<'static>,
+    csrf: Cookie<'static>,
+    csrf_token: String,
+}
+
+/// Mint a portal session for `user` within `workspace_uuid`: create the session
+/// record and the portal token bundle, returning the cookies to set. Reuses the
+/// agent session machinery wholesale (`create_session_record`, refresh-token
+/// rotation, CSRF); only the access token's scope/binding and the cookie names
+/// are portal-specific.
+fn mint_portal_session(
     user: &User,
     workspace_uuid: Uuid,
     request: &HttpRequest,
     conn: &mut DbConnection,
-) -> Result<HttpResponse, HttpResponse> {
+) -> Result<PortalSessionCookies, HttpResponse> {
     let session =
         crate::handlers::auth::create_session_record(&user.uuid, request, conn).map_err(|e| {
             tracing::error!(error = ?e, "portal session: failed to create session record");
@@ -119,19 +130,228 @@ pub fn establish_portal_session(
         conn,
     )?;
 
+    Ok(PortalSessionCookies {
+        access: crate::utils::cookies::create_portal_access_cookie(&tokens.access_token),
+        refresh: crate::utils::cookies::create_portal_refresh_cookie(&tokens.refresh_token),
+        csrf: crate::utils::cookies::create_portal_csrf_cookie(&tokens.csrf_token),
+        csrf_token: tokens.csrf_token,
+    })
+}
+
+/// Establish a portal session and return a JSON response carrying the portal
+/// cookies. Called once a login flow has proven the customer's email ownership.
+pub fn establish_portal_session(
+    user: &User,
+    workspace_uuid: Uuid,
+    request: &HttpRequest,
+    conn: &mut DbConnection,
+) -> Result<HttpResponse, HttpResponse> {
+    let session = mint_portal_session(user, workspace_uuid, request, conn)?;
     Ok(HttpResponse::Ok()
-        .cookie(crate::utils::cookies::create_portal_access_cookie(
-            &tokens.access_token,
-        ))
-        .cookie(crate::utils::cookies::create_portal_refresh_cookie(
-            &tokens.refresh_token,
-        ))
-        .cookie(crate::utils::cookies::create_portal_csrf_cookie(
-            &tokens.csrf_token,
-        ))
+        .cookie(session.access)
+        .cookie(session.refresh)
+        .cookie(session.csrf)
         .json(json!({
             "success": true,
-            "csrf_token": tokens.csrf_token,
+            "csrf_token": session.csrf_token,
             "workspace_uuid": workspace_uuid,
         })))
+}
+
+// --- Magic-link sign-in ---
+
+#[derive(Deserialize)]
+pub struct MagicLinkRequest {
+    pub email: String,
+}
+
+#[derive(Deserialize)]
+pub struct MagicLinkCallbackQuery {
+    pub token: String,
+}
+
+/// Uniform response for the request endpoint: the same body whether or not an
+/// account exists, so the portal can't be used to enumerate which addresses are
+/// customers of a workspace.
+fn magic_link_accepted() -> HttpResponse {
+    HttpResponse::Ok().json(json!({
+        "status": "ok",
+        "message": "If an account exists for that email, a sign-in link has been sent."
+    }))
+}
+
+/// `POST /api/portal/auth/magic-link` (portal origin, unauthenticated). Issues a
+/// single-use sign-in link to a baseline member of the origin's workspace.
+///
+/// Always returns the same uniform body. Work happens only when the email
+/// belongs to a member of THIS workspace; everything else (unknown email,
+/// non-member, rate-limited, no primary email) silently no-ops behind the same
+/// response.
+pub async fn request_magic_link(
+    req: HttpRequest,
+    body: web::Json<MagicLinkRequest>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    let Some(ctx) = req.extensions().get::<WorkspaceContext>().cloned() else {
+        // No workspace resolved for this origin: nothing to sign in to.
+        return magic_link_accepted();
+    };
+    let email = body.email.trim().to_lowercase();
+    if email.is_empty() || !email.contains('@') {
+        return magic_link_accepted();
+    }
+
+    let mut conn = match pool.get() {
+        Ok(c) => c,
+        Err(_) => return magic_link_accepted(),
+    };
+
+    // Resolve a member of THIS workspace with that email; bail (uniformly) if
+    // there is none.
+    let user = match crate::repository::users::get_user_by_email(&email, &mut conn) {
+        Ok(u) => u,
+        Err(_) => return magic_link_accepted(),
+    };
+    let is_member = matches!(
+        crate::repository::workspaces::membership(&mut conn, ctx.workspace_id, user.uuid),
+        Ok(Some(_))
+    );
+    if !is_member {
+        return magic_link_accepted();
+    }
+
+    // Rate-limit: cap sign-in links per user per hour.
+    let since = chrono::Utc::now() - chrono::Duration::hours(1);
+    let recent = crate::repository::reset_tokens::count_recent_tokens(
+        &mut conn,
+        user.uuid,
+        TokenType::PortalMagicLink.as_str(),
+        since,
+    )
+    .unwrap_or(0);
+    if recent >= 5 {
+        return magic_link_accepted();
+    }
+
+    let token = ResetTokenUtils::create_reset_token(user.uuid, TokenType::PortalMagicLink);
+    if crate::repository::reset_tokens::create_reset_token(
+        &mut conn,
+        &token.token_hash,
+        user.uuid,
+        TokenType::PortalMagicLink.as_str(),
+        None,
+        None,
+        token.expires_at,
+        None,
+    )
+    .is_err()
+    {
+        return magic_link_accepted();
+    }
+
+    let Some(recipient) = crate::repository::user_helpers::get_primary_email(&user.uuid, &mut conn)
+    else {
+        return magic_link_accepted();
+    };
+
+    // Link base is the workspace's own canonical origin (the portal host), so
+    // the emailed link lands back on the same origin the request came from.
+    let base_url = crate::utils::tenant_origin::canonical_host_for(
+        &ctx.slug,
+        ctx.custom_domain.as_deref(),
+        crate::utils::tenant_origin::tenant_domain().as_deref(),
+    )
+    .map(|host| format!("https://{host}"))
+    .or_else(|| crate::utils::tenant_origin::email_link_base(None))
+    .unwrap_or_default();
+
+    let email_service = match crate::utils::email::EmailService::from_env() {
+        Ok(s) => s,
+        Err(_) => return magic_link_accepted(),
+    };
+
+    // Branding read + enqueue touch workspace-isolated tables, so run pinned +
+    // elevated (the standard background path for tenant-table writes).
+    let raw_token = token.raw_token.clone();
+    let user_name = user.name.clone();
+    let _ = crate::sync::session::background_run_in_workspace(
+        &pool,
+        "background:portal_magic_link",
+        ctx.workspace_id,
+        move |conn| {
+            let branding = crate::utils::email_branding::get_email_branding(conn, &base_url);
+            let locale = crate::repository::user_locale::resolve_effective_locale(conn, user.uuid);
+            crate::services::transactional_email::enqueue_portal_magic_link(
+                conn,
+                &email_service,
+                &branding,
+                &recipient,
+                &user_name,
+                &raw_token,
+                &locale,
+            )
+        },
+    );
+
+    magic_link_accepted()
+}
+
+/// `GET /api/portal/auth/callback?token=…` (portal origin, unauthenticated).
+/// Consumes a single-use sign-in token, confirms the subject is a member of the
+/// origin's workspace, and establishes the portal session, redirecting to the
+/// portal home with the session cookies set.
+pub async fn magic_link_callback(
+    req: HttpRequest,
+    query: web::Query<MagicLinkCallbackQuery>,
+    pool: web::Data<Pool>,
+) -> impl Responder {
+    let Some(ctx) = req.extensions().get::<WorkspaceContext>().cloned() else {
+        return errors::bad_request("No workspace for this origin");
+    };
+    let mut conn = match pool.get() {
+        Ok(c) => c,
+        Err(_) => return errors::internal("Database connection failed"),
+    };
+
+    // Single-use: the token is claimed (marked used) atomically here.
+    let user_uuid = match crate::repository::reset_tokens::validate_and_consume_token(
+        &mut conn,
+        &query.token,
+        TokenType::PortalMagicLink.as_str(),
+    ) {
+        Ok(uuid) => uuid,
+        Err(_) => return sign_in_error_redirect(),
+    };
+
+    // The link is workspace-agnostic, so confirm the subject actually belongs
+    // to the workspace this origin serves before minting a session for it.
+    if !matches!(
+        crate::repository::workspaces::membership(&mut conn, ctx.workspace_id, user_uuid),
+        Ok(Some(_))
+    ) {
+        return sign_in_error_redirect();
+    }
+
+    let user = match crate::repository::users::find_active_by_uuid(&user_uuid, &mut conn) {
+        Ok(u) => u,
+        Err(_) => return sign_in_error_redirect(),
+    };
+
+    match mint_portal_session(&user, ctx.workspace_uuid, &req, &mut conn) {
+        Ok(session) => HttpResponse::Found()
+            .cookie(session.access)
+            .cookie(session.refresh)
+            .cookie(session.csrf)
+            .append_header(("Location", "/"))
+            .finish(),
+        Err(resp) => resp,
+    }
+}
+
+/// Bounce a failed sign-in back to the portal with a generic error flag (a bad,
+/// expired, or already-used link). Uniform regardless of the specific failure.
+fn sign_in_error_redirect() -> HttpResponse {
+    HttpResponse::Found()
+        .append_header(("Location", "/?signin_error=1"))
+        .finish()
 }

--- a/backend/src/handlers/portal.rs
+++ b/backend/src/handlers/portal.rs
@@ -387,6 +387,7 @@ impl FromRequest for PortalContext {
     }
 }
 
+// tenant-read-exempt: authorize_portal_request's only tenant read is require_workspace_membership, which pins via with_actor_context (invisible to the scanner).
 /// Authenticate a portal request from its `portal_access` cookie and gate it.
 /// Mirrors the agent `cookie_auth_middleware`: validate the token (and its
 /// session), run the portal authorization gate, then pin the request actor to

--- a/backend/src/handlers/portal.rs
+++ b/backend/src/handlers/portal.rs
@@ -17,19 +17,29 @@
 //!   who is a member of that workspace. Split out (like the agent gate) so it
 //!   is unit-testable independently of the actix middleware that will wrap it.
 
+use std::future::{ready, Ready};
+
+use actix_web::body::MessageBody;
 use actix_web::cookie::Cookie;
-use actix_web::dev::ServiceRequest;
-use actix_web::{web, Error, HttpMessage, HttpRequest, HttpResponse, Responder};
+use actix_web::dev::{Payload, ServiceRequest, ServiceResponse};
+use actix_web::middleware::Next;
+use actix_web::{web, Error, FromRequest, HttpMessage, HttpRequest, HttpResponse, Responder};
 use serde::Deserialize;
 use serde_json::json;
 use uuid::Uuid;
 
 use crate::db::{DbConnection, Pool};
-use crate::extractors::WorkspaceContext;
+use crate::extractors::{TenantConn, WorkspaceContext};
 use crate::handlers::errors;
 use crate::middleware::cookie_auth::{require_workspace_membership, PORTAL_SCOPE};
-use crate::models::{Claims, User};
+use crate::models::{Claims, Ticket, User};
+use crate::repository::ticket_visibility::{
+    can_view_ticket, visible_tickets_query, VisibilityContext,
+};
+use crate::schema::tickets;
+use crate::utils::jwt::JwtUtils;
 use crate::utils::reset_tokens::{ResetTokenUtils, TokenType};
+use diesel::prelude::*;
 
 /// The authenticated portal principal for a request: a customer (`user_uuid`)
 /// acting within one workspace (resolved from the portal origin and confirmed
@@ -354,4 +364,112 @@ fn sign_in_error_redirect() -> HttpResponse {
     HttpResponse::Found()
         .append_header(("Location", "/?signin_error=1"))
         .finish()
+}
+
+// --- Authenticated portal API ---
+
+/// Extractor for the authenticated portal principal, published by
+/// [`portal_auth_middleware`]. A handler that takes `PortalContext` is only
+/// reachable behind that middleware.
+impl FromRequest for PortalContext {
+    type Error = Error;
+    type Future = Ready<Result<Self, Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        match req.extensions().get::<PortalContext>().cloned() {
+            Some(ctx) => ready(Ok(ctx)),
+            None => ready(Err(actix_web::error::ErrorUnauthorized(
+                "Portal authentication required",
+            ))),
+        }
+    }
+}
+
+/// Authenticate a portal request from its `portal_access` cookie and gate it.
+/// Mirrors the agent `cookie_auth_middleware`: validate the token (and its
+/// session), run the portal authorization gate, then pin the request actor to
+/// the workspace so `TenantConn` queries are RLS-scoped. A non-portal token, a
+/// token bound to a different tenant, or a non-member all fail here.
+pub async fn portal_auth_middleware(
+    req: ServiceRequest,
+    next: Next<impl MessageBody>,
+) -> Result<ServiceResponse<impl MessageBody>, Error> {
+    let pool = req
+        .app_data::<web::Data<Pool>>()
+        .ok_or_else(|| actix_web::error::ErrorInternalServerError("Database pool not found"))?;
+    let mut conn = pool
+        .get()
+        .map_err(|_| actix_web::error::ErrorInternalServerError("Database connection failed"))?;
+
+    let token = req
+        .cookie(crate::utils::cookies::PORTAL_ACCESS_TOKEN_COOKIE)
+        .ok_or_else(|| actix_web::error::ErrorUnauthorized("Authentication required"))?;
+
+    let (claims, _user) = JwtUtils::authenticate_with_token(token.value(), &mut conn)
+        .await
+        .map_err(|_| actix_web::error::ErrorUnauthorized("Invalid or expired token"))?;
+
+    let portal_ctx = authorize_portal_request(&req, &mut conn, &claims)?;
+    drop(conn);
+
+    req.extensions_mut().insert(portal_ctx);
+    // Pin the actor to the resolved workspace (same path the agent auth uses) so
+    // TenantConn runs portal queries RLS-scoped to this tenant.
+    crate::middleware::request_context::populate(&req, &claims);
+    req.extensions_mut().insert(claims);
+
+    next.call(req).await
+}
+
+/// `GET /api/portal/tickets` — the customer's own tickets in this workspace.
+///
+/// RLS pins to the workspace (the portal origin's tenant); the visibility
+/// context is forced requester-only, so the rows are exactly the tickets this
+/// customer requested or watches, never another customer's.
+pub async fn list_my_tickets(mut tc: TenantConn, portal: PortalContext) -> impl Responder {
+    let vis = VisibilityContext::requester_only(portal.user_uuid);
+    let result = tc.run(move |conn| {
+        visible_tickets_query(&vis)
+            .order(tickets::updated_at.desc())
+            .load::<Ticket>(conn)
+    });
+    match result {
+        Ok(rows) => HttpResponse::Ok().json(rows),
+        Err(e) => {
+            tracing::error!(error = ?e, "portal: failed to list tickets");
+            errors::internal("Failed to list tickets")
+        }
+    }
+}
+
+/// `GET /api/portal/tickets/{id}` — one of the customer's tickets with its
+/// customer-visible thread (internal notes dropped). 404 (not 403) when the
+/// ticket isn't theirs, so ticket existence doesn't leak.
+pub async fn get_my_ticket(
+    mut tc: TenantConn,
+    portal: PortalContext,
+    path: web::Path<i32>,
+) -> impl Responder {
+    let ticket_id = path.into_inner();
+    let vis = VisibilityContext::requester_only(portal.user_uuid);
+    let result = tc.run(move |conn| {
+        if !can_view_ticket(conn, &vis, ticket_id)? {
+            return Ok(None);
+        }
+        let ticket = crate::repository::tickets::get_ticket_by_id(conn, ticket_id)?;
+        let comments =
+            crate::repository::comments::get_public_comments_by_ticket_id(conn, ticket_id)?;
+        Ok(Some((ticket, comments)))
+    });
+    match result {
+        Ok(Some((ticket, comments))) => HttpResponse::Ok().json(json!({
+            "ticket": ticket,
+            "comments": comments,
+        })),
+        Ok(None) => errors::not_found("Ticket not found"),
+        Err(e) => {
+            tracing::error!(error = ?e, "portal: failed to load ticket");
+            errors::internal("Failed to load ticket")
+        }
+    }
 }

--- a/backend/src/handlers/sse.rs
+++ b/backend/src/handlers/sse.rs
@@ -664,6 +664,10 @@ pub async fn sse_events_stream(
     // app.workspace_id on checkout, so without the pin an admin is downgraded
     // to member visibility. SSE bypasses the cookie/dual-auth middleware, so
     // the gate that middleware runs for REST is invoked explicitly here.
+    //
+    // The gate runs immediately after the pin with no tenant-content read in
+    // between, so pinning a client-selected workspace cannot leak. Keep the
+    // per-topic visibility reads (parse_topics_authorized below) after this.
     if let Some(workspace_id) = workspace_id {
         crate::handlers::helpers::pin_workspace(&mut conn, workspace_id);
         crate::middleware::cookie_auth::require_workspace_membership(

--- a/backend/src/handlers/sse.rs
+++ b/backend/src/handlers/sse.rs
@@ -621,20 +621,15 @@ pub async fn sse_events_stream(
             return Ok(errors::internal("Database connection error"));
         }
     };
-    // Pin the request's workspace so the caller's visibility (their role +
-    // per-ticket checks) resolves under RLS. The pool clears app.workspace_id
-    // on checkout, so without this an admin is downgraded to member visibility.
-    crate::handlers::helpers::pin_request_workspace(&req, &mut conn);
-
-    // Validate SSE token
+    // Validate the SSE token first; the selected workspace is bound into it
+    // (EventSource can't send the selection header), so the claims drive the
+    // workspace resolution below.
     let token = match query.sse_token.as_ref() {
         Some(t) => t.as_str(),
         None => {
             return Ok(errors::unauthorized("Missing SSE token"));
         }
     };
-
-    // Validate the SSE token
     use crate::utils::jwt::JwtUtils;
     let (user_info, user) = match JwtUtils::validate_token_with_user_check(token, &mut conn).await {
         Ok((claims, user)) => (claims, user),
@@ -643,19 +638,34 @@ pub async fn sse_events_stream(
         }
     };
 
-    // Membership gate. SSE bypasses the cookie/dual-auth middleware, so it
-    // authorizes the workspace explicitly: when the request resolved to a
-    // workspace, the authenticated user must be a member, otherwise they could
-    // subscribe to another tenant's live SyncActions stream (the topic +
-    // visibility checks below run UNDER the pinned workspace). Defense-in-depth
-    // while the workspace is Host-derived; load-bearing once it is a client
-    // selection (Model C). See docs/plans/v1.1-scope.md.
+    // Resolve the stream's workspace: the token's bound selection (Model C)
+    // wins, else the Host-derived context the middleware put on this request.
     use actix_web::HttpMessage as _;
-    if let Some(workspace_id) = req
-        .extensions()
-        .get::<crate::extractors::WorkspaceContext>()
-        .map(|w| w.workspace_id)
-    {
+    let workspace_id = match user_info.workspace_uuid {
+        Some(ws_uuid) => match crate::repository::workspaces::find_by_uuid(&mut conn, ws_uuid) {
+            Ok(Some(ws)) => Some(ws.id),
+            // Unknown workspace collapses into the same denial a non-member
+            // gets below, so workspace existence does not leak.
+            Ok(None) => return Ok(errors::forbidden("Not a member of this workspace")),
+            Err(e) => {
+                tracing::error!(error = ?e, "SSE token workspace resolution failed");
+                return Ok(errors::internal("Workspace resolution failed"));
+            }
+        },
+        None => req
+            .extensions()
+            .get::<crate::extractors::WorkspaceContext>()
+            .map(|w| w.workspace_id),
+    };
+
+    // Pin + membership-gate the resolved workspace so the caller's visibility
+    // (their role + per-ticket checks) resolves under RLS, and they can't
+    // subscribe to another tenant's live SyncActions stream. The pool clears
+    // app.workspace_id on checkout, so without the pin an admin is downgraded
+    // to member visibility. SSE bypasses the cookie/dual-auth middleware, so
+    // the gate that middleware runs for REST is invoked explicitly here.
+    if let Some(workspace_id) = workspace_id {
+        crate::handlers::helpers::pin_workspace(&mut conn, workspace_id);
         crate::middleware::cookie_auth::require_workspace_membership(
             &mut conn,
             workspace_id,
@@ -873,9 +883,23 @@ pub async fn get_sse_token(
         }
     };
 
+    // Bind the request's resolved workspace into the SSE token. The auth
+    // middleware has already resolved it (selection header or Host) and
+    // membership-gated it, so the stream can authorize against the same
+    // workspace without the selection header EventSource can't send. `None`
+    // when no workspace resolved (apex / self-hosted bootstrap is still set).
+    let workspace_uuid = req
+        .extensions()
+        .get::<crate::extractors::WorkspaceContext>()
+        .map(|w| w.workspace_uuid);
+
     // Generate a short-lived SSE token (1 hour)
     use crate::utils::jwt::JwtUtils;
-    let sse_token = match JwtUtils::create_sse_token(&user_info.sub, &user_info.platform_role) {
+    let sse_token = match JwtUtils::create_sse_token(
+        &user_info.sub,
+        &user_info.platform_role,
+        workspace_uuid,
+    ) {
         Ok(token) => token,
         Err(_) => {
             return errors::internal("Failed to create SSE token");

--- a/backend/src/handlers/sse.rs
+++ b/backend/src/handlers/sse.rs
@@ -643,6 +643,26 @@ pub async fn sse_events_stream(
         }
     };
 
+    // Membership gate. SSE bypasses the cookie/dual-auth middleware, so it
+    // authorizes the workspace explicitly: when the request resolved to a
+    // workspace, the authenticated user must be a member, otherwise they could
+    // subscribe to another tenant's live SyncActions stream (the topic +
+    // visibility checks below run UNDER the pinned workspace). Defense-in-depth
+    // while the workspace is Host-derived; load-bearing once it is a client
+    // selection (Model C). See docs/plans/v1.1-scope.md.
+    use actix_web::HttpMessage as _;
+    if let Some(workspace_id) = req
+        .extensions()
+        .get::<crate::extractors::WorkspaceContext>()
+        .map(|w| w.workspace_id)
+    {
+        crate::middleware::cookie_auth::require_workspace_membership(
+            &mut conn,
+            workspace_id,
+            user.uuid,
+        )?;
+    }
+
     // Resolve subscription set. The client may declare interest via
     // `?topics=user,global,ticket-42` (comma-separated). When absent,
     // `user` + `global` are subscribed for back-compat. Unknown

--- a/backend/src/handlers/unsubscribe.rs
+++ b/backend/src/handlers/unsubscribe.rs
@@ -1,0 +1,75 @@
+//! Public one-click email unsubscribe (B2 / RFC 8058).
+//!
+//! Linked from the `List-Unsubscribe` header on notification mail. No auth: the
+//! signed token in the query names the user, so the endpoint is safe to expose
+//! publicly. POST is the RFC 8058 one-click form (the mail client submits
+//! `List-Unsubscribe=One-Click` automatically); GET is the human following the
+//! link in a browser. Both turn off the email channel for every notification
+//! type for that user; transactional mail (password reset, invitation) is
+//! unaffected.
+
+use actix_web::{web, HttpResponse, Responder};
+use serde::Deserialize;
+
+use crate::services::notifications::NotificationService;
+use crate::utils::unsubscribe_token;
+
+#[derive(Deserialize)]
+pub struct UnsubscribeQuery {
+    pub token: String,
+}
+
+/// Verify the token and apply the opt-out, or return the response to send.
+async fn apply(
+    token: &str,
+    notification_service: &web::Data<NotificationService>,
+) -> Result<(), HttpResponse> {
+    // Don't distinguish "bad signature" from "unknown user": a public endpoint
+    // shouldn't confirm whether a given token or user is valid.
+    let user_uuid = unsubscribe_token::verify(token).ok_or_else(|| {
+        HttpResponse::BadRequest().body("This unsubscribe link is invalid or has expired.")
+    })?;
+    notification_service
+        .preferences()
+        .disable_all_email(&user_uuid)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "unsubscribe: failed to disable email notifications");
+            HttpResponse::InternalServerError().body("Could not process the unsubscribe request.")
+        })?;
+    Ok(())
+}
+
+/// RFC 8058 one-click POST. The mail client sends this when the user taps its
+/// built-in unsubscribe affordance; the request body is ignored.
+pub async fn one_click(
+    query: web::Query<UnsubscribeQuery>,
+    notification_service: web::Data<NotificationService>,
+) -> impl Responder {
+    match apply(&query.token, &notification_service).await {
+        Ok(()) => HttpResponse::Ok().finish(),
+        Err(resp) => resp,
+    }
+}
+
+/// Human-facing GET: someone followed the link in their mail client. Same
+/// effect, with a plain confirmation page.
+pub async fn landing(
+    query: web::Query<UnsubscribeQuery>,
+    notification_service: web::Data<NotificationService>,
+) -> impl Responder {
+    match apply(&query.token, &notification_service).await {
+        Ok(()) => HttpResponse::Ok()
+            .content_type("text/html; charset=utf-8")
+            .body(CONFIRM_HTML),
+        Err(resp) => resp,
+    }
+}
+
+const CONFIRM_HTML: &str = "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\
+<title>Unsubscribed</title></head>\
+<body style=\"font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1rem\">\
+<h1>You're unsubscribed</h1>\
+<p>You will no longer receive email notifications. You can re-enable them anytime \
+in your notification settings.</p></body></html>";

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -179,12 +179,10 @@ async fn prepare_invitation(
         .extensions()
         .get::<crate::extractors::WorkspaceContext>()
         .and_then(|ws| ws.canonical_origin());
-    let base_url = ws_origin
-        .or_else(|| std::env::var("FRONTEND_URL").ok())
-        .unwrap_or_else(|| {
-            let conn_info = req.connection_info();
-            format!("{}://{}", conn_info.scheme(), conn_info.host())
-        });
+    let base_url = crate::utils::tenant_origin::email_link_base(ws_origin).unwrap_or_else(|| {
+        let conn_info = req.connection_info();
+        format!("{}://{}", conn_info.scheme(), conn_info.host())
+    });
 
     let email_service = crate::utils::email::EmailService::from_env()
         .map_err(|e| SendInvitationResult::EmailServiceError(format!("{e:?}")))?;

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -170,10 +170,21 @@ async fn prepare_invitation(
         return Err(SendInvitationResult::TokenStorageError(format!("{e:?}")));
     }
 
-    let base_url = std::env::var("FRONTEND_URL").unwrap_or_else(|_| {
-        let conn_info = req.connection_info();
-        format!("{}://{}", conn_info.scheme(), conn_info.host())
-    });
+    // Invite into the current workspace, so the link lives on this workspace's
+    // canonical origin (custom domain or `<slug>.<NOSDESK_TENANT_DOMAIN>`),
+    // falling back to FRONTEND_URL / the request host for self-hosted. The
+    // `extensions()` borrow is dropped before `connection_info()` (which borrows
+    // extensions mutably) to avoid a RefCell double-borrow.
+    let ws_origin = req
+        .extensions()
+        .get::<crate::extractors::WorkspaceContext>()
+        .and_then(|ws| ws.canonical_origin());
+    let base_url = ws_origin
+        .or_else(|| std::env::var("FRONTEND_URL").ok())
+        .unwrap_or_else(|| {
+            let conn_info = req.connection_info();
+            format!("{}://{}", conn_info.scheme(), conn_info.host())
+        });
 
     let email_service = crate::utils::email::EmailService::from_env()
         .map_err(|e| SendInvitationResult::EmailServiceError(format!("{e:?}")))?;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1585,6 +1585,22 @@ async fn main() -> std::io::Result<()> {
             .route("/api/events/stream", web::get().to(handlers::sse::sse_events_stream))
             .route("/api/events/status", web::get().to(handlers::sse::sse_status))
 
+            // Customer portal sign-in (public by design). Unauthenticated;
+            // the workspace is resolved from the portal origin by the app-wide
+            // workspace-context middleware. Rate-limited like the auth scope to
+            // bound magic-link sends.
+            .service(
+                web::scope("/api/portal/auth")
+                    .wrap(RateLimiter::default())
+                    .route(
+                        "/magic-link",
+                        web::post().to(handlers::portal::request_magic_link),
+                    )
+                    .route(
+                        "/callback",
+                        web::get().to(handlers::portal::magic_link_callback),
+                    ),
+            )
             // Authentication routes (public by design)
             .service(
                 web::scope("/api/auth")

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -73,11 +73,26 @@ fn handle_missing_asset(path: &str) -> HttpResponse {
     HttpResponse::NotFound().finish()
 }
 
-/// Serve the SPA index.html for all non-API routes (SPA routing)
+/// The SPA shell file for a request's surface: the customer portal
+/// (`portal.html`) on a hosted per-tenant origin (the workspace middleware
+/// host-resolved a `WorkspaceContext` from `<slug>.nosdesk.app` or a verified
+/// custom domain), the agent app (`index.html`) otherwise. Self-host always
+/// serves the agent app, ignoring its ever-present bootstrap workspace.
+fn spa_shell_path(mode: middleware::DeploymentMode, host_resolved_workspace: bool) -> &'static str {
+    if mode == middleware::DeploymentMode::Hosted && host_resolved_workspace {
+        "./public/portal.html"
+    } else {
+        "./public/index.html"
+    }
+}
+
+/// Serve the SPA shell for all non-API routes (SPA routing)
 /// This follows Actix best practices for SPA applications
-async fn serve_spa(_req: HttpRequest) -> HttpResponse {
+async fn serve_spa(req: HttpRequest) -> HttpResponse {
+    use actix_web::HttpMessage as _;
+
     // Check if this is a static asset request (has file extension and not HTML)
-    let path = _req.path();
+    let path = req.path();
 
     // If it's a hashed asset request (contains hash pattern), handle as missing asset.
     // Frontend assets live under `/static/` (Vite's `assetsDir`),
@@ -91,9 +106,21 @@ async fn serve_spa(_req: HttpRequest) -> HttpResponse {
         return HttpResponse::NotFound().finish();
     }
 
-    // For all other routes (SPA routes), serve index.html
+    // Pick the SPA shell by surface (see `spa_shell_path`). The portal origin
+    // host-resolves to a `WorkspaceContext` in hosted mode; the agent origin
+    // resolves to none; self-host always serves the agent app.
+    let host_resolved_workspace = req
+        .extensions()
+        .get::<backend::extractors::WorkspaceContext>()
+        .is_some();
+    let shell = spa_shell_path(
+        middleware::DeploymentMode::current(),
+        host_resolved_workspace,
+    );
+
+    // For all other routes (SPA routes), serve the chosen shell.
     // Use no-cache so browsers always check for updated versions after deployments
-    match tokio::fs::read("./public/index.html").await {
+    match tokio::fs::read(shell).await {
         Ok(content) => {
             HttpResponse::Ok()
                 .content_type("text/html; charset=utf-8")
@@ -2527,4 +2554,34 @@ async fn main() -> std::io::Result<()> {
     });
 
     server.await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::spa_shell_path;
+    use backend::middleware::DeploymentMode;
+
+    #[test]
+    fn portal_shell_only_on_a_hosted_tenant_origin() {
+        // Hosted + a host-resolved workspace => the customer portal.
+        assert_eq!(
+            spa_shell_path(DeploymentMode::Hosted, true),
+            "./public/portal.html"
+        );
+        // Hosted agent origin (no host-resolved workspace) => the agent app.
+        assert_eq!(
+            spa_shell_path(DeploymentMode::Hosted, false),
+            "./public/index.html"
+        );
+        // Self-host always serves the agent app, even though its bootstrap
+        // workspace makes a context ever-present.
+        assert_eq!(
+            spa_shell_path(DeploymentMode::SelfHosted, true),
+            "./public/index.html"
+        );
+        assert_eq!(
+            spa_shell_path(DeploymentMode::SelfHosted, false),
+            "./public/index.html"
+        );
+    }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1522,6 +1522,9 @@ async fn main() -> std::io::Result<()> {
             // Public branding config (needed for favicon/logo before login)
             .route("/api/branding", web::get().to(handlers::branding::get_public_branding))
 
+            // Public instance config (routing topology) read at SPA startup
+            .route("/api/config", web::get().to(handlers::app_config::get_public_config))
+
             // Public (unauthenticated) guest endpoints — feature flags checked per handler.
             // Tighter JSON payload limit here than the app-wide default: the only
             // write endpoint in this scope is /tickets with a 10KB description cap,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1611,9 +1611,14 @@ async fn main() -> std::io::Result<()> {
                         handlers::portal::portal_auth_middleware,
                     ))
                     .route("/tickets", web::get().to(handlers::portal::list_my_tickets))
+                    .route("/tickets", web::post().to(handlers::portal::create_my_ticket))
                     .route(
                         "/tickets/{id}",
                         web::get().to(handlers::portal::get_my_ticket),
+                    )
+                    .route(
+                        "/tickets/{id}/comments",
+                        web::post().to(handlers::portal::reply_to_my_ticket),
                     ),
             )
             // Authentication routes (public by design)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1541,6 +1541,10 @@ async fn main() -> std::io::Result<()> {
                     .route("/docs", web::get().to(handlers::guest::list_public_docs))
                     .route("/docs/search", web::get().to(handlers::guest::search_public_docs))
                     .route("/docs/{slug}", web::get().to(handlers::guest::get_public_doc))
+                    // One-click email unsubscribe (RFC 8058): POST is the mail
+                    // client's automatic one-click, GET the human-followed link.
+                    .route("/unsubscribe", web::post().to(handlers::unsubscribe::one_click))
+                    .route("/unsubscribe", web::get().to(handlers::unsubscribe::landing))
             )
 
             // Public WebSocket for collaboration (auth handled in WebSocket handler)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1601,6 +1601,21 @@ async fn main() -> std::io::Result<()> {
                         web::get().to(handlers::portal::magic_link_callback),
                     ),
             )
+            // Authenticated customer portal API. Registered AFTER the public
+            // `/api/portal/auth` scope so the sign-in routes match there first.
+            // The portal session is ownership-scoped: every handler reads its
+            // own tickets only, RLS-pinned to the origin's workspace.
+            .service(
+                web::scope("/api/portal")
+                    .wrap(actix_web::middleware::from_fn(
+                        handlers::portal::portal_auth_middleware,
+                    ))
+                    .route("/tickets", web::get().to(handlers::portal::list_my_tickets))
+                    .route(
+                        "/tickets/{id}",
+                        web::get().to(handlers::portal::get_my_ticket),
+                    ),
+            )
             // Authentication routes (public by design)
             .service(
                 web::scope("/api/auth")

--- a/backend/src/middleware/api_token.rs
+++ b/backend/src/middleware/api_token.rs
@@ -157,6 +157,7 @@ pub fn try_bearer_auth(
         platform_role: user.platform_role.clone(),
         scope,
         sid: None,
+        workspace_uuid: None,
         exp: (now + chrono::Duration::hours(24)).timestamp() as usize,
         iat: now.timestamp() as usize,
     };

--- a/backend/src/middleware/cookie_auth.rs
+++ b/backend/src/middleware/cookie_auth.rs
@@ -22,6 +22,15 @@ use crate::models::Claims;
 use crate::utils::jwt::JwtUtils;
 use actix_web::HttpMessage;
 
+/// Token scope for an authenticated CUSTOMER PORTAL session (a baseline user
+/// signed in on the per-tenant portal origin). It is a distinct principal realm
+/// from an agent session: a portal token must never authenticate an agent /
+/// management request, even though both subjects are `users` rows. The agent
+/// membership gate refuses it outright (see [`enforce_workspace_membership`]);
+/// portal routes require it via their own auth. Kept here next to the gate that
+/// enforces the boundary.
+pub const PORTAL_SCOPE: &str = "portal";
+
 /// Item U: resolve-then-gate the request's workspace.
 ///
 /// The request's ORIGIN is authoritative for tenant scope, and resolution is
@@ -55,6 +64,18 @@ pub fn enforce_workspace_membership(
     conn: &mut DbConnection,
     claims: &Claims,
 ) -> Result<(), Error> {
+    // A customer-portal token is a different principal realm and must never
+    // authenticate an agent / management request. This gate is the single
+    // chokepoint both agent auth paths (cookie + dual) share, so refusing
+    // portal scope here walls it off everywhere at once. Belt-and-suspenders
+    // behind the separate portal cookie names and the separate portal origin.
+    if claims.scope == PORTAL_SCOPE {
+        warn!(user = %claims.sub, "Portal-scope token rejected on the agent surface");
+        return Err(actix_web::error::ErrorForbidden(
+            "This session cannot access the agent application",
+        ));
+    }
+
     // Origin-derived context wins when present (tenant portal / custom domain /
     // self-hosted bootstrap). Only when the origin resolved to no workspace
     // (the agent origin) do we consult the selection header. Resolving

--- a/backend/src/middleware/cookie_auth.rs
+++ b/backend/src/middleware/cookie_auth.rs
@@ -83,11 +83,12 @@ pub fn enforce_workspace_membership(
     Ok(())
 }
 
-/// Resolve the `X-Nosdesk-Workspace` selection header to a
-/// `WorkspaceContext`, or `Ok(None)` when selection resolution is off or
-/// the header is absent. A malformed uuid is `400 Bad Request`; an
-/// unknown workspace is `403 Forbidden` (indistinguishable from a
-/// non-member so workspace existence does not leak).
+/// Resolve the `X-Nosdesk-Workspace` selection header (the workspace **slug**,
+/// as it appears in the agent app's URL) to a `WorkspaceContext`, or `Ok(None)`
+/// when selection resolution is off or the header is absent. An unknown slug is
+/// `403 Forbidden`, indistinguishable from a non-member so workspace existence
+/// does not leak. The slug is the selection *input*; everything downstream keys
+/// off the resolved workspace's id / uuid.
 fn selected_workspace_context(
     req: &ServiceRequest,
     conn: &mut DbConnection,
@@ -96,16 +97,16 @@ fn selected_workspace_context(
     if !wc::selection_resolution_enabled() {
         return Ok(None);
     }
-    let Some(raw) = req
+    let Some(slug) = req
         .headers()
         .get(wc::WORKSPACE_SELECTION_HEADER)
         .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
     else {
         return Ok(None);
     };
-    let workspace_uuid = uuid::Uuid::parse_str(raw.trim())
-        .map_err(|_| actix_web::error::ErrorBadRequest("Invalid workspace selection"))?;
-    match wc::resolve_selected_context(conn, workspace_uuid) {
+    match wc::resolve_selected_context(conn, slug) {
         Ok(Some(ctx)) => Ok(Some(ctx)),
         Ok(None) => Err(actix_web::error::ErrorForbidden(
             "Not a member of this workspace",

--- a/backend/src/middleware/cookie_auth.rs
+++ b/backend/src/middleware/cookie_auth.rs
@@ -24,48 +24,54 @@ use actix_web::HttpMessage;
 
 /// Item U: resolve-then-gate the request's workspace.
 ///
-/// Two resolution paths feed the same membership 403 gate:
+/// The request's ORIGIN is authoritative for tenant scope, and resolution is
+/// keyed on it:
 ///
-/// - **Host-derived** (today / customer portal / self-hosted): the
-///   `WorkspaceContextMiddleware` already put a `WorkspaceContext` in
-///   extensions from the subdomain. The user must be a member of it or
-///   the request is `403 Forbidden` instead of falling through into the
-///   app with RLS-filtered-to-empty queries.
-/// - **Selection-derived** (Model C single-origin agent app, behind
-///   `NOSDESK_WORKSPACE_SELECTION`): the client names the workspace in
-///   the `X-Nosdesk-Workspace` header. The gate resolves it, membership-
-///   checks it, and inserts the resulting `WorkspaceContext` so handlers
-///   read the selection. Header wins when present; absent header falls
-///   back to Host-derived.
+/// - **Origin-derived** (customer portal `<slug>.nosdesk.app`, custom domains,
+///   and the self-hosted bootstrap): the `WorkspaceContextMiddleware` already
+///   put a `WorkspaceContext` in extensions from the Host. When present it wins
+///   outright. A client cannot override its own origin's tenant via a header,
+///   so on a tenant origin the selection header is never consulted (it could
+///   otherwise 403 on a stray slug and is a cross-tenant confusion vector).
+/// - **Selection-derived** (the single-origin agent app at `app.nosdesk.com`,
+///   behind `NOSDESK_WORKSPACE_SELECTION`): consulted ONLY when the origin
+///   resolved to no workspace — i.e. the agent origin, whose Host is on a
+///   different base domain and so never matches a tenant. The client names the
+///   workspace in the `X-Nosdesk-Workspace` header; the gate resolves it,
+///   membership-checks it, and inserts the resulting `WorkspaceContext`.
 ///
-/// Skipped (Ok) when neither path yields a workspace (apex / public
-/// routes that pin nothing); those routes don't touch tenant tables and
-/// the strict RLS policy is the secondary guard.
+/// Either way the same membership 403 gate fires: the user must be a member of
+/// the resolved workspace or the request is `403 Forbidden` rather than falling
+/// through into the app with RLS-filtered-to-empty queries.
 ///
-/// Called by every authentication middleware (cookie auth + dual auth)
-/// so the gate fires on every authenticated entry path.
+/// Skipped (Ok) when neither path yields a workspace (apex / public routes that
+/// pin nothing); those routes don't touch tenant tables and the strict RLS
+/// policy is the secondary guard.
+///
+/// Called by every authentication middleware (cookie auth + dual auth) so the
+/// gate fires on every authenticated entry path.
 pub fn enforce_workspace_membership(
     req: &ServiceRequest,
     conn: &mut DbConnection,
     claims: &Claims,
 ) -> Result<(), Error> {
-    // Selection-derived workspace takes precedence when enabled and the header
-    // is present. Resolve it to a context up front; an unknown slug collapses
-    // into the same 403 a non-member gets below (no workspace-existence leak),
-    // and a blank header is simply no selection.
-    let selected = selected_workspace_context(req, conn)?;
+    // Origin-derived context wins when present (tenant portal / custom domain /
+    // self-hosted bootstrap). Only when the origin resolved to no workspace
+    // (the agent origin) do we consult the selection header. Resolving
+    // selection eagerly would 403 a tenant-origin request that carries a stray
+    // header, so the ordering here is load-bearing, not just precedence.
+    let host_derived = req
+        .extensions()
+        .get::<crate::extractors::WorkspaceContext>()
+        .map(|w| w.workspace_id);
 
-    // Otherwise fall back to the Host-derived context the middleware resolved.
-    let target = match &selected {
-        Some(ctx) => Some(ctx.workspace_id),
-        None => req
-            .extensions()
-            .get::<crate::extractors::WorkspaceContext>()
-            .map(|w| w.workspace_id),
-    };
-    let Some(workspace_id) = target else {
-        // No tenant scope to authorize against (apex / public route).
-        return Ok(());
+    let (workspace_id, selected) = match host_derived {
+        Some(id) => (id, None),
+        None => match selected_workspace_context(req, conn)? {
+            Some(ctx) => (ctx.workspace_id, Some(ctx)),
+            // No tenant scope to authorize against (agent apex / public route).
+            None => return Ok(()),
+        },
     };
 
     // A workspace-scoped request whose subject doesn't parse is malformed; fail

--- a/backend/src/middleware/cookie_auth.rs
+++ b/backend/src/middleware/cookie_auth.rs
@@ -42,6 +42,9 @@ pub(crate) fn enforce_workspace_membership(
     conn: &mut DbConnection,
     claims: &Claims,
 ) -> Result<(), Error> {
+    // No resolved workspace (apex / public routes that pin nothing): there is
+    // no tenant scope to authorize against. Any route that DOES pin a workspace
+    // carries a WorkspaceContext, so it reaches the membership check below.
     let Some(workspace_id) = req
         .extensions()
         .get::<crate::extractors::WorkspaceContext>()
@@ -49,20 +52,31 @@ pub(crate) fn enforce_workspace_membership(
     else {
         return Ok(());
     };
-    let Ok(user_uuid) = uuid::Uuid::parse_str(&claims.sub) else {
-        return Ok(());
-    };
-    // Scope the read to the request's workspace before touching
-    // workspace_members. Its RLS policy is
-    // `workspace_id = current_setting('app.workspace_id')`, so on a raw
-    // pooled connection (where ResetAppGucs cleared the GUC) the
-    // membership row is filtered out and a real member reads as "not a
-    // member" — a chicken-and-egg, since the gate would establish the
-    // tenant scope it needs to read. Run the lookup through
-    // `with_actor_context` (the same path every tenant query uses) with the
-    // actor pinned to the resolved workspace, so `app.workspace_id` is set
-    // and RLS sees the row. The workspace is the one the host already
-    // resolved to, not anything user-supplied.
+    // A workspace-scoped request whose subject doesn't parse is malformed; fail
+    // closed rather than skip the gate (auth already validated the token, so
+    // this is unreachable in practice, but the gate must never fail open).
+    let user_uuid = uuid::Uuid::parse_str(&claims.sub)
+        .map_err(|_| actix_web::error::ErrorForbidden("Not a member of this workspace"))?;
+    require_workspace_membership(conn, workspace_id, user_uuid)
+}
+
+/// Fail-closed membership check: `Ok(())` iff `user_uuid` is a member of
+/// `workspace_id`, else a 403 (500 on lookup error). Shared by the request gate
+/// above and the SSE / collab-WS handlers, which authenticate outside the
+/// middleware and so must call this explicitly.
+///
+/// RLS-pinned read: `workspace_members`' policy is
+/// `workspace_id = current_setting('app.workspace_id')`, so on a raw pooled
+/// connection (GUC cleared by ResetAppGucs) a real member would read as "not a
+/// member". Running the lookup through `with_actor_context` pins the read to
+/// `workspace_id`. Callers that have already session-pinned the SAME workspace
+/// (SSE/collab via `pin_request_workspace`) are unaffected: the actor workspace
+/// equals the pin, so subsequent reads stay correctly scoped.
+pub fn require_workspace_membership(
+    conn: &mut DbConnection,
+    workspace_id: i32,
+    user_uuid: uuid::Uuid,
+) -> Result<(), Error> {
     let actor = crate::sync::actor::ActorContext::user_at_workspace(user_uuid, workspace_id);
     let lookup = crate::sync::session::with_actor_context(conn, &actor, |c| {
         crate::repository::workspaces::membership(c, workspace_id, user_uuid)
@@ -71,7 +85,7 @@ pub(crate) fn enforce_workspace_membership(
         Ok(Some(_)) => Ok(()),
         Ok(None) => {
             warn!(
-                user = %claims.sub,
+                user = %user_uuid,
                 workspace_id,
                 "Workspace membership 403 gate: user is not a member; denying"
             );

--- a/backend/src/middleware/cookie_auth.rs
+++ b/backend/src/middleware/cookie_auth.rs
@@ -50,9 +50,9 @@ pub fn enforce_workspace_membership(
     claims: &Claims,
 ) -> Result<(), Error> {
     // Selection-derived workspace takes precedence when enabled and the header
-    // is present. Resolve it to a context up front; a present-but-bad header is
-    // a client error (400), an unknown workspace collapses into the same 403 a
-    // non-member gets below (no workspace-existence leak).
+    // is present. Resolve it to a context up front; an unknown slug collapses
+    // into the same 403 a non-member gets below (no workspace-existence leak),
+    // and a blank header is simply no selection.
     let selected = selected_workspace_context(req, conn)?;
 
     // Otherwise fall back to the Host-derived context the middleware resolved.

--- a/backend/src/middleware/cookie_auth.rs
+++ b/backend/src/middleware/cookie_auth.rs
@@ -22,42 +22,101 @@ use crate::models::Claims;
 use crate::utils::jwt::JwtUtils;
 use actix_web::HttpMessage;
 
-/// Item U: workspace membership 403 gate.
+/// Item U: resolve-then-gate the request's workspace.
 ///
-/// If the request has a `WorkspaceContext` (hosted mode with the
-/// subdomain resolved) and the authenticated user has no
-/// `workspace_members` row for that workspace, return
-/// `403 Forbidden` instead of letting the request fall through
-/// into the app with RLS-filtered-to-empty queries.
+/// Two resolution paths feed the same membership 403 gate:
 ///
-/// Skipped when no `WorkspaceContext` is present (apex domain,
-/// unrecognised subdomain) - those routes shouldn't touch tenant
-/// tables anyway, and the strict RLS policy is the secondary
-/// guard there.
+/// - **Host-derived** (today / customer portal / self-hosted): the
+///   `WorkspaceContextMiddleware` already put a `WorkspaceContext` in
+///   extensions from the subdomain. The user must be a member of it or
+///   the request is `403 Forbidden` instead of falling through into the
+///   app with RLS-filtered-to-empty queries.
+/// - **Selection-derived** (Model C single-origin agent app, behind
+///   `NOSDESK_WORKSPACE_SELECTION`): the client names the workspace in
+///   the `X-Nosdesk-Workspace` header. The gate resolves it, membership-
+///   checks it, and inserts the resulting `WorkspaceContext` so handlers
+///   read the selection. Header wins when present; absent header falls
+///   back to Host-derived.
 ///
-/// Used by every authentication middleware (cookie auth + dual
-/// auth) so the gate fires on every authenticated entry path.
-pub(crate) fn enforce_workspace_membership(
+/// Skipped (Ok) when neither path yields a workspace (apex / public
+/// routes that pin nothing); those routes don't touch tenant tables and
+/// the strict RLS policy is the secondary guard.
+///
+/// Called by every authentication middleware (cookie auth + dual auth)
+/// so the gate fires on every authenticated entry path.
+pub fn enforce_workspace_membership(
     req: &ServiceRequest,
     conn: &mut DbConnection,
     claims: &Claims,
 ) -> Result<(), Error> {
-    // No resolved workspace (apex / public routes that pin nothing): there is
-    // no tenant scope to authorize against. Any route that DOES pin a workspace
-    // carries a WorkspaceContext, so it reaches the membership check below.
-    let Some(workspace_id) = req
-        .extensions()
-        .get::<crate::extractors::WorkspaceContext>()
-        .map(|w| w.workspace_id)
-    else {
+    // Selection-derived workspace takes precedence when enabled and the header
+    // is present. Resolve it to a context up front; a present-but-bad header is
+    // a client error (400), an unknown workspace collapses into the same 403 a
+    // non-member gets below (no workspace-existence leak).
+    let selected = selected_workspace_context(req, conn)?;
+
+    // Otherwise fall back to the Host-derived context the middleware resolved.
+    let target = match &selected {
+        Some(ctx) => Some(ctx.workspace_id),
+        None => req
+            .extensions()
+            .get::<crate::extractors::WorkspaceContext>()
+            .map(|w| w.workspace_id),
+    };
+    let Some(workspace_id) = target else {
+        // No tenant scope to authorize against (apex / public route).
         return Ok(());
     };
+
     // A workspace-scoped request whose subject doesn't parse is malformed; fail
     // closed rather than skip the gate (auth already validated the token, so
     // this is unreachable in practice, but the gate must never fail open).
     let user_uuid = uuid::Uuid::parse_str(&claims.sub)
         .map_err(|_| actix_web::error::ErrorForbidden("Not a member of this workspace"))?;
-    require_workspace_membership(conn, workspace_id, user_uuid)
+    require_workspace_membership(conn, workspace_id, user_uuid)?;
+
+    // Membership confirmed: publish the selection-derived context so downstream
+    // handlers and pins read the selected workspace, not a Host-derived one.
+    if let Some(ctx) = selected {
+        req.extensions_mut().insert(ctx);
+    }
+    Ok(())
+}
+
+/// Resolve the `X-Nosdesk-Workspace` selection header to a
+/// `WorkspaceContext`, or `Ok(None)` when selection resolution is off or
+/// the header is absent. A malformed uuid is `400 Bad Request`; an
+/// unknown workspace is `403 Forbidden` (indistinguishable from a
+/// non-member so workspace existence does not leak).
+fn selected_workspace_context(
+    req: &ServiceRequest,
+    conn: &mut DbConnection,
+) -> Result<Option<crate::extractors::WorkspaceContext>, Error> {
+    use crate::middleware::workspace_context as wc;
+    if !wc::selection_resolution_enabled() {
+        return Ok(None);
+    }
+    let Some(raw) = req
+        .headers()
+        .get(wc::WORKSPACE_SELECTION_HEADER)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return Ok(None);
+    };
+    let workspace_uuid = uuid::Uuid::parse_str(raw.trim())
+        .map_err(|_| actix_web::error::ErrorBadRequest("Invalid workspace selection"))?;
+    match wc::resolve_selected_context(conn, workspace_uuid) {
+        Ok(Some(ctx)) => Ok(Some(ctx)),
+        Ok(None) => Err(actix_web::error::ErrorForbidden(
+            "Not a member of this workspace",
+        )),
+        Err(e) => {
+            error!(error = ?e, "Selection-header workspace lookup failed");
+            Err(actix_web::error::ErrorInternalServerError(
+                "Workspace resolution failed",
+            ))
+        }
+    }
 }
 
 /// Fail-closed membership check: `Ok(())` iff `user_uuid` is a member of

--- a/backend/src/middleware/token_scope.rs
+++ b/backend/src/middleware/token_scope.rs
@@ -431,6 +431,7 @@ mod enforcement_tests {
             platform_role: "user".into(),
             scope: scope.into(),
             sid: None,
+            workspace_uuid: None,
             exp: 0,
             iat: 0,
         }

--- a/backend/src/middleware/workspace_context.rs
+++ b/backend/src/middleware/workspace_context.rs
@@ -89,6 +89,45 @@ pub fn invalidate_cache_key(key: &str) {
     WORKSPACE_CACHE.remove(key);
 }
 
+/// Request header carrying the agent app's selected workspace uuid
+/// (Model C). In selection mode the auth gate resolves this to a
+/// workspace and membership-gates it, replacing Host-derived
+/// resolution for the single-origin agent surface. The customer
+/// portal stays Host-derived and ignores this header.
+pub const WORKSPACE_SELECTION_HEADER: &str = "X-Nosdesk-Workspace";
+
+/// Whether selection-based workspace resolution is enabled.
+///
+/// True only when running `hosted` AND `NOSDESK_WORKSPACE_SELECTION`
+/// is truthy. Read fresh from the environment (not memoised) so it is
+/// operationally toggleable and the unit tests can flip it. Off by
+/// default: self-hosted and current Host-derived hosted are unaffected.
+pub fn selection_resolution_enabled() -> bool {
+    DeploymentMode::from_env() == DeploymentMode::Hosted
+        && matches!(
+            std::env::var("NOSDESK_WORKSPACE_SELECTION")
+                .ok()
+                .as_deref()
+                .map(str::trim)
+                .map(str::to_ascii_lowercase)
+                .as_deref(),
+            Some("1") | Some("true") | Some("yes") | Some("on")
+        )
+}
+
+/// Resolve a selection-header workspace uuid to a [`WorkspaceContext`].
+/// `Ok(None)` for an unknown / soft-archived workspace; the caller maps
+/// that to the same 403 a non-member gets so workspace existence does
+/// not leak. The `workspaces` table is resolvable without a pinned GUC
+/// (it is the resolution table), the same way `find_by_slug` is used in
+/// Host-derived resolution above.
+pub fn resolve_selected_context(
+    conn: &mut crate::db::DbConnection,
+    workspace_uuid: uuid::Uuid,
+) -> diesel::QueryResult<Option<WorkspaceContext>> {
+    Ok(workspace_repo::find_by_uuid(conn, workspace_uuid)?.map(workspace_to_context))
+}
+
 /// Deployment topology. Drives whether workspace context comes
 /// from a process-wide bootstrap (self-hosted) or per-request
 /// subdomain resolution (hosted SaaS).
@@ -382,5 +421,57 @@ mod tests {
         } else {
             std::env::remove_var("NOSDESK_DEPLOYMENT_MODE");
         }
+    }
+
+    /// Snapshot + restore both env vars selection resolution reads, run `body`
+    /// with them set to the given values. std::env is process-wide, so tests
+    /// that touch it must put it back.
+    fn with_selection_env(mode: Option<&str>, flag: Option<&str>, body: impl FnOnce()) {
+        let prev_mode = std::env::var("NOSDESK_DEPLOYMENT_MODE").ok();
+        let prev_flag = std::env::var("NOSDESK_WORKSPACE_SELECTION").ok();
+        match mode {
+            Some(v) => std::env::set_var("NOSDESK_DEPLOYMENT_MODE", v),
+            None => std::env::remove_var("NOSDESK_DEPLOYMENT_MODE"),
+        }
+        match flag {
+            Some(v) => std::env::set_var("NOSDESK_WORKSPACE_SELECTION", v),
+            None => std::env::remove_var("NOSDESK_WORKSPACE_SELECTION"),
+        }
+        body();
+        match prev_mode {
+            Some(v) => std::env::set_var("NOSDESK_DEPLOYMENT_MODE", v),
+            None => std::env::remove_var("NOSDESK_DEPLOYMENT_MODE"),
+        }
+        match prev_flag {
+            Some(v) => std::env::set_var("NOSDESK_WORKSPACE_SELECTION", v),
+            None => std::env::remove_var("NOSDESK_WORKSPACE_SELECTION"),
+        }
+    }
+
+    #[test]
+    fn selection_off_by_default_and_requires_both_hosted_and_flag() {
+        // Default: neither hosted nor flag.
+        with_selection_env(None, None, || {
+            assert!(!selection_resolution_enabled());
+        });
+        // Hosted but flag absent: still off.
+        with_selection_env(Some("hosted"), None, || {
+            assert!(!selection_resolution_enabled());
+        });
+        // Flag set but self-hosted: off (single-tenant ignores selection).
+        with_selection_env(Some("self_hosted"), Some("1"), || {
+            assert!(!selection_resolution_enabled());
+        });
+        // Both present: on.
+        with_selection_env(Some("hosted"), Some("1"), || {
+            assert!(selection_resolution_enabled());
+        });
+        // Truthy spellings accepted; junk is not.
+        with_selection_env(Some("hosted"), Some("true"), || {
+            assert!(selection_resolution_enabled());
+        });
+        with_selection_env(Some("hosted"), Some("maybe"), || {
+            assert!(!selection_resolution_enabled());
+        });
     }
 }

--- a/backend/src/middleware/workspace_context.rs
+++ b/backend/src/middleware/workspace_context.rs
@@ -327,7 +327,16 @@ async fn resolve_context(
             }
 
             // --- Pass 2: subdomain match against slug ---
-            let slug = subdomain_from_host(&host_no_port)?;
+            // Scope slug resolution to the configured tenant base domain so a
+            // host on a DIFFERENT base domain (the agent origin
+            // `app.nosdesk.com` vs tenants on `*.nosdesk.app`) never resolves
+            // to a tenant workspace. With no tenant domain configured (legacy /
+            // single-base-domain hosted), fall back to the bare first-label
+            // extraction.
+            let slug = match crate::utils::tenant_origin::tenant_domain() {
+                Some(td) => slug_under_tenant_domain(&host_no_port, &td)?,
+                None => subdomain_from_host(&host_no_port)?,
+            };
             let slug_key = format!("slug:{slug}");
             if let Some(ctx) = cache_get(&slug_key) {
                 return Some(ctx);
@@ -376,6 +385,25 @@ fn subdomain_from_host(host: &str) -> Option<&str> {
     Some(labels[0])
 }
 
+/// Extract the tenant slug from a host that sits DIRECTLY under the configured
+/// tenant base domain: `acme.nosdesk.app` with tenant domain `nosdesk.app` ->
+/// `Some("acme")`.
+///
+/// Returns `None` when the host is not exactly `<label>.<tenant_domain>`: a
+/// different base domain (the agent origin `app.nosdesk.com`), the apex domain
+/// itself, or a multi-level subdomain (`x.acme.nosdesk.app`). Scoping slug
+/// resolution to the tenant domain is what keeps the agent origin (served on a
+/// different base domain) from ever resolving to a tenant workspace, which is
+/// the origin boundary the surface model relies on. `host` is expected already
+/// port-stripped and lowercased.
+fn slug_under_tenant_domain<'a>(host: &'a str, tenant_domain: &str) -> Option<&'a str> {
+    let label = host.strip_suffix(tenant_domain)?.strip_suffix('.')?;
+    if label.is_empty() || label.contains('.') {
+        return None;
+    }
+    Some(label)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -396,6 +424,44 @@ mod tests {
     fn subdomain_localhost_returns_none() {
         assert_eq!(subdomain_from_host("localhost"), None);
         assert_eq!(subdomain_from_host("localhost:8080"), None);
+    }
+
+    #[test]
+    fn tenant_slug_extracted_under_tenant_domain() {
+        assert_eq!(
+            slug_under_tenant_domain("acme.nosdesk.app", "nosdesk.app"),
+            Some("acme")
+        );
+    }
+
+    #[test]
+    fn tenant_slug_none_on_different_base_domain() {
+        // The agent origin lives on a DIFFERENT base domain; it must never
+        // resolve to a tenant, no matter what slugs exist.
+        assert_eq!(
+            slug_under_tenant_domain("app.nosdesk.com", "nosdesk.app"),
+            None
+        );
+        assert_eq!(
+            slug_under_tenant_domain("nosdesk-dev.fly.dev", "nosdesk.app"),
+            None
+        );
+    }
+
+    #[test]
+    fn tenant_slug_none_for_apex_and_multilevel() {
+        // The tenant apex itself has no slug label.
+        assert_eq!(slug_under_tenant_domain("nosdesk.app", "nosdesk.app"), None);
+        // Multi-level subdomains are not provisioned and must not resolve.
+        assert_eq!(
+            slug_under_tenant_domain("x.acme.nosdesk.app", "nosdesk.app"),
+            None
+        );
+        // A host that merely ends with the domain string but isn't under it.
+        assert_eq!(
+            slug_under_tenant_domain("evilnosdesk.app", "nosdesk.app"),
+            None
+        );
     }
 
     #[test]

--- a/backend/src/middleware/workspace_context.rs
+++ b/backend/src/middleware/workspace_context.rs
@@ -89,11 +89,11 @@ pub fn invalidate_cache_key(key: &str) {
     WORKSPACE_CACHE.remove(key);
 }
 
-/// Request header carrying the agent app's selected workspace uuid
-/// (Model C). In selection mode the auth gate resolves this to a
-/// workspace and membership-gates it, replacing Host-derived
-/// resolution for the single-origin agent surface. The customer
-/// portal stays Host-derived and ignores this header.
+/// Request header carrying the agent app's selected workspace **slug**
+/// (Model C), as it appears in the single-origin URL (`/acme/...`). In
+/// selection mode the auth gate resolves this to a workspace and
+/// membership-gates it, replacing Host-derived resolution for the agent
+/// surface. The customer portal stays Host-derived and ignores this header.
 pub const WORKSPACE_SELECTION_HEADER: &str = "X-Nosdesk-Workspace";
 
 /// Whether selection-based workspace resolution is enabled.
@@ -115,17 +115,17 @@ pub fn selection_resolution_enabled() -> bool {
         )
 }
 
-/// Resolve a selection-header workspace uuid to a [`WorkspaceContext`].
+/// Resolve a selection-header workspace slug to a [`WorkspaceContext`].
 /// `Ok(None)` for an unknown / soft-archived workspace; the caller maps
 /// that to the same 403 a non-member gets so workspace existence does
 /// not leak. The `workspaces` table is resolvable without a pinned GUC
-/// (it is the resolution table), the same way `find_by_slug` is used in
-/// Host-derived resolution above.
+/// (it is the resolution table), the same `find_by_slug` Host-derived
+/// resolution uses above.
 pub fn resolve_selected_context(
     conn: &mut crate::db::DbConnection,
-    workspace_uuid: uuid::Uuid,
+    slug: &str,
 ) -> diesel::QueryResult<Option<WorkspaceContext>> {
-    Ok(workspace_repo::find_by_uuid(conn, workspace_uuid)?.map(workspace_to_context))
+    Ok(workspace_repo::find_by_slug(conn, slug)?.map(workspace_to_context))
 }
 
 /// Deployment topology. Drives whether workspace context comes

--- a/backend/src/middleware/workspace_context.rs
+++ b/backend/src/middleware/workspace_context.rs
@@ -166,6 +166,7 @@ impl WorkspaceContextConfig {
                     workspace_uuid: ws.uuid,
                     slug: ws.slug,
                     name: ws.name,
+                    custom_domain: ws.custom_domain,
                     organisation_id: ws.organisation_id,
                 }))
             }
@@ -308,6 +309,7 @@ fn workspace_to_context(ws: crate::models::Workspace) -> WorkspaceContext {
         workspace_uuid: ws.uuid,
         slug: ws.slug,
         name: ws.name,
+        custom_domain: ws.custom_domain,
         organisation_id: ws.organisation_id,
     }
 }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -7039,6 +7039,10 @@ pub struct OutboundEmail {
     /// (the instance identity, for auth mail that must not originate from a
     /// tenant relay). Decided at enqueue.
     pub sender_identity: String,
+    /// Notification vs transactional (see [`outbound_email_mail_class`]).
+    /// Drives deliverability headers (List-Unsubscribe on notification only).
+    /// Last field so the column order matches the schema.
+    pub mail_class: String,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -7065,6 +7069,9 @@ pub struct NewOutboundEmail {
     /// See [`outbound_email_sender_identity`]: `workspace` for conversation /
     /// notification mail, `platform` for password reset / invitation.
     pub sender_identity: String,
+    /// See [`outbound_email_mail_class`]: `notification` (opt-out-able) or
+    /// `transactional` (must-deliver). Set explicitly at enqueue.
+    pub mail_class: String,
 }
 
 /// Status string constants. Centralised so Rust callers (worker, repo,
@@ -7086,6 +7093,17 @@ pub mod outbound_email_status {
 pub mod outbound_email_sender_identity {
     pub const WORKSPACE: &str = "workspace";
     pub const PLATFORM: &str = "platform";
+}
+
+/// Mail-class constants, kept in lockstep with the
+/// `outbound_emails_mail_class_check` SQL constraint. `NOTIFICATION` is
+/// opt-out-able mail (ticket-update notifications) that carries
+/// List-Unsubscribe; `TRANSACTIONAL` is must-deliver mail (password reset,
+/// invitation, the agent's reply, auto-ack) that never does. A distinct axis
+/// from sender identity: a conversation reply is `workspace` + `transactional`.
+pub mod outbound_email_mail_class {
+    pub const TRANSACTIONAL: &str = "transactional";
+    pub const NOTIFICATION: &str = "notification";
 }
 
 // === Email suppression list ==================================

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -2580,6 +2580,14 @@ pub struct Claims {
     pub scope: String, // Token scope: "full" for normal sessions
     #[serde(default)] // Session ID (UUID) — None for SSE/API tokens
     pub sid: Option<String>,
+    /// Workspace selected when an SSE token was minted (Model C). EventSource
+    /// can't send the `X-Nosdesk-Workspace` header, so the selected workspace
+    /// is bound into the SSE token instead and the stream authorizes against
+    /// it. `None` on session/API tokens (which resolve the workspace per
+    /// request) and on SSE tokens minted before this claim existed (the stream
+    /// falls back to the Host-derived context).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_uuid: Option<Uuid>,
     pub exp: usize, // Expiration time
     pub iat: usize, // Issued at
 }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -2805,19 +2805,6 @@ pub struct OAuthState {
     pub pkce_verifier: Option<String>,
     /// Nonce for ID token validation (for OIDC providers)
     pub nonce: Option<String>,
-    /// Workspace this login was initiated against, captured at
-    /// initiation from the authoritative request context (the user is on
-    /// their own workspace subdomain) and carried through the IdP
-    /// round-trip inside this signed, tamper-proof token. The callback
-    /// provisions membership into THIS workspace rather than re-deriving
-    /// the tenant from the callback's `Host` header, binding the
-    /// workspace into the integrity-protected login transaction instead
-    /// of trusting attacker-influenceable ambient state. `None` for
-    /// user-connection flows (which don't provision membership) and for
-    /// legacy in-flight tokens minted before this field existed (a
-    /// <=10-minute transition window).
-    #[serde(default)]
-    pub workspace_id: Option<i32>,
     /// OAuth `redirect_uri` (the IdP callback) used for THIS flow, bound
     /// at initiation so the token exchange presents the identical value.
     /// In hosted mode each tenant authenticates on its own subdomain, so

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -2827,6 +2827,14 @@ pub struct OAuthState {
     /// in-flight tokens minted before this field existed).
     #[serde(default)]
     pub callback_redirect_uri: Option<String>,
+    /// Per-flow random value bound to the initiating user-agent via the
+    /// `oauth_state` cookie (RFC 9700 §2.1). The callback rejects unless the
+    /// cookie matches this value, so an attacker can't CSRF their own
+    /// `(code, state)` onto a victim (login-CSRF / session swap). `None` for
+    /// legacy in-flight tokens minted before this field existed (a <=10-minute
+    /// transition window, after which every state carries a binding).
+    #[serde(default)]
+    pub binding: Option<String>,
 }
 
 // OAuth Authentication request

--- a/backend/src/repository/outbound_emails.rs
+++ b/backend/src/repository/outbound_emails.rs
@@ -562,6 +562,7 @@ mod tests {
             correlation_id: None,
             idempotency_key: None,
             sender_identity: crate::models::outbound_email_sender_identity::WORKSPACE.to_string(),
+            mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL.to_string(),
         }
     }
 

--- a/backend/src/repository/outbound_emails.rs
+++ b/backend/src/repository/outbound_emails.rs
@@ -331,6 +331,32 @@ pub fn mark_bounced(
     .execute(conn)
 }
 
+// sync-audit-only: worker terminal state transition on the outbound queue
+/// Like [`mark_bounced`] but matches the row by its primary key. Used when a
+/// VERP Return-Path token (B1) named the originating row directly, which is
+/// more reliable than the DSN echoing the original Message-ID. Stamps the same
+/// bounce metadata and likewise leaves `status` untouched.
+pub fn mark_bounced_by_id(
+    conn: &mut DbConnection,
+    id: i64,
+    recipient: Option<&str>,
+    diagnostic: Option<&str>,
+) -> Result<usize, DieselError> {
+    diesel::sql_query(
+        r#"
+        UPDATE outbound_emails
+        SET bounced_at = now(),
+            bounce_recipient = $2,
+            bounce_diagnostic = $3
+        WHERE id = $1
+        "#,
+    )
+    .bind::<BigInt, _>(id)
+    .bind::<Nullable<Text>, _>(recipient)
+    .bind::<Nullable<Text>, _>(diagnostic)
+    .execute(conn)
+}
+
 // sync-audit-only: worker lease release on the outbound queue
 /// Release a claim without recording a failure — used by the circuit
 /// breaker when SMTP is down and the worker shouldn't burn an attempt.
@@ -575,6 +601,42 @@ mod tests {
         assert_eq!(fetched.recipient, row.recipient);
         assert_eq!(fetched.status, outbound_email_status::PENDING);
         assert_eq!(fetched.attempts, 0);
+    }
+
+    #[test]
+    fn mark_bounced_by_id_stamps_only_that_row() {
+        let mut conn = setup_test_connection();
+        let ch = seed_channel(&mut conn);
+        let row = enqueue(&mut conn, fresh_row(ch, "verp")).unwrap();
+        assert!(row.bounced_at.is_none());
+
+        let n = mark_bounced_by_id(
+            &mut conn,
+            row.id,
+            Some("test-verp@example.com"),
+            Some("550 mailbox unavailable"),
+        )
+        .unwrap();
+        assert_eq!(n, 1, "matches exactly the row by id");
+
+        let refreshed = get(&mut conn, row.id).unwrap();
+        assert!(refreshed.bounced_at.is_some());
+        assert_eq!(
+            refreshed.bounce_recipient.as_deref(),
+            Some("test-verp@example.com")
+        );
+        assert_eq!(
+            refreshed.bounce_diagnostic.as_deref(),
+            Some("550 mailbox unavailable")
+        );
+        // A bounce is delivery detail, not a fresh state: status is untouched.
+        assert_eq!(refreshed.status, outbound_email_status::PENDING);
+
+        // A non-existent id matches nothing.
+        assert_eq!(
+            mark_bounced_by_id(&mut conn, row.id + 99_999, None, None).unwrap(),
+            0
+        );
     }
 
     #[test]

--- a/backend/src/repository/ticket_merge.rs
+++ b/backend/src/repository/ticket_merge.rs
@@ -842,6 +842,10 @@ pub fn enqueue_merge_notifications(
                 idempotency_key: None,
                 sender_identity: crate::models::outbound_email_sender_identity::WORKSPACE
                     .to_string(),
+                // A merge notice to the customer is conversation mail about
+                // their own ticket: transactional, not an opt-out-able
+                // notification (only internal ticket-activity notifications are).
+                mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL.to_string(),
             },
         )?;
         enqueued += 1;

--- a/backend/src/repository/ticket_merge.rs
+++ b/backend/src/repository/ticket_merge.rs
@@ -812,17 +812,25 @@ pub fn enqueue_merge_notifications(
         if channel.provider != "email_imap" {
             continue;
         }
-        let reply_domain = match serde_json::from_value::<ImapChannelConfig>(channel.config.clone())
-        {
-            Ok(cfg) => cfg.reply_domain,
+        let config = match serde_json::from_value::<ImapChannelConfig>(channel.config.clone()) {
+            Ok(cfg) => cfg,
             Err(_) => continue,
         };
         let Some(recipient) = user_helpers::get_primary_email(&requester_uuid, conn) else {
             continue;
         };
 
-        let message_id = format_outbound_message_id(destination.id, source.id, &reply_domain);
+        let message_id =
+            format_outbound_message_id(destination.id, source.id, &config.reply_domain);
         let subject = format_outbound_subject(destination.id, &destination.title);
+        // B3: customer replies to the merge notice should thread back into the
+        // ticket via the channel's polled mailbox (see outbound.rs). Only when
+        // the IMAP username is an address.
+        let headers_json = if config.username.contains('@') {
+            serde_json::json!({ "Reply-To": config.username })
+        } else {
+            serde_json::json!({})
+        };
 
         outbound_emails::enqueue(
             conn,
@@ -837,7 +845,7 @@ pub fn enqueue_merge_notifications(
                 message_id,
                 in_reply_to: None,
                 references_list: Vec::new(),
-                headers_json: serde_json::json!({}),
+                headers_json,
                 correlation_id: None,
                 idempotency_key: None,
                 sender_identity: crate::models::outbound_email_sender_identity::WORKSPACE

--- a/backend/src/repository/ticket_visibility.rs
+++ b/backend/src/repository/ticket_visibility.rs
@@ -94,6 +94,18 @@ impl VisibilityContext {
         Some(Self::new(user_uuid, platform_role, workspace_role))
     }
 
+    /// Visibility for the customer portal: ALWAYS requester-scoped, never
+    /// sees-all, whatever the underlying user's role. The portal is an
+    /// ownership-bounded surface, so a user who also happens to be an agent
+    /// must still see only their own tickets there. Do not derive portal
+    /// visibility from a role lookup; it must be forced.
+    pub fn requester_only(user_uuid: Uuid) -> Self {
+        Self {
+            user_uuid,
+            sees_all: false,
+        }
+    }
+
     /// Build from the `AuthContext` extractor that most handlers
     /// already destructure out of the request. Uses the workspace
     /// role AuthContext already resolved for the request's workspace.
@@ -227,6 +239,33 @@ mod tests {
         let ticket = TestFixtures::create_ticket(&mut conn, "other", Some(requester.uuid), None);
 
         assert!(can_view_ticket(&mut conn, &ctx(tech.uuid, "technician"), ticket.id).unwrap());
+    }
+
+    #[test]
+    fn requester_only_confines_even_a_technician_to_their_own() {
+        // The portal is ownership-bounded regardless of role: a user who is
+        // ALSO a technician (and would otherwise see every ticket) must see
+        // only their own tickets through the portal's forced-requester context.
+        let mut conn = setup_test_connection();
+        let tech = TestFixtures::create_user(&mut conn, "tech-portal", "technician");
+        let other = TestFixtures::create_user(&mut conn, "other-cust", "user");
+        let theirs = TestFixtures::create_ticket(&mut conn, "not yours", Some(other.uuid), None);
+        let own = TestFixtures::create_ticket(&mut conn, "yours", Some(tech.uuid), None);
+
+        // Role-derived context: the tech sees the other customer's ticket.
+        assert!(can_view_ticket(&mut conn, &ctx(tech.uuid, "technician"), theirs.id).unwrap());
+
+        // Portal (requester_only): forced non-sees-all, confined to own tickets.
+        let portal = VisibilityContext::requester_only(tech.uuid);
+        assert!(!portal.sees_all(), "portal visibility must never see all");
+        assert!(
+            !can_view_ticket(&mut conn, &portal, theirs.id).unwrap(),
+            "portal must not see another customer's ticket"
+        );
+        assert!(
+            can_view_ticket(&mut conn, &portal, own.id).unwrap(),
+            "portal sees the user's own ticket"
+        );
     }
 
     #[test]

--- a/backend/src/repository/workspaces.rs
+++ b/backend/src/repository/workspaces.rs
@@ -96,6 +96,20 @@ pub fn find_by_id(conn: &mut DbConnection, id: i32) -> QueryResult<Option<Worksp
         .optional()
 }
 
+/// Load a workspace by its public uuid. Used by selection-based
+/// resolution (Model C): the agent app sends the chosen workspace
+/// uuid in the `X-Nosdesk-Workspace` header and the auth gate
+/// resolves it here before membership-gating. The uuid is the
+/// stable, opaque identifier (slug is mutable). Returns `None` for
+/// an unknown or soft-archived workspace.
+pub fn find_by_uuid(conn: &mut DbConnection, uuid: Uuid) -> QueryResult<Option<Workspace>> {
+    workspaces::table
+        .filter(workspaces::uuid.eq(uuid))
+        .filter(workspaces::archived_at.is_null())
+        .first(conn)
+        .optional()
+}
+
 /// Load a workspace by URL slug. Used by the hosted-mode
 /// middleware to resolve `acme.nosdesk.com` -> the Acme
 /// workspace row. Returns `None` if the slug doesn't match an

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -955,6 +955,8 @@ diesel::table! {
         provider_message_id -> Nullable<Text>,
         #[max_length = 16]
         sender_identity -> Varchar,
+        #[max_length = 16]
+        mail_class -> Varchar,
     }
 }
 

--- a/backend/src/services/channels/auto_ack.rs
+++ b/backend/src/services/channels/auto_ack.rs
@@ -192,6 +192,8 @@ async fn send_auto_ack(
         // This IS the auto-acknowledgement: a direct reply, so RFC 3834
         // marks it auto-replied and a customer OOO won't ping-pong with us.
         auto_submitted: Some("auto-replied"),
+        // Conversation mail to the customer about their own ticket: transactional.
+        mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
     };
 
     // Don't auto-reply to an address that previously hard-bounced or complained:

--- a/backend/src/services/channels/auto_ack.rs
+++ b/backend/src/services/channels/auto_ack.rs
@@ -202,6 +202,7 @@ async fn send_auto_ack(
         // Direct send (not queued), so there's no outbound row to encode a
         // VERP token against; bounces fall back to Message-ID correlation.
         envelope_from: None,
+        list_unsubscribe: None,
     };
 
     // Don't auto-reply to an address that previously hard-bounced or complained:

--- a/backend/src/services/channels/auto_ack.rs
+++ b/backend/src/services/channels/auto_ack.rs
@@ -199,6 +199,9 @@ async fn send_auto_ack(
             .username
             .contains('@')
             .then(|| config.username.as_str()),
+        // Direct send (not queued), so there's no outbound row to encode a
+        // VERP token against; bounces fall back to Message-ID correlation.
+        envelope_from: None,
     };
 
     // Don't auto-reply to an address that previously hard-bounced or complained:

--- a/backend/src/services/channels/auto_ack.rs
+++ b/backend/src/services/channels/auto_ack.rs
@@ -194,6 +194,11 @@ async fn send_auto_ack(
         auto_submitted: Some("auto-replied"),
         // Conversation mail to the customer about their own ticket: transactional.
         mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
+        // B3: reply to the channel's polled mailbox so it threads back in.
+        reply_to: config
+            .username
+            .contains('@')
+            .then(|| config.username.as_str()),
     };
 
     // Don't auto-reply to an address that previously hard-bounced or complained:

--- a/backend/src/services/channels/email_imap.rs
+++ b/backend/src/services/channels/email_imap.rs
@@ -546,6 +546,7 @@ impl ChannelAdapter for EmailImapAdapter {
                 .then(|| self.config.username.as_str()),
             // Direct send (not queued): no outbound row id for a VERP token.
             envelope_from: None,
+            list_unsubscribe: None,
         };
 
         self.email

--- a/backend/src/services/channels/email_imap.rs
+++ b/backend/src/services/channels/email_imap.rs
@@ -544,6 +544,8 @@ impl ChannelAdapter for EmailImapAdapter {
                 .username
                 .contains('@')
                 .then(|| self.config.username.as_str()),
+            // Direct send (not queued): no outbound row id for a VERP token.
+            envelope_from: None,
         };
 
         self.email

--- a/backend/src/services/channels/email_imap.rs
+++ b/backend/src/services/channels/email_imap.rs
@@ -536,6 +536,8 @@ impl ChannelAdapter for EmailImapAdapter {
             references: &thread.references,
             // Tech-authored reply: a human wrote it, so no auto headers.
             auto_submitted: None,
+            // Conversation mail to the customer: transactional, never opt-out-able.
+            mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
         };
 
         self.email

--- a/backend/src/services/channels/email_imap.rs
+++ b/backend/src/services/channels/email_imap.rs
@@ -538,6 +538,12 @@ impl ChannelAdapter for EmailImapAdapter {
             auto_submitted: None,
             // Conversation mail to the customer: transactional, never opt-out-able.
             mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
+            // B3: reply to the channel's polled mailbox so it threads back in.
+            reply_to: self
+                .config
+                .username
+                .contains('@')
+                .then(|| self.config.username.as_str()),
         };
 
         self.email

--- a/backend/src/services/channels/email_signature.rs
+++ b/backend/src/services/channels/email_signature.rs
@@ -118,6 +118,62 @@ fn trailing_is_signatureish(rest: &[&str]) -> bool {
         .all(|l| l.trim().chars().count() <= TOO_LONG_SIGNATURE_LINE)
 }
 
+/// HTML signature-container markers, mirroring `email_quote`'s quote markers:
+/// distinctive literal substrings that never appear in normal body content, so
+/// a substring match is safe. Must run on the RAW (pre-sanitise) HTML — the
+/// sanitiser strips `class` / `id`, so a post-sanitise search finds nothing.
+const HTML_SIGNATURE_MARKERS: &[&str] = &[
+    // Gmail wraps the signature in `<div class="gmail_signature">`, usually also
+    // carrying `data-smartmail="gmail_signature"`.
+    "class=\"gmail_signature\"",
+    "class='gmail_signature'",
+    "data-smartmail=\"gmail_signature\"",
+    "data-smartmail='gmail_signature'",
+    // Outlook on the web wraps it in `<div id="Signature">`.
+    "id=\"Signature\"",
+    "id='Signature'",
+    // Outlook mobile.
+    "id=\"ms-outlook-mobile-signature\"",
+    "id='ms-outlook-mobile-signature'",
+];
+
+/// Strip a trailing signature container from already-quote-stripped HTML by
+/// finding the earliest signature marker and cutting at its opening tag. Mirrors
+/// [`super::email_quote::split_html`]. Operate on RAW HTML (see the marker doc);
+/// the caller sanitises the resulting parts.
+pub fn strip_html(html: &str) -> SignatureSplit {
+    let trimmed = html.trim_end_matches(['\r', '\n', ' ', '\t']);
+
+    let mut earliest: Option<usize> = None;
+    for marker in HTML_SIGNATURE_MARKERS {
+        if let Some(pos) = trimmed.find(marker) {
+            // The markers are attribute fragments, so walk back to the opening
+            // `<` of the containing tag.
+            let tag_start = trimmed[..pos].rfind('<').unwrap_or(pos);
+            earliest = Some(match earliest {
+                Some(existing) if existing < tag_start => existing,
+                _ => tag_start,
+            });
+        }
+    }
+
+    match earliest {
+        Some(boundary) => {
+            let signature = trimmed[boundary..].trim();
+            SignatureSplit {
+                content: trimmed[..boundary]
+                    .trim_end_matches(['\r', '\n', ' ', '\t'])
+                    .to_string(),
+                signature: (!signature.is_empty()).then(|| signature.to_string()),
+            }
+        }
+        None => SignatureSplit {
+            content: trimmed.to_string(),
+            signature: None,
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -182,5 +238,30 @@ mod tests {
         let split = strip_plaintext("Done.\n\n-- \nJohn");
         assert_eq!(split.content, "Done.");
         assert_eq!(split.signature.as_deref(), Some("-- \nJohn"));
+    }
+
+    #[test]
+    fn html_cuts_at_gmail_signature() {
+        let html = "<div>Sounds good to me.</div>\
+                    <div class=\"gmail_signature\" data-smartmail=\"gmail_signature\">\
+                    <div>John Smith</div><div>Acme Corp</div></div>";
+        let split = strip_html(html);
+        assert_eq!(split.content, "<div>Sounds good to me.</div>");
+        assert!(split.signature.unwrap().contains("gmail_signature"));
+    }
+
+    #[test]
+    fn html_cuts_at_outlook_web_signature() {
+        let html = "<p>Approved.</p><div id=\"Signature\"><p>Jane, IT</p></div>";
+        let split = strip_html(html);
+        assert_eq!(split.content, "<p>Approved.</p>");
+    }
+
+    #[test]
+    fn html_without_signature_marker_is_unchanged() {
+        let html = "<div>Just a reply, no signature block.</div>";
+        let split = strip_html(html);
+        assert_eq!(split.content, html);
+        assert_eq!(split.signature, None);
     }
 }

--- a/backend/src/services/channels/email_signature.rs
+++ b/backend/src/services/channels/email_signature.rs
@@ -1,0 +1,186 @@
+//! Inbound signature stripping (B5), plaintext path.
+//!
+//! Runs AFTER quote-splitting ([`super::email_quote`]) on the reply-only text, to
+//! trim the sender's signature/footer so it doesn't land in the ticket comment.
+//! A port of Mailgun talon's bruteforce heuristic (no ML): a signature lives in
+//! the last few lines and is recognised by a small set of high-confidence
+//! signals, applied in confidence order. The raw body is always retained
+//! (`Comment.body_text` + `raw_source_uri`), so a mis-strip is recoverable.
+//!
+//! Bias: UNDER-strip. A leftover signature is cosmetic; a cut sentence loses real
+//! content. Each rule below is anchored and bounded to the trailing window so an
+//! in-body "Thanks for the help, here's what I found:" is never mistaken for a
+//! sign-off.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Talon's bound: only the last N non-empty lines are signature candidates.
+const SIGNATURE_MAX_LINES: usize = 11;
+/// Talon's bound: lines longer than this are unlikely to be signature lines, so
+/// a trailing block containing one is treated as content, not a signature.
+const TOO_LONG_SIGNATURE_LINE: usize = 60;
+
+/// Result of [`strip_plaintext`]: the content with any signature removed, and
+/// the removed signature (kept so callers can stash it in the collapsed region
+/// rather than discard it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureSplit {
+    pub content: String,
+    pub signature: Option<String>,
+}
+
+/// A `-- ` / `--` / `__` delimiter line (RFC 3676 §4.3). Clients often strip the
+/// trailing space, so match dashes-only too.
+static DELIMITER_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\s*(-{2,}|_{2,})\s*$").unwrap());
+
+/// Mobile / webmail footers. Always trailing and never followed by real content.
+static MOBILE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)^\s*(sent from my |get outlook for |sent from mailbox|enviado desde mi |envoyé de mon |von meinem .* gesendet)",
+    )
+    .unwrap()
+});
+
+/// A line that is ONLY a closing word (anchored), optionally with trailing
+/// punctuation. The anchor is what stops "Thanks for the help:" from matching.
+static CLOSING_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)^\s*(thanks|thank you|thanks again|many thanks|regards|kind regards|best regards|warm regards|best wishes|all the best|best|cheers|sincerely|cordially|talk soon)[\s,.!-]*$",
+    )
+    .unwrap()
+});
+
+/// Strip a trailing signature from already-quote-stripped plaintext.
+pub fn strip_plaintext(body: &str) -> SignatureSplit {
+    let lines: Vec<&str> = body.split('\n').collect();
+    match signature_start(&lines) {
+        Some(i) => SignatureSplit {
+            content: lines[..i].join("\n").trim_end().to_string(),
+            signature: Some(lines[i..].join("\n").trim().to_string()),
+        },
+        None => SignatureSplit {
+            content: body.to_string(),
+            signature: None,
+        },
+    }
+}
+
+/// The earliest line index that begins the signature, or `None`. Constrained to
+/// the trailing candidate window and never the first line of the message.
+fn signature_start(lines: &[&str]) -> Option<usize> {
+    if lines.len() < 2 {
+        return None;
+    }
+    let from = window_start(lines);
+
+    // Rule 1: explicit delimiter (highest confidence). Earliest in-window wins;
+    // everything after a `-- ` is signature by convention even if it's long.
+    if let Some(i) = (from..lines.len()).find(|&i| DELIMITER_RE.is_match(lines[i])) {
+        return Some(i);
+    }
+    // Rule 2: a mobile footer line; cut from it to the end.
+    if let Some(i) = (from..lines.len()).find(|&i| MOBILE_RE.is_match(lines[i])) {
+        return Some(i);
+    }
+    // Rule 3: a closing-word line, but only when everything after it to the end
+    // is signature-ish (short / blank) — the over-stripping guard.
+    if let Some(i) = (from..lines.len())
+        .find(|&i| CLOSING_RE.is_match(lines[i]) && trailing_is_signatureish(&lines[i + 1..]))
+    {
+        return Some(i);
+    }
+    None
+}
+
+/// Smallest line index inside the last [`SIGNATURE_MAX_LINES`] non-empty lines,
+/// clamped to `>= 1` (a signature never starts on the body's first line).
+fn window_start(lines: &[&str]) -> usize {
+    let mut non_empty = 0;
+    let mut start = lines.len();
+    for i in (0..lines.len()).rev() {
+        if !lines[i].trim().is_empty() {
+            non_empty += 1;
+            start = i;
+            if non_empty == SIGNATURE_MAX_LINES {
+                break;
+            }
+        }
+    }
+    start.max(1)
+}
+
+/// True when every non-empty line in `rest` is short enough to be a contact /
+/// sign-off line. A long line means real content follows, so don't cut.
+fn trailing_is_signatureish(rest: &[&str]) -> bool {
+    rest.iter()
+        .filter(|l| !l.trim().is_empty())
+        .all(|l| l.trim().chars().count() <= TOO_LONG_SIGNATURE_LINE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stripped(body: &str) -> String {
+        strip_plaintext(body).content
+    }
+
+    #[test]
+    fn cuts_at_dash_delimiter() {
+        let body = "Yes, that works for me.\n\n-- \nJohn Smith\nAcme Corp\n555-1234";
+        assert_eq!(stripped(body), "Yes, that works for me.");
+    }
+
+    #[test]
+    fn cuts_mobile_footer() {
+        let body = "Looks good, ship it.\n\nSent from my iPhone";
+        assert_eq!(stripped(body), "Looks good, ship it.");
+    }
+
+    #[test]
+    fn cuts_closing_word_with_contact_block() {
+        let body = "Please reset my password.\n\nThanks,\nJane Doe\nIT Manager\njane@acme.com";
+        assert_eq!(stripped(body), "Please reset my password.");
+    }
+
+    #[test]
+    fn keeps_closing_word_when_real_content_follows() {
+        // "Thanks," is not a sign-off here: a long content line follows it.
+        let body = "Thanks,\nHere is the detailed reproduction you asked for: it fails when the queue drains.";
+        assert_eq!(stripped(body), body);
+    }
+
+    #[test]
+    fn no_signature_returns_body_unchanged() {
+        let body = "Just a plain reply with no sign-off at all.";
+        assert_eq!(stripped(body), body);
+        assert_eq!(strip_plaintext(body).signature, None);
+    }
+
+    #[test]
+    fn does_not_cut_on_the_first_line() {
+        // A one-line body that happens to look like a closing word stays intact;
+        // a signature never starts on the body's first line.
+        assert_eq!(stripped("Thanks"), "Thanks");
+    }
+
+    #[test]
+    fn delimiter_outside_window_is_ignored() {
+        // A `--` early in a long body (a markdown rule, say) isn't a signature
+        // because it's not within the trailing candidate window.
+        let mut lines = vec!["--".to_string()];
+        for i in 0..20 {
+            lines.push(format!("real content line {i}"));
+        }
+        let body = lines.join("\n");
+        assert_eq!(stripped(&body), body);
+    }
+
+    #[test]
+    fn captures_the_signature_text() {
+        let split = strip_plaintext("Done.\n\n-- \nJohn");
+        assert_eq!(split.content, "Done.");
+        assert_eq!(split.signature.as_deref(), Some("-- \nJohn"));
+    }
+}

--- a/backend/src/services/channels/mod.rs
+++ b/backend/src/services/channels/mod.rs
@@ -36,6 +36,7 @@ pub mod email_imap;
 pub mod email_quote;
 pub mod email_render_kind;
 pub mod email_sanitise;
+pub mod email_signature;
 pub mod email_trackers;
 pub mod forward_parser;
 pub mod outbound;

--- a/backend/src/services/channels/outbound.rs
+++ b/backend/src/services/channels/outbound.rs
@@ -215,6 +215,17 @@ pub fn enqueue_for_comment(
                     .clone()
                     .unwrap_or_else(|| thread.recipient.external_id.clone());
 
+                // B3: point the customer's reply at the channel's polled mailbox
+                // so it threads back into the ticket even when the workspace
+                // sends From a different (verified-domain) identity. Only when the
+                // IMAP username is itself an address, so the send-path parse can't
+                // fail on a non-email login.
+                let headers_json = if config.username.contains('@') {
+                    serde_json::json!({ "Reply-To": config.username })
+                } else {
+                    serde_json::json!({})
+                };
+
                 let new_row = crate::models::NewOutboundEmail {
                     channel_id: Some(channel.id),
                     ticket_id: Some(thread.ticket_id),
@@ -226,7 +237,7 @@ pub fn enqueue_for_comment(
                     message_id,
                     in_reply_to: thread.external_thread_id,
                     references_list: thread.references.into_iter().map(Some).collect(),
-                    headers_json: serde_json::json!({}),
+                    headers_json,
                     // Item S correlation_id flows in once the per-
                     // request context propagates through this far.
                     correlation_id: None,

--- a/backend/src/services/channels/outbound.rs
+++ b/backend/src/services/channels/outbound.rs
@@ -233,6 +233,9 @@ pub fn enqueue_for_comment(
                     idempotency_key: None,
                     sender_identity: crate::models::outbound_email_sender_identity::WORKSPACE
                         .to_string(),
+                    // The agent's reply is conversation mail: workspace identity,
+                    // but transactional (no List-Unsubscribe on a human reply).
+                    mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL.to_string(),
                 };
 
                 let row = crate::repository::outbound_emails::enqueue_or_suppress(conn, new_row)

--- a/backend/src/services/channels/pipeline.rs
+++ b/backend/src/services/channels/pipeline.rs
@@ -190,17 +190,46 @@ pub async fn process_event(
                 "bounce: detected but DSN was unparseable; no linkage"
             );
         }
+
+        // B1b: prefer VERP linkage. If the DSN was addressed to one of our
+        // VERP Return-Paths, the embedded token names the originating row
+        // directly, so we don't depend on the remote MTA echoing the original
+        // Message-ID (many don't). Only for single-report DSNs: our outbound
+        // rows are per-recipient, so a bounce of our mail carries one report,
+        // and one token must not be applied across several reports.
+        let verp_row_id = if msg.bounce_reports.len() == 1 {
+            crate::utils::verp::configured_secret().and_then(|secret| {
+                msg.recipients
+                    .iter()
+                    .find_map(|addr| crate::utils::verp::row_id_from_address(addr, &secret))
+            })
+        } else {
+            None
+        };
+
         for report in &msg.bounce_reports {
-            match crate::repository::outbound_emails::mark_bounced(
-                conn,
-                &report.original_message_id,
-                report.recipient.as_deref(),
-                report.diagnostic.as_deref(),
-            ) {
+            let linkage = match verp_row_id {
+                Some(id) => crate::repository::outbound_emails::mark_bounced_by_id(
+                    conn,
+                    id,
+                    report.recipient.as_deref(),
+                    report.diagnostic.as_deref(),
+                ),
+                None => crate::repository::outbound_emails::mark_bounced(
+                    conn,
+                    &report.original_message_id,
+                    report.recipient.as_deref(),
+                    report.diagnostic.as_deref(),
+                ),
+            };
+            // How the row was located, for the log line below.
+            let via = verp_row_id.map_or("message-id", |_| "verp");
+            match linkage {
                 Ok(0) => {
                     debug!(
                         channel_id = channel.id,
                         message_id = %report.original_message_id,
+                        via,
                         "bounce: no matching outbound row"
                     );
                 }
@@ -208,6 +237,7 @@ pub async fn process_event(
                     debug!(
                         channel_id = channel.id,
                         message_id = %report.original_message_id,
+                        via,
                         rows = n,
                         recipient = ?report.recipient,
                         "bounce: linked to outbound row"
@@ -218,6 +248,7 @@ pub async fn process_event(
                         channel_id = channel.id,
                         error = %e,
                         message_id = %report.original_message_id,
+                        via,
                         "bounce: failed to update outbound row"
                     );
                 }

--- a/backend/src/services/channels/pipeline.rs
+++ b/backend/src/services/channels/pipeline.rs
@@ -762,13 +762,28 @@ fn insert_inbound_comment(
     // columns, forcing the renderer to re-sanitise per-render or
     // risk XSS. For plaintext there's nothing to sanitise; we split
     // the raw text directly.
-    let split = match content_format {
+    let mut split = match content_format {
         crate::models::ContentFormat::Html => {
             let clean = super::email_sanitise::sanitise(&content).html;
             super::email_quote::split_html(&clean)
         }
         _ => super::email_quote::split_plaintext(&content),
     };
+
+    // B5: trim the sender's signature from the reply (plaintext path; HTML is
+    // B5b). Fold the removed signature into the collapsed quoted region rather
+    // than drop it, so nothing is lost in-app and the raw body stays the source
+    // of truth for recovery.
+    if content_format == crate::models::ContentFormat::Plaintext {
+        let sig = super::email_signature::strip_plaintext(&split.new_content);
+        if let Some(signature) = sig.signature {
+            split.new_content = sig.content;
+            split.quoted_content = Some(match split.quoted_content.take() {
+                Some(quoted) => format!("{signature}\n\n{quoted}"),
+                None => signature,
+            });
+        }
+    }
 
     // Native-first render tiering: classify the (already-sanitised)
     // body into text / simple / rich so the frontend renders the common

--- a/backend/src/services/channels/pipeline.rs
+++ b/backend/src/services/channels/pipeline.rs
@@ -716,6 +716,20 @@ fn open_ticket_from_message(
     tickets_repo::create_ticket_with_annotation(conn, new_ticket, annotation, None)
 }
 
+/// Fold a stripped signature and the quoted thread into the single collapsed
+/// region, signature first (its original position, before the quote).
+fn combine_collapsed(
+    signature: Option<String>,
+    quoted: Option<String>,
+    sep: &str,
+) -> Option<String> {
+    match (signature, quoted) {
+        (Some(s), Some(q)) => Some(format!("{s}{sep}{q}")),
+        (Some(s), None) => Some(s),
+        (None, q) => q,
+    }
+}
+
 fn insert_inbound_comment(
     conn: &mut DbConnection,
     ticket_id: i32,
@@ -762,28 +776,35 @@ fn insert_inbound_comment(
     // columns, forcing the renderer to re-sanitise per-render or
     // risk XSS. For plaintext there's nothing to sanitise; we split
     // the raw text directly.
-    let mut split = match content_format {
-        crate::models::ContentFormat::Html => {
-            let clean = super::email_sanitise::sanitise(&content).html;
-            super::email_quote::split_html(&clean)
-        }
-        _ => super::email_quote::split_plaintext(&content),
-    };
-
-    // B5: trim the sender's signature from the reply (plaintext path; HTML is
-    // B5b). Fold the removed signature into the collapsed quoted region rather
-    // than drop it, so nothing is lost in-app and the raw body stays the source
+    // Split the reply from the quoted thread (B5: and the sender's signature),
+    // then sanitise each stored part. The HTML split MUST run on RAW HTML: the
+    // quote/signature markers (gmail_quote, blockquote cite, gmail_signature) are
+    // `class`/`id` attributes the sanitiser strips, so a sanitise-first order
+    // would never find them. Sanitising `new_content` + `quoted_content` AFTER
+    // the split keeps the stored columns render-safe (the invariant the old
+    // sanitise-first order protected). Plaintext needs no sanitising. The removed
+    // signature folds into the collapsed quoted region (its original position,
+    // before the quote) so nothing is lost in-app; the raw body stays the source
     // of truth for recovery.
-    if content_format == crate::models::ContentFormat::Plaintext {
-        let sig = super::email_signature::strip_plaintext(&split.new_content);
-        if let Some(signature) = sig.signature {
-            split.new_content = sig.content;
-            split.quoted_content = Some(match split.quoted_content.take() {
-                Some(quoted) => format!("{signature}\n\n{quoted}"),
-                None => signature,
-            });
+    let split = match content_format {
+        crate::models::ContentFormat::Html => {
+            let quote = super::email_quote::split_html(&content);
+            let sig = super::email_signature::strip_html(&quote.new_content);
+            let quoted = combine_collapsed(sig.signature, quote.quoted_content, "\n");
+            super::email_quote::QuoteSplit {
+                new_content: super::email_sanitise::sanitise(&sig.content).html,
+                quoted_content: quoted.map(|q| super::email_sanitise::sanitise(&q).html),
+            }
         }
-    }
+        _ => {
+            let quote = super::email_quote::split_plaintext(&content);
+            let sig = super::email_signature::strip_plaintext(&quote.new_content);
+            super::email_quote::QuoteSplit {
+                new_content: sig.content,
+                quoted_content: combine_collapsed(sig.signature, quote.quoted_content, "\n\n"),
+            }
+        }
+    };
 
     // Native-first render tiering: classify the (already-sanitised)
     // body into text / simple / rich so the frontend renders the common
@@ -1204,6 +1225,72 @@ mod tests {
         m.body_text = body_text.into();
         m.body_html = body_html.map(str::to_string);
         m
+    }
+
+    /// Regression guard for the split-before-sanitise order (B5): a Gmail-shaped
+    /// HTML reply (new text, then a `gmail_signature` block, then a `gmail_quote`
+    /// block) must land with the signature AND the quote trimmed out of
+    /// `new_content`. This only works because the split runs on RAW HTML — the
+    /// markers are `class` attributes the sanitiser strips, so a sanitise-first
+    /// order would leave both inline. Folds the trimmed parts into the collapsed
+    /// region.
+    #[tokio::test]
+    async fn html_quote_and_signature_stripped_through_sanitiser() {
+        use crate::schema::comments;
+        use diesel::prelude::*;
+        let mut conn = setup_test_connection();
+        let ch = TestFixtures::create_channel(&mut conn, "email_imap");
+
+        let html = concat!(
+            r#"<div dir="ltr"><div>Yes, ship it.</div>"#,
+            r#"<div class="gmail_signature" data-smartmail="gmail_signature">"#,
+            r#"<div>Jane Doe</div><div>Acme</div></div>"#,
+            r#"<div class="gmail_quote"><blockquote type="cite">"#,
+            r#"the original question</blockquote></div></div>"#,
+        );
+
+        let out = process_event(
+            &StubAdapter,
+            &ch,
+            InboundEvent::MessageReceived(message_with_body(
+                "<sig-quote@ex>",
+                "Re: x",
+                "",
+                Some(html),
+            )),
+            &mut conn,
+            &PipelineContext::bare(),
+        )
+        .await
+        .expect("process_event");
+        let comment_id = match out {
+            PipelineOutcome::TicketOpened { comment_id, .. } => comment_id,
+            other => panic!("expected TicketOpened, got {other:?}"),
+        };
+        let (new_content, quoted): (Option<String>, Option<String>) = comments::table
+            .filter(comments::id.eq(comment_id))
+            .select((comments::new_content, comments::quoted_content))
+            .first(&mut conn)
+            .expect("ingested comment");
+
+        let nc = new_content.unwrap_or_default();
+        assert!(
+            nc.contains("Yes, ship it"),
+            "new_content keeps the reply: {nc}"
+        );
+        assert!(
+            !nc.contains("Jane Doe"),
+            "signature stripped from new_content: {nc}"
+        );
+        assert!(
+            !nc.contains("original question"),
+            "quote stripped from new_content: {nc}"
+        );
+        let q = quoted.unwrap_or_default();
+        assert!(
+            q.contains("Jane Doe") && q.contains("original question"),
+            "collapsed region carries both the signature and the quote: {q}"
+        );
     }
 
     /// End-to-end render-tier classification (Item J native-first): a

--- a/backend/src/services/channels/pipeline.rs
+++ b/backend/src/services/channels/pipeline.rs
@@ -1446,6 +1446,7 @@ mod tests {
             correlation_id: None,
             idempotency_key: None,
             sender_identity: crate::models::outbound_email_sender_identity::WORKSPACE.to_string(),
+            mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL.to_string(),
         }
     }
 

--- a/backend/src/services/email_queue/worker.rs
+++ b/backend/src/services/email_queue/worker.rs
@@ -236,6 +236,7 @@ async fn dispatch(
         in_reply_to: row.in_reply_to.as_deref(),
         references: &references,
         auto_submitted,
+        mail_class: &row.mail_class,
     };
 
     match email.send_outbound(&message).await {

--- a/backend/src/services/email_queue/worker.rs
+++ b/backend/src/services/email_queue/worker.rs
@@ -227,6 +227,15 @@ async fn dispatch(
         .and_then(|v| v.as_str())
         .filter(|s| !s.eq_ignore_ascii_case("no"));
 
+    // B3: producer-supplied Reply-To (channel inbound mailbox), same bag as
+    // Auto-Submitted. Absent / blank means no header.
+    let reply_to = row
+        .headers_json
+        .get("Reply-To")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
     let message = OutboundEmailMessage {
         to: &row.recipient,
         subject: &row.subject,
@@ -237,6 +246,7 @@ async fn dispatch(
         references: &references,
         auto_submitted,
         mail_class: &row.mail_class,
+        reply_to,
     };
 
     match email.send_outbound(&message).await {

--- a/backend/src/services/email_queue/worker.rs
+++ b/backend/src/services/email_queue/worker.rs
@@ -236,6 +236,15 @@ async fn dispatch(
         .map(str::trim)
         .filter(|s| !s.is_empty());
 
+    // B1: VERP Return-Path so a bounce links back to THIS row by token, even
+    // when the remote MTA doesn't echo our Message-ID. The base is the polled
+    // mailbox (= the Reply-To target), so the bounce lands where replies already
+    // do. Off unless SMTP_VERP_SECRET is set, so existing deployments are
+    // unchanged until an operator enables and deliverability-tests it.
+    let envelope_from: Option<String> = crate::utils::verp::configured_secret()
+        .zip(reply_to)
+        .and_then(|(secret, base)| crate::utils::verp::tagged_return_path(base, row.id, &secret));
+
     let message = OutboundEmailMessage {
         to: &row.recipient,
         subject: &row.subject,
@@ -247,6 +256,7 @@ async fn dispatch(
         auto_submitted,
         mail_class: &row.mail_class,
         reply_to,
+        envelope_from: envelope_from.as_deref(),
     };
 
     match email.send_outbound(&message).await {

--- a/backend/src/services/email_queue/worker.rs
+++ b/backend/src/services/email_queue/worker.rs
@@ -245,6 +245,15 @@ async fn dispatch(
         .zip(reply_to)
         .and_then(|(secret, base)| crate::utils::verp::tagged_return_path(base, row.id, &secret));
 
+    // B2: producer-supplied one-click unsubscribe URL, set only on notification
+    // mail. Same headers_json bag as Reply-To.
+    let list_unsubscribe = row
+        .headers_json
+        .get("List-Unsubscribe")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
     let message = OutboundEmailMessage {
         to: &row.recipient,
         subject: &row.subject,
@@ -257,6 +266,7 @@ async fn dispatch(
         mail_class: &row.mail_class,
         reply_to,
         envelope_from: envelope_from.as_deref(),
+        list_unsubscribe,
     };
 
     match email.send_outbound(&message).await {

--- a/backend/src/services/notifications/channels/email.rs
+++ b/backend/src/services/notifications/channels/email.rs
@@ -96,21 +96,27 @@ impl EmailChannel {
         )
     }
 
-    /// Generate the entity URL for the email
-    fn generate_entity_url(&self, notification: &DeliverableNotification) -> String {
+    /// Build the deep link for a notification. `base_url` is the recipient
+    /// workspace's canonical origin (resolved per notification), so links land
+    /// on the tenant's own host rather than the channel's static fallback.
+    fn generate_entity_url(
+        &self,
+        notification: &DeliverableNotification,
+        base_url: &str,
+    ) -> String {
         match &notification.payload.entity {
             crate::services::notifications::types::NotificationEntity::DocumentationPage {
                 slug,
                 ..
             } => {
-                format!("{}/documentation/{}", self.base_url, slug)
+                format!("{base_url}/documentation/{slug}")
             }
             crate::services::notifications::types::NotificationEntity::Asset { id, .. } => {
-                format!("{}/assets/{}", self.base_url, id)
+                format!("{base_url}/assets/{id}")
             }
             _ => {
                 let ticket_id = notification.payload.entity.ticket_id();
-                format!("{}/tickets/{}", self.base_url, ticket_id)
+                format!("{base_url}/tickets/{ticket_id}")
             }
         }
     }
@@ -224,32 +230,40 @@ impl NotificationDeliveryChannel for EmailChannel {
             .get_recipient_email(&notification.payload.recipient_uuid)
             .await?;
 
-        // Load workspace branding + recipient locale in one
-        // connection. Branding feeds every transactional surface
-        // (logo, primary color); the locale picks which message
-        // catalogue formats the subject.
+        // Load the link base, workspace branding, and recipient locale in one
+        // connection. Branding feeds every transactional surface (logo, primary
+        // color); the locale picks which message catalogue formats the subject.
         // Pinned to the notification's workspace: the branding read is
         // RLS-isolated site_settings, and delivery runs from a background
         // dispatcher with no request context. Without the pin the read
         // falls back to default branding (or, under the hosted role, sees
         // nothing).
-        let base_url = self.base_url.clone();
+        let workspace_id = notification.payload.workspace_id;
         let recipient_uuid = notification.payload.recipient_uuid;
-        let (branding, recipient_locale) = crate::sync::session::run_in_workspace(
+        let fallback_base = self.base_url.clone();
+        let (base_url, branding, recipient_locale) = crate::sync::session::run_in_workspace(
             &self.pool,
             "background:notification_email_prep",
-            notification.payload.workspace_id,
-            |conn| {
+            workspace_id,
+            move |conn| {
+                // Deep links use the notification workspace's canonical origin
+                // (custom domain or `<slug>.<NOSDESK_TENANT_DOMAIN>`), else the
+                // channel's configured base (FRONTEND_URL).
+                let base_url = match crate::repository::workspaces::find_by_id(conn, workspace_id) {
+                    Ok(Some(ws)) => crate::utils::tenant_origin::workspace_origin(&ws)
+                        .unwrap_or_else(|| fallback_base.clone()),
+                    _ => fallback_base.clone(),
+                };
                 let branding = get_email_branding(conn, &base_url);
                 let locale =
                     crate::repository::user_locale::resolve_effective_locale(conn, recipient_uuid);
-                Ok((branding, locale))
+                Ok((base_url, branding, locale))
             },
         )
         .map_err(|e| ChannelError::DatabaseError(e.to_string()))?;
 
         let subject = self.generate_subject(notification, &branding.app_name, &recipient_locale);
-        let entity_url = self.generate_entity_url(notification);
+        let entity_url = self.generate_entity_url(notification, &base_url);
         let body_text = match notification.payload.body.as_deref() {
             Some(text) if !text.is_empty() => text.to_string(),
             _ => crate::utils::i18n::tr_with(&recipient_locale, "notif-body-fallback", &[]),

--- a/backend/src/services/notifications/preferences.rs
+++ b/backend/src/services/notifications/preferences.rs
@@ -183,6 +183,47 @@ impl PreferenceService {
         Ok(())
     }
 
+    /// One-click unsubscribe (B2 / RFC 8058): turn OFF the email channel for
+    /// EVERY notification type for this user, so notification mail stops while
+    /// transactional mail (password reset, invitation) is unaffected. Inserts a
+    /// disabled row per type (or flips an existing one) so a type added later
+    /// still respects the opt-out's per-type rows. Preferences are global per
+    /// user; the resolved workspace only pins the audit trigger (the table's
+    /// unique key carries no workspace_id).
+    pub async fn disable_all_email(&self, user_uuid_val: &Uuid) -> Result<(), String> {
+        let resolved_workspace = crate::sync::session::background_run(
+            &self.pool,
+            "background:notification_unsubscribe",
+            |conn| crate::repository::workspaces::primary_workspace_for_user(conn, *user_uuid_val),
+        )
+        .map_err(|e| format!("Failed to resolve workspace for unsubscribe: {e}"))?;
+
+        let mut conn = self
+            .pool
+            .get()
+            .map_err(|e| format!("Failed to acquire connection: {e}"))?;
+        let actor = crate::sync::actor::ActorContext::system("background:notification_unsubscribe")
+            .with_workspace(resolved_workspace);
+        crate::sync::session::with_actor_bypass_context(&mut conn, &actor, |conn| {
+            diesel::sql_query(
+                "INSERT INTO notification_preferences \
+                   (user_uuid, notification_type_id, channel, enabled, created_at, updated_at) \
+                 SELECT $1, nt.id, 'email', false, now(), now() FROM notification_types nt \
+                 ON CONFLICT (user_uuid, notification_type_id, channel) \
+                 DO UPDATE SET enabled = false, updated_at = now()",
+            )
+            .bind::<diesel::sql_types::Uuid, _>(*user_uuid_val)
+            .execute(conn)
+        })
+        .map_err(|e| format!("Failed to disable email notifications: {e}"))?;
+
+        {
+            let mut cache = self.cache.write().await;
+            cache.remove(user_uuid_val);
+        }
+        Ok(())
+    }
+
     /// Get all preferences for a user (for settings UI)
     pub async fn get_all_preferences(
         &self,

--- a/backend/src/services/oauth_provisioning.rs
+++ b/backend/src/services/oauth_provisioning.rs
@@ -37,7 +37,7 @@
 //! the lazy caller can ignore the bool.
 
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::db::DbConnection;
 use crate::models::{NewUserAuthIdentity, NewUserEmail, PlatformRole, User, WorkspaceRole};
@@ -56,6 +56,15 @@ pub struct ProjectedUserInput {
     /// Mapped onto `user_auth_identities.external_id`.
     pub sub: String,
     pub email: String,
+    /// Whether the provider asserts this email is verified. Gates the
+    /// email-fallback account link in [`resolve_user_by_identity_or_email`]:
+    /// a new `(iss, sub)` is only attached to an existing email-matched user
+    /// when the provider vouches for the address, since email-alone linking on
+    /// an unverified address is an account-takeover vector. The control plane
+    /// passes `true` (it provisions verified seat emails); the login paths read
+    /// the IdP's `email_verified` claim (Entra directory emails count as
+    /// verified).
+    pub email_verified: bool,
     /// Display name. Required for new-user creation; for the
     /// existing-by-identity path we use whatever's already on the
     /// users row (no rename here).
@@ -111,14 +120,22 @@ impl ProjectionOutcome {
 /// membership are provisioned upstream by the control plane, not at login):
 ///
 ///  1. `(iss, sub)` identity match -> that user.
-///  2. no identity, but the OIDC email matches a user -> attach the identity to
-///     them (the first OIDC login for a pre-provisioned seat) and return them.
-///  3. neither -> `Ok(None)`; the caller decides create-vs-deny.
+///  2. no identity, but the email matches a user AND the provider vouches the
+///     email is verified -> attach the identity to them (the first OIDC login
+///     for a pre-provisioned seat) and return them.
+///  3. neither (or email matched but unverified) -> `Ok(None)`; the caller
+///     decides create-vs-deny.
+///
+/// The `email_verified` gate on step 2 is load-bearing: linking a fresh
+/// `(iss, sub)` to an existing user on an UNVERIFIED email lets anyone who can
+/// make the IdP assert a victim's address take over that account. Step 1 is a
+/// cryptographic identity match and is never gated.
 pub fn resolve_user_by_identity_or_email(
     conn: &mut DbConnection,
     iss: &str,
     sub: &str,
     email: &str,
+    email_verified: bool,
     metadata: &Option<serde_json::Value>,
     password_hash: &Option<String>,
 ) -> Result<Option<User>, String> {
@@ -127,6 +144,17 @@ pub fn resolve_user_by_identity_or_email(
             let user = users_repo::find_active_by_uuid(&user_uuid, conn)
                 .map_err(|e| format!("identity {iss}/{sub} resolved a user that's gone: {e:?}"))?;
             Ok(Some(user))
+        }
+        // Email-fallback link, but only for a provider-verified address. An
+        // unverified email match is treated as no match (caller creates or
+        // denies) rather than silently attaching to the existing account.
+        Ok(None) if !email_verified => {
+            warn!(
+                %iss,
+                "OIDC email-fallback link refused: provider did not verify the email; \
+                 not attaching a new identity to the email-matched account"
+            );
+            Ok(None)
         }
         Ok(None) => match users_repo::get_user_by_email(email, conn) {
             Ok(user) => {
@@ -182,6 +210,7 @@ pub fn find_or_create_projected_user(
         iss,
         sub,
         email,
+        email_verified,
         name,
         role,
         workspace_id,
@@ -196,6 +225,7 @@ pub fn find_or_create_projected_user(
         &iss,
         &sub,
         &email,
+        email_verified,
         &metadata,
         &password_hash,
     )? {
@@ -365,6 +395,7 @@ mod tests {
             iss: iss.to_string(),
             sub: sub.clone(),
             email: email.clone(),
+            email_verified: true,
             name: Some("Owner One".to_string()),
             role: "owner".to_string(),
             workspace_id: 1,
@@ -379,6 +410,7 @@ mod tests {
             iss: iss.to_string(),
             sub: sub.clone(),
             email: email.clone(),
+            email_verified: true,
             name: Some("Owner One renamed by IdP".to_string()),
             role: "owner".to_string(),
             workspace_id: 1,
@@ -418,6 +450,7 @@ mod tests {
             iss: iss_canonical.to_string(),
             sub: sub.clone(),
             email: email.clone(),
+            email_verified: true,
             name: Some("Owner Two".to_string()),
             role: "owner".to_string(),
             workspace_id: 1,
@@ -431,6 +464,7 @@ mod tests {
             iss: iss_drifted.to_string(),
             sub: sub.clone(),
             email: email.clone(),
+            email_verified: true,
             name: Some("Owner Two".to_string()),
             role: "owner".to_string(),
             workspace_id: 1,
@@ -460,6 +494,70 @@ mod tests {
         assert_eq!(
             count, 2,
             "drifted iss must store a separate identity row, not reuse the canonical one"
+        );
+    }
+
+    /// The email-fallback link (step 2) must refuse to attach a fresh
+    /// `(iss, sub)` to an existing email-matched user when the provider has
+    /// NOT verified the email: that is the account-takeover vector. A later
+    /// call with the same identity but a verified email links as normal.
+    #[test]
+    fn email_fallback_link_requires_a_verified_email() {
+        let mut conn = setup_test_connection();
+        let iss = "https://api.nosdesk.com/";
+        let email = format!("victim+{}@acme.example", uuid::Uuid::new_v4());
+
+        // Seed an existing user that owns the email (via the verified eager
+        // projection), under a DIFFERENT identity than the attacker will use.
+        let owner_sub = format!("owner-{}", uuid::Uuid::new_v4());
+        let owner = ProjectedUserInput {
+            iss: iss.to_string(),
+            sub: owner_sub,
+            email: email.clone(),
+            email_verified: true,
+            name: Some("Victim".to_string()),
+            role: "member".to_string(),
+            workspace_id: 1,
+            password_hash: None,
+            metadata: None,
+        };
+        let owner_uuid = find_or_create_projected_user(&mut conn, owner)
+            .expect("seed owner")
+            .into_user()
+            .uuid;
+
+        // A new identity arrives matching the email but unverified: no link.
+        let attacker_sub = format!("attacker-{}", uuid::Uuid::new_v4());
+        let unverified = resolve_user_by_identity_or_email(
+            &mut conn,
+            iss,
+            &attacker_sub,
+            &email,
+            false,
+            &None,
+            &None,
+        )
+        .expect("resolve must not error");
+        assert!(
+            unverified.is_none(),
+            "unverified email must not link a new identity to the existing account"
+        );
+
+        // The same identity with a verified email links to the owner.
+        let verified = resolve_user_by_identity_or_email(
+            &mut conn,
+            iss,
+            &attacker_sub,
+            &email,
+            true,
+            &None,
+            &None,
+        )
+        .expect("resolve must not error")
+        .expect("verified email links to the email-matched user");
+        assert_eq!(
+            verified.uuid, owner_uuid,
+            "a verified email links the new identity to the email-matched user"
         );
     }
 }

--- a/backend/src/services/oauth_provisioning.rs
+++ b/backend/src/services/oauth_provisioning.rs
@@ -103,6 +103,74 @@ impl ProjectionOutcome {
     }
 }
 
+/// Resolve an OIDC identity to an EXISTING local user, without creating one.
+///
+/// Steps 1-2 of the projection lookup, shared by the full provisioner (which
+/// creates a user when this returns `None`) and the central-origin agent login
+/// (which DENIES when this returns `None`, because the seat and its workspace
+/// membership are provisioned upstream by the control plane, not at login):
+///
+///  1. `(iss, sub)` identity match -> that user.
+///  2. no identity, but the OIDC email matches a user -> attach the identity to
+///     them (the first OIDC login for a pre-provisioned seat) and return them.
+///  3. neither -> `Ok(None)`; the caller decides create-vs-deny.
+pub fn resolve_user_by_identity_or_email(
+    conn: &mut DbConnection,
+    iss: &str,
+    sub: &str,
+    email: &str,
+    metadata: &Option<serde_json::Value>,
+    password_hash: &Option<String>,
+) -> Result<Option<User>, String> {
+    match user_auth_identities::find_user_by_identity(iss, sub, conn) {
+        Ok(Some(user_uuid)) => {
+            let user = users_repo::find_active_by_uuid(&user_uuid, conn)
+                .map_err(|e| format!("identity {iss}/{sub} resolved a user that's gone: {e:?}"))?;
+            Ok(Some(user))
+        }
+        Ok(None) => match users_repo::get_user_by_email(email, conn) {
+            Ok(user) => {
+                let new_identity = NewUserAuthIdentity {
+                    user_uuid: user.uuid,
+                    provider_type: iss.to_string(),
+                    external_id: sub.to_string(),
+                    email: Some(email.to_string()),
+                    metadata: metadata.clone(),
+                    password_hash: password_hash.clone(),
+                };
+                // Step 1 found no identity under (iss, sub), so a
+                // UniqueViolation here means a SEPARATE identity row already
+                // owns (iss, sub) and points at a different user. Silently
+                // linking would route the projected workspace member to user A
+                // while OIDC login resolves (iss, sub) to user B above, so B
+                // would log in with no membership and access would be broken
+                // with no failure surfaced. Surface as a hard error instead.
+                // The transient case (any other DieselError) also returns Err
+                // so the control plane retries via the idempotency key rather
+                // than being told `created: false` for a row we did not link.
+                match user_auth_identities::create_identity(new_identity, conn) {
+                    Ok(_) => {
+                        // Mirror the OIDC-provided email into user_emails if it
+                        // isn't already there.
+                        ensure_email_linked(conn, &user, iss, email);
+                        Ok(Some(user))
+                    }
+                    Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => {
+                        Err(format!(
+                            "OIDC identity ({iss}, {sub}) is already attached to a different \
+                             user; refusing to silently link to the email-matched user {}",
+                            user.uuid,
+                        ))
+                    }
+                    Err(e) => Err(format!("attach OIDC identity to email-matched user: {e:?}")),
+                }
+            }
+            Err(_) => Ok(None),
+        },
+        Err(e) => Err(format!("find_user_by_identity: {e:?}")),
+    }
+}
+
 /// Resolve a user from an OIDC identity, creating one if needed,
 /// and ensure they're a member of the target workspace. See the
 /// module docs for the four-step lookup order.
@@ -121,122 +189,70 @@ pub fn find_or_create_projected_user(
         metadata,
     } = input;
 
-    // --- 1. find by (iss, sub) ---
-    let outcome = match user_auth_identities::find_user_by_identity(&iss, &sub, conn) {
-        Ok(Some(user_uuid)) => {
-            let user = users_repo::find_active_by_uuid(&user_uuid, conn)
-                .map_err(|e| format!("identity {iss}/{sub} resolved a user that's gone: {e:?}"))?;
-            ProjectionOutcome::Existed(user)
-        }
-        Ok(None) => {
-            // --- 2. fall back by email; attach identity if found ---
-            match users_repo::get_user_by_email(&email, conn) {
-                Ok(user) => {
-                    let new_identity = NewUserAuthIdentity {
-                        user_uuid: user.uuid,
-                        provider_type: iss.clone(),
-                        external_id: sub.clone(),
-                        email: Some(email.clone()),
-                        metadata: metadata.clone(),
-                        password_hash: password_hash.clone(),
-                    };
-                    // Step 1 found no identity under (iss, sub), so a
-                    // UniqueViolation here means a SEPARATE identity row
-                    // already owns (iss, sub) and points at a different
-                    // user. Silently linking would route the projected
-                    // workspace member to user A while OIDC login would
-                    // resolve (iss, sub) to user B at line 123, so B
-                    // would log in with no membership and access would
-                    // be broken with no failure surfaced. Surface as a
-                    // hard error instead. The transient case (any other
-                    // DieselError) also returns Err so the control
-                    // plane retries via the idempotency key rather than
-                    // being told `created: false` for a row we did not
-                    // actually link.
-                    match user_auth_identities::create_identity(new_identity, conn) {
-                        Ok(_) => {
-                            // Mirror the OIDC-provided email into
-                            // user_emails if it isn't already there.
-                            ensure_email_linked(conn, &user, &iss, &email);
-                            ProjectionOutcome::Existed(user)
-                        }
-                        Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => {
-                            return Err(format!(
-                                "OIDC identity ({iss}, {sub}) is already attached to a \
-                                 different user; refusing to silently link to the \
-                                 email-matched user {user_uuid}",
-                                user_uuid = user.uuid,
-                            ));
-                        }
-                        Err(e) => {
-                            return Err(format!(
-                                "attach OIDC identity to email-matched user: {e:?}"
-                            ));
-                        }
-                    }
-                }
-                Err(_) => {
-                    // --- 3. create fresh user + identity + email ---
-                    let display_name = name.clone().unwrap_or_else(|| {
-                        // Fallback for callers that didn't send a
-                        // name. Email local-part is a reasonable
-                        // best-guess; the operator can rename
-                        // later.
-                        email
-                            .split('@')
-                            .next()
-                            .unwrap_or(email.as_str())
-                            .to_string()
-                    });
-                    // A brand-new OIDC user has no platform privileges;
-                    // their workspace role comes from the projection's
-                    // requested `role`, set explicitly below.
-                    let new_user =
-                        NewUserBuilder::local_user(display_name, email.clone(), PlatformRole::User)
-                            .build();
-                    // Mint via the sync-wired helper so the OIDC address
-                    // lands as the user's PRIMARY email in user_emails.
-                    // get_user_by_email (step 2 above) and the MFA /
-                    // password-reset flows resolve only the primary
-                    // email, so a user minted without one would miss the
-                    // email fallback on the next projection and get a
-                    // duplicate row. The low-level users_repo::create_user
-                    // writes only the users table and is vestigial for
-                    // exactly this reason. Address is provider-verified,
-                    // so seed it verified; source records the issuer.
-                    //
-                    // The membership role is the projection's requested
-                    // `role` (e.g. `owner`), passed as an explicit
-                    // WorkspaceRole. Deriving it from `user_role` would
-                    // wrongly write `member` for an owner-projection,
-                    // since `UserRole` has no `Owner`.
-                    let (user, _email) = user_helpers::create_user_with_email(
-                        new_user,
-                        WorkspaceRole::from_db(&role),
-                        email.clone(),
-                        true,
-                        Some(iss.clone()),
-                        conn,
-                        None,
-                    )
-                    .map_err(|e| format!("create_user: {e:?}"))?;
+    // --- 1-2. resolve an existing user (by identity, then email-link) ---
+    // --- 3. none matched -> create a fresh user + identity + email ---
+    let outcome = match resolve_user_by_identity_or_email(
+        conn,
+        &iss,
+        &sub,
+        &email,
+        &metadata,
+        &password_hash,
+    )? {
+        Some(user) => ProjectionOutcome::Existed(user),
+        None => {
+            let display_name = name.clone().unwrap_or_else(|| {
+                // Fallback for callers that didn't send a name. Email
+                // local-part is a reasonable best-guess; the operator can
+                // rename later.
+                email
+                    .split('@')
+                    .next()
+                    .unwrap_or(email.as_str())
+                    .to_string()
+            });
+            // A brand-new OIDC user has no platform privileges; their
+            // workspace role comes from the projection's requested `role`,
+            // set explicitly below.
+            let new_user =
+                NewUserBuilder::local_user(display_name, email.clone(), PlatformRole::User).build();
+            // Mint via the sync-wired helper so the OIDC address lands as the
+            // user's PRIMARY email in user_emails. get_user_by_email (step 2)
+            // and the MFA / password-reset flows resolve only the primary
+            // email, so a user minted without one would miss the email
+            // fallback on the next projection and get a duplicate row. The
+            // low-level users_repo::create_user writes only the users table and
+            // is vestigial for exactly this reason. Address is
+            // provider-verified, so seed it verified; source records the issuer.
+            //
+            // The membership role is the projection's requested `role` (e.g.
+            // `owner`), passed as an explicit WorkspaceRole. Deriving it from
+            // `user_role` would wrongly write `member` for an owner-projection,
+            // since `UserRole` has no `Owner`.
+            let (user, _email) = user_helpers::create_user_with_email(
+                new_user,
+                WorkspaceRole::from_db(&role),
+                email.clone(),
+                true,
+                Some(iss.clone()),
+                conn,
+                None,
+            )
+            .map_err(|e| format!("create_user: {e:?}"))?;
 
-                    let new_identity = NewUserAuthIdentity {
-                        user_uuid: user.uuid,
-                        provider_type: iss.clone(),
-                        external_id: sub.clone(),
-                        email: Some(email),
-                        metadata,
-                        password_hash,
-                    };
-                    if let Err(e) = user_auth_identities::create_identity(new_identity, conn) {
-                        return Err(format!("created user but failed to attach identity: {e:?}"));
-                    }
-                    ProjectionOutcome::Created(user)
-                }
+            let new_identity = NewUserAuthIdentity {
+                user_uuid: user.uuid,
+                provider_type: iss.clone(),
+                external_id: sub.clone(),
+                email: Some(email),
+                metadata,
+                password_hash,
+            };
+            if let Err(e) = user_auth_identities::create_identity(new_identity, conn) {
+                return Err(format!("created user but failed to attach identity: {e:?}"));
             }
+            ProjectionOutcome::Created(user)
         }
-        Err(e) => return Err(format!("find_user_by_identity: {e:?}")),
     };
 
     // --- 4. ensure workspace_members row exists ---

--- a/backend/src/services/transactional_email.rs
+++ b/backend/src/services/transactional_email.rs
@@ -193,6 +193,24 @@ pub fn enqueue_invitation(
     outbound_emails::enqueue_idempotent(conn, row)
 }
 
+/// Build the signed one-click unsubscribe URL for a notification email, on the
+/// same origin as `cta_url` (the product app that serves the endpoint). `None`
+/// when the recipient uuid or the CTA origin can't be parsed, or `JWT_SECRET`
+/// is unset — the `List-Unsubscribe` header is then simply omitted.
+fn unsubscribe_url(cta_url: &str, recipient_uuid: &str) -> Option<String> {
+    let user = uuid::Uuid::parse_str(recipient_uuid).ok()?;
+    let token = crate::utils::unsubscribe_token::sign(&user)?;
+    let origin = url::Url::parse(cta_url)
+        .ok()?
+        .origin()
+        .ascii_serialization();
+    // `origin()` yields "null" for opaque / relative URLs; don't build a bad link.
+    if origin == "null" {
+        return None;
+    }
+    Some(format!("{origin}/api/public/unsubscribe?token={token}"))
+}
+
 /// Build the `NewOutboundEmail` row for a notification send.
 /// See `prepare_password_reset` for the rationale.
 #[allow(clippy::too_many_arguments)]
@@ -218,7 +236,14 @@ pub fn prepare_notification(
     // Auto-Submitted: doing so makes Gmail treat them as bot
     // traffic and reduces engagement scoring. Keep them
     // person-to-person-shaped.
-    let headers_json = serde_json::json!({});
+    //
+    // B2: notification mail is opt-out-able, so carry a one-click unsubscribe
+    // URL. The endpoint lives on the same origin the CTA links to (the product
+    // app), and the token is signed so the no-auth endpoint can trust it.
+    let headers_json = match unsubscribe_url(cta_url, recipient_uuid) {
+        Some(url) => serde_json::json!({ "List-Unsubscribe": url }),
+        None => serde_json::json!({}),
+    };
 
     NewOutboundEmail {
         channel_id: None,

--- a/backend/src/services/transactional_email.rs
+++ b/backend/src/services/transactional_email.rs
@@ -193,6 +193,60 @@ pub fn enqueue_invitation(
     outbound_emails::enqueue_idempotent(conn, row)
 }
 
+/// Build the `NewOutboundEmail` row for a customer-portal sign-in link.
+/// Transactional auth mail (no unsubscribe), sent from the WORKSPACE identity
+/// (the tenant's branded portal, falling back to the instance identity when the
+/// workspace has no verified sending domain).
+pub fn prepare_portal_magic_link(
+    svc: &EmailService,
+    branding: &EmailBranding,
+    recipient: &str,
+    user_name: &str,
+    magic_token: &str,
+    locale: &unic_langid::LanguageIdentifier,
+) -> NewOutboundEmail {
+    let (subject, body_html, body_text) =
+        svc.compose_portal_magic_link(user_name, magic_token, branding, locale);
+    let message_id = make_message_id("portal-signin", &from_email_domain(svc));
+    let headers_json = serde_json::json!({
+        "Auto-Submitted": "auto-generated",
+    });
+
+    NewOutboundEmail {
+        channel_id: None,
+        ticket_id: None,
+        comment_id: None,
+        recipient: recipient.to_string(),
+        subject,
+        body_text,
+        body_html: Some(body_html),
+        message_id,
+        in_reply_to: None,
+        references_list: vec![],
+        headers_json,
+        correlation_id: None,
+        idempotency_key: Some(format!("portal_magic_link:{}", hash16(magic_token))),
+        sender_identity: outbound_email_sender_identity::WORKSPACE.to_string(),
+        mail_class: outbound_email_mail_class::TRANSACTIONAL.to_string(),
+    }
+}
+
+/// Enqueue a customer-portal sign-in email. The key derives from the token, so
+/// a fresh sign-in request (new token) is a new send; idempotency only catches
+/// enqueue retries inside one request.
+pub fn enqueue_portal_magic_link(
+    conn: &mut DbConnection,
+    svc: &EmailService,
+    branding: &EmailBranding,
+    recipient: &str,
+    user_name: &str,
+    magic_token: &str,
+    locale: &unic_langid::LanguageIdentifier,
+) -> Result<OutboundEmail, DieselError> {
+    let row = prepare_portal_magic_link(svc, branding, recipient, user_name, magic_token, locale);
+    outbound_emails::enqueue_idempotent(conn, row)
+}
+
 /// Build the signed one-click unsubscribe URL for a notification email, on the
 /// same origin as `cta_url` (the product app that serves the endpoint). `None`
 /// when the recipient uuid or the CTA origin can't be parsed, or `JWT_SECRET`

--- a/backend/src/services/transactional_email.rs
+++ b/backend/src/services/transactional_email.rs
@@ -23,7 +23,9 @@ use diesel::result::Error as DieselError;
 use ring::digest;
 
 use crate::db::DbConnection;
-use crate::models::{outbound_email_sender_identity, NewOutboundEmail, OutboundEmail};
+use crate::models::{
+    outbound_email_mail_class, outbound_email_sender_identity, NewOutboundEmail, OutboundEmail,
+};
 use crate::repository::outbound_emails;
 use crate::utils::email::{EmailBranding, EmailService};
 
@@ -106,6 +108,7 @@ pub fn prepare_password_reset(
         idempotency_key: Some(format!("password_reset:{}", hash16(reset_token))),
         // Auth mail: pin the instance identity, never a tenant relay.
         sender_identity: outbound_email_sender_identity::PLATFORM.to_string(),
+        mail_class: outbound_email_mail_class::TRANSACTIONAL.to_string(),
     }
 }
 
@@ -160,6 +163,7 @@ pub fn prepare_invitation(
         idempotency_key: Some(format!("invitation:{}", hash16(invitation_token))),
         // Auth mail: pin the instance identity, never a tenant relay.
         sender_identity: outbound_email_sender_identity::PLATFORM.to_string(),
+        mail_class: outbound_email_mail_class::TRANSACTIONAL.to_string(),
     }
 }
 
@@ -233,6 +237,7 @@ pub fn prepare_notification(
         // Notifications send from the workspace identity (fall back to the
         // instance identity when the workspace hasn't configured one).
         sender_identity: outbound_email_sender_identity::WORKSPACE.to_string(),
+        mail_class: outbound_email_mail_class::NOTIFICATION.to_string(),
     }
 }
 
@@ -406,6 +411,48 @@ mod tests {
             row.body_text
         );
         assert!(row.body_text.contains("Alice"));
+    }
+
+    #[test]
+    fn mail_class_distinguishes_notification_from_transactional() {
+        use crate::models::outbound_email_mail_class as mc;
+
+        let reset = prepare_password_reset(
+            &test_svc(),
+            &test_branding(),
+            "alice@example.com",
+            "Alice",
+            "tok",
+            &en_us(),
+        );
+        let invite = prepare_invitation(
+            &test_svc(),
+            &test_branding(),
+            "bob@example.com",
+            "Bob",
+            "tok",
+            "Kyle",
+            &en_us(),
+        );
+        let notify = prepare_notification(
+            &test_svc(),
+            &test_branding(),
+            "carol@example.com",
+            "subj",
+            "title",
+            "body",
+            "Dave",
+            "https://desk.example.com/tickets/1",
+            "evt-1",
+            "11111111-1111-1111-1111-111111111111",
+            &en_us(),
+        );
+
+        // Auth mail is must-deliver; only the ticket-activity notification is the
+        // opt-out-able class that will carry List-Unsubscribe (B2).
+        assert_eq!(reset.mail_class, mc::TRANSACTIONAL);
+        assert_eq!(invite.mail_class, mc::TRANSACTIONAL);
+        assert_eq!(notify.mail_class, mc::NOTIFICATION);
     }
 
     #[test]

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -463,6 +463,7 @@ pub fn create_test_claims(user: &User) -> crate::models::Claims {
         platform_role: user.platform_role.clone(),
         scope: "full".to_string(),
         sid: None,
+        workspace_uuid: None,
         exp: (chrono::Utc::now() + chrono::Duration::hours(24)).timestamp() as usize,
         iat: chrono::Utc::now().timestamp() as usize,
     }

--- a/backend/src/utils/cookies.rs
+++ b/backend/src/utils/cookies.rs
@@ -71,6 +71,37 @@ pub fn delete_csrf_token_cookie() -> Cookie<'static> {
         .finish()
 }
 
+/// Binds an in-progress OAuth/OIDC login to the browser that started it
+/// (RFC 9700 §2.1). Set at initiation carrying the flow's random binding value;
+/// the callback rejects unless this cookie matches the value in the signed
+/// state, so an attacker can't CSRF their own `(code, state)` onto a victim.
+pub const OAUTH_STATE_COOKIE: &str = "oauth_state";
+
+/// Cookie binding an OAuth flow to its initiating user-agent. `SameSite=Lax`
+/// (NOT Strict): the IdP redirects the browser back to the callback as a
+/// cross-site top-level navigation, and a Strict cookie would not be sent. Lives
+/// as long as the state JWT (10 min). Scoped to the OAuth endpoints.
+pub fn create_oauth_state_cookie(binding: &str) -> Cookie<'static> {
+    Cookie::build(OAUTH_STATE_COOKIE, binding.to_string())
+        .path("/api/auth/oauth")
+        .http_only(true)
+        .secure(auth_cookies_use_secure_flag())
+        .same_site(SameSite::Lax)
+        .max_age(actix_web::cookie::time::Duration::minutes(10))
+        .finish()
+}
+
+/// Cookie that clears [`OAUTH_STATE_COOKIE`] once a flow completes.
+pub fn delete_oauth_state_cookie() -> Cookie<'static> {
+    Cookie::build(OAUTH_STATE_COOKIE, "")
+        .path("/api/auth/oauth")
+        .http_only(true)
+        .secure(auth_cookies_use_secure_flag())
+        .same_site(SameSite::Lax)
+        .max_age(actix_web::cookie::time::Duration::seconds(0))
+        .finish()
+}
+
 /// Whether auth cookies receive the `Secure` attribute.
 ///
 /// **Fail-closed:** `ENVIRONMENT` unset / empty / anything other than an
@@ -125,6 +156,18 @@ mod tests {
         // CSRF cookie must be readable by JavaScript
         assert!(!cookie.http_only().unwrap_or(true));
         assert_eq!(cookie.same_site(), Some(SameSite::Strict));
+    }
+
+    #[test]
+    fn oauth_state_cookie_is_lax_and_http_only() {
+        let cookie = create_oauth_state_cookie("bind-abc");
+        assert_eq!(cookie.name(), OAUTH_STATE_COOKIE);
+        assert_eq!(cookie.value(), "bind-abc");
+        assert!(cookie.http_only().unwrap_or(false));
+        // MUST be Lax, not Strict: the IdP redirects the browser back to the
+        // callback cross-site, and a Strict cookie would not be sent.
+        assert_eq!(cookie.same_site(), Some(SameSite::Lax));
+        assert_eq!(cookie.path(), Some("/api/auth/oauth"));
     }
 
     #[test]

--- a/backend/src/utils/cookies.rs
+++ b/backend/src/utils/cookies.rs
@@ -102,6 +102,56 @@ pub fn delete_oauth_state_cookie() -> Cookie<'static> {
         .finish()
 }
 
+// --- Customer portal session cookies ---
+//
+// The portal is a separate principal realm on a separate registrable domain
+// (`<slug>.nosdesk.app`), so it gets its OWN cookie names. Distinct names mean
+// an agent session and a portal session never collide in one browser even if a
+// custom domain later puts them under the same registrable domain; the agent
+// auth path only ever reads `access_token`, never these. Host-only and
+// `SameSite=Strict` like the agent cookies (no `Domain=.` sharing).
+pub const PORTAL_ACCESS_TOKEN_COOKIE: &str = "portal_access";
+pub const PORTAL_REFRESH_TOKEN_COOKIE: &str = "portal_refresh";
+pub const PORTAL_CSRF_TOKEN_COOKIE: &str = "portal_csrf";
+
+/// Path the portal refresh cookie is scoped to (sent only to the refresh
+/// endpoint, like the agent refresh cookie).
+const PORTAL_REFRESH_PATH: &str = "/api/portal/auth/refresh";
+
+/// httpOnly portal access-token cookie (15 minutes).
+pub fn create_portal_access_cookie(token: &str) -> Cookie<'static> {
+    Cookie::build(PORTAL_ACCESS_TOKEN_COOKIE, token.to_string())
+        .path("/")
+        .http_only(true)
+        .secure(auth_cookies_use_secure_flag())
+        .same_site(SameSite::Strict)
+        .max_age(actix_web::cookie::time::Duration::minutes(15))
+        .finish()
+}
+
+/// httpOnly portal refresh-token cookie (7 days, scoped to the portal refresh
+/// endpoint).
+pub fn create_portal_refresh_cookie(token: &str) -> Cookie<'static> {
+    Cookie::build(PORTAL_REFRESH_TOKEN_COOKIE, token.to_string())
+        .path(PORTAL_REFRESH_PATH)
+        .http_only(true)
+        .secure(auth_cookies_use_secure_flag())
+        .same_site(SameSite::Strict)
+        .max_age(actix_web::cookie::time::Duration::days(7))
+        .finish()
+}
+
+/// Portal CSRF cookie (NOT httpOnly so the portal SPA can echo it in a header).
+pub fn create_portal_csrf_cookie(token: &str) -> Cookie<'static> {
+    Cookie::build(PORTAL_CSRF_TOKEN_COOKIE, token.to_string())
+        .path("/")
+        .http_only(false)
+        .secure(auth_cookies_use_secure_flag())
+        .same_site(SameSite::Strict)
+        .max_age(actix_web::cookie::time::Duration::minutes(15))
+        .finish()
+}
+
 /// Whether auth cookies receive the `Secure` attribute.
 ///
 /// **Fail-closed:** `ENVIRONMENT` unset / empty / anything other than an

--- a/backend/src/utils/csrf.rs
+++ b/backend/src/utils/csrf.rs
@@ -14,6 +14,19 @@ pub fn generate_csrf_token() -> String {
 }
 
 /// Validate a CSRF token by comparing it to the expected value
+/// The CSRF cookie name for a request path. Authenticated portal requests
+/// (`/api/portal/...`, excluding the public `/api/portal/auth/` sign-in routes
+/// which skip CSRF entirely) carry the portal session's own `portal_csrf`
+/// cookie; everything else uses the agent `csrf_token` cookie. Selecting by
+/// surface keeps the double-submit check honest across the two session realms.
+pub fn csrf_cookie_for_path(path: &str) -> &'static str {
+    if path.starts_with("/api/portal/") {
+        crate::utils::cookies::PORTAL_CSRF_TOKEN_COOKIE
+    } else {
+        crate::utils::cookies::CSRF_TOKEN_COOKIE
+    }
+}
+
 pub fn validate_csrf_token(provided: &str, expected: &str) -> bool {
     // Use constant-time comparison to prevent timing attacks
     use constant_time_eq::constant_time_eq;
@@ -124,6 +137,11 @@ where
             // no CSRF surface to protect. Rate limiting is handled by the
             // scope's dedicated limiter + per-handler Redis counters.
             || path.starts_with("/api/public/")
+            // Public portal sign-in (magic-link request + callback):
+            // unauthenticated, no portal session cookie yet, so nothing to
+            // forge against. The authenticated portal API below validates
+            // against the portal_csrf cookie.
+            || path.starts_with("/api/portal/auth/")
             // CSP violation reports are sent by browsers without
             // credentials, so there's no session to forge against.
             // Browsers also don't include arbitrary headers, so we
@@ -147,9 +165,11 @@ where
             .and_then(|h| h.to_str().ok())
             .map(|s| s.to_string());
 
-        // Extract CSRF token from cookie
+        // Extract CSRF token from cookie. The portal is a separate session
+        // realm with its own cookie, so pick the cookie that matches the
+        // surface this request belongs to.
         let cookie_token = req
-            .cookie(crate::utils::cookies::CSRF_TOKEN_COOKIE)
+            .cookie(csrf_cookie_for_path(path))
             .map(|c| c.value().to_string());
 
         // Log only a short prefix, taken char-wise so an attacker-
@@ -232,6 +252,22 @@ mod tests {
     #[test]
     fn validate_matching_tokens() {
         assert!(validate_csrf_token("abc123", "abc123"));
+    }
+
+    #[test]
+    fn portal_paths_use_the_portal_csrf_cookie() {
+        use crate::utils::cookies::{CSRF_TOKEN_COOKIE, PORTAL_CSRF_TOKEN_COOKIE};
+        assert_eq!(
+            csrf_cookie_for_path("/api/portal/tickets"),
+            PORTAL_CSRF_TOKEN_COOKIE
+        );
+        assert_eq!(
+            csrf_cookie_for_path("/api/portal/tickets/5/comments"),
+            PORTAL_CSRF_TOKEN_COOKIE
+        );
+        // Agent + everything else keeps the agent cookie.
+        assert_eq!(csrf_cookie_for_path("/api/tickets"), CSRF_TOKEN_COOKIE);
+        assert_eq!(csrf_cookie_for_path("/api/auth/me"), CSRF_TOKEN_COOKIE);
     }
 
     #[test]

--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -795,6 +795,13 @@ fn build_outbound_message(
             .header(AutoSubmitted(value.to_string()))
             .header(XAutoResponseSuppress("All".to_string()));
     }
+    // B3: point replies at the channel's polled mailbox when the From diverges.
+    if let Some(reply_to) = outbound.reply_to {
+        let mailbox: Mailbox = reply_to
+            .parse()
+            .map_err(|e| format!("Invalid Reply-To address: {e}"))?;
+        builder = builder.reply_to(mailbox);
+    }
 
     // Prefer multipart/alternative when both text + html are given so
     // clients can pick; text-only falls back to a single part. Both
@@ -1122,6 +1129,7 @@ impl EmailService {
             // Generic direct-send path; its callers (test mail, guest ticket
             // confirmation) are transactional, the safe no-unsubscribe default.
             mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
+            reply_to: None,
         };
         self.send_outbound(&outbound).await.map(|_| ())
     }
@@ -1149,6 +1157,7 @@ impl EmailService {
             // Generic direct-send path; its callers (test mail, guest ticket
             // confirmation) are transactional, the safe no-unsubscribe default.
             mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
+            reply_to: None,
         };
         self.send_outbound(&outbound).await.map(|_| ())
     }
@@ -1566,6 +1575,12 @@ pub struct OutboundEmailMessage<'a> {
     /// notification only). Defaults to transactional on any path that hasn't
     /// classified itself, which is the safe, no-unsubscribe choice.
     pub mail_class: &'a str,
+    /// `Reply-To` address (B3). Set on channel-bound conversation mail to the
+    /// channel's polled inbound mailbox so a recipient's reply threads back into
+    /// the ticket even when the `From` is a different workspace send identity
+    /// (verified-domain / relay mode). `None` emits no header, leaving the
+    /// `From` as the implicit reply target.
+    pub reply_to: Option<&'a str>,
 }
 
 #[cfg(test)]
@@ -1636,6 +1651,7 @@ mod tests {
                 references: &[],
                 auto_submitted: None,
                 mail_class: "transactional",
+                reply_to: None,
             })
             .unwrap();
         assert!(
@@ -1658,6 +1674,7 @@ mod tests {
                 references: &[],
                 auto_submitted: None,
                 mail_class: "transactional",
+                reply_to: None,
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -1684,6 +1701,7 @@ mod tests {
                         references: &[],
                         auto_submitted: auto,
                         mail_class: "transactional",
+                        reply_to: None,
                     })
                     .unwrap(),
             )
@@ -1760,6 +1778,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             references: &[],
             auto_submitted: None,
             mail_class: "transactional",
+            reply_to: None,
         }
     }
 
@@ -1903,6 +1922,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
                 references: &refs,
                 auto_submitted: None,
                 mail_class: "transactional",
+                reply_to: None,
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -1911,6 +1931,34 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             dump.contains("References: <first@x> <second@x>"),
             "dump:\n{dump}"
         );
+    }
+
+    #[test]
+    fn reply_to_header_emitted_only_when_set() {
+        let base = OutboundEmailMessage {
+            to: "alice@example.com",
+            subject: "[#42] Re: thread",
+            body_text: "reply",
+            body_html: None,
+            message_id: "ticket-42.comment-3.cafef00d@yourco.com",
+            in_reply_to: None,
+            references: &[],
+            auto_submitted: None,
+            mail_class: "transactional",
+            reply_to: Some("support@acme.com"),
+        };
+        let with = rendered(&svc().build_ticket_reply_message(&base).unwrap());
+        assert!(with.contains("Reply-To: support@acme.com"), "dump:\n{with}");
+
+        let without = rendered(
+            &svc()
+                .build_ticket_reply_message(&OutboundEmailMessage {
+                    reply_to: None,
+                    ..base
+                })
+                .unwrap(),
+        );
+        assert!(!without.contains("Reply-To:"), "dump:\n{without}");
     }
 
     #[test]
@@ -1926,6 +1974,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
                 references: &[],
                 auto_submitted: None,
                 mail_class: "transactional",
+                reply_to: None,
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -1956,6 +2005,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             references: &[],
             auto_submitted: None,
             mail_class: "transactional",
+            reply_to: None,
         };
         let rt = tokio::runtime::Runtime::new().unwrap();
         let err = rt

--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -1501,6 +1501,85 @@ impl EmailService {
         (subject, html_body, body_text)
     }
 
+    /// Render the customer-portal passwordless sign-in email. Returns
+    /// `(subject, html_body, body_text)`. Same HTML/plaintext split as the
+    /// invitation; the CTA links to the portal callback on the workspace's own
+    /// origin (carried in `branding.base_url`).
+    pub fn compose_portal_magic_link(
+        &self,
+        user_name: &str,
+        magic_token: &str,
+        branding: &EmailBranding,
+        locale: &unic_langid::LanguageIdentifier,
+    ) -> (String, String, String) {
+        let sign_in_link = format!(
+            "{}/portal/auth/callback?token={}",
+            branding.base_url, magic_token
+        );
+        let template = EmailTemplate::new(branding);
+        let tr = |key: &str, args: &[(&str, fluent_bundle::FluentValue<'static>)]| {
+            crate::utils::i18n::tr_with(locale, key, args)
+        };
+
+        let name_html = escape_html(user_name);
+        let app_html = escape_html(&branding.app_name);
+
+        let title = tr(
+            "portal-magic-link-title",
+            &[("app", app_html.clone().into())],
+        );
+        let greeting = tr(
+            "portal-magic-link-greeting",
+            &[("name", name_html.clone().into())],
+        );
+        let intro = tr(
+            "portal-magic-link-intro",
+            &[("app", app_html.clone().into())],
+        );
+        let cta_label = tr("portal-magic-link-cta-label", &[]);
+        let notice_items: Vec<String> = [
+            "portal-magic-link-notice-expiry",
+            "portal-magic-link-notice-unexpected",
+        ]
+        .iter()
+        .map(|key| tr(key, &[]))
+        .collect();
+
+        let html_body = template.render(
+            EmailLayout {
+                headline: &title,
+                body: vec![text(greeting), text(intro)],
+                cta: Some(Cta {
+                    label: cta_label,
+                    url: sign_in_link.clone(),
+                }),
+                notice: Some(Notice {
+                    kind: NoticeType::Info,
+                    items: notice_items,
+                }),
+                signoff: None,
+                preheader: &title,
+            },
+            locale,
+        );
+
+        let subject = tr(
+            "portal-magic-link-subject",
+            &[("app", branding.app_name.clone().into())],
+        );
+
+        let body_text = tr(
+            "portal-magic-link-body-text",
+            &[
+                ("name", user_name.to_string().into()),
+                ("app", branding.app_name.clone().into()),
+                ("link", sign_in_link.clone().into()),
+            ],
+        );
+
+        (subject, html_body, body_text)
+    }
+
     /// Send a confirmation email for a guest ticket submission. The link
     /// uses the same accept-invitation flow as a normal invitation, but the
     /// copy is tailored to the ticket-submission context — the email is
@@ -2318,12 +2397,26 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
         );
         write("notification", &html);
 
+        let (_subj, html, text) =
+            svc.compose_portal_magic_link("Alex", "EXAMPLE-SIGNIN-TOKEN", &branding, &locale);
+        write("portal-magic-link", &html);
+        // The CTA must carry the portal callback link on the configured origin.
+        assert!(
+            html.contains("/portal/auth/callback?token=EXAMPLE-SIGNIN-TOKEN"),
+            "magic-link html must link to the portal callback"
+        );
+        assert!(
+            text.contains("/portal/auth/callback?token=EXAMPLE-SIGNIN-TOKEN"),
+            "magic-link plaintext must carry the callback link"
+        );
+
         // Sanity: every preview file exists and is non-trivial.
         for name in [
             "password-reset",
             "invitation",
             "guest-ticket-confirmation",
             "notification",
+            "portal-magic-link",
         ] {
             let p = out_dir.join(format!("{name}.html"));
             let content = std::fs::read_to_string(&p).expect("preview readable");

--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -1027,9 +1027,31 @@ impl EmailTransport for SmtpEmailTransport {
         } else {
             build_smtp_mailer(&self.config)?
         };
-        mailer
-            .send(&message)
-            .map_err(|e| format!("Failed to send ticket reply: {e}"))?;
+        // B1: when a VERP Return-Path is set, send with an explicit envelope so
+        // `MAIL FROM` is the bounce-token address, distinct from the `From`
+        // header. lettre's default `send` derives the envelope from `From`;
+        // overriding it needs `send_raw` with the formatted (DKIM-signed) bytes.
+        match msg.envelope_from {
+            Some(return_path) => {
+                let from: lettre::Address = return_path
+                    .parse()
+                    .map_err(|e| format!("Invalid Return-Path {return_path}: {e}"))?;
+                let to: lettre::Address = msg
+                    .to
+                    .parse()
+                    .map_err(|e| format!("Invalid recipient {}: {e}", msg.to))?;
+                let envelope = lettre::address::Envelope::new(Some(from), vec![to])
+                    .map_err(|e| format!("Invalid envelope: {e}"))?;
+                mailer
+                    .send_raw(&envelope, &message.formatted())
+                    .map_err(|e| format!("Failed to send ticket reply: {e}"))?;
+            }
+            None => {
+                mailer
+                    .send(&message)
+                    .map_err(|e| format!("Failed to send ticket reply: {e}"))?;
+            }
+        }
         Ok(SendOutcome {
             provider_message_id: None,
         })
@@ -1130,6 +1152,7 @@ impl EmailService {
             // confirmation) are transactional, the safe no-unsubscribe default.
             mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
             reply_to: None,
+            envelope_from: None,
         };
         self.send_outbound(&outbound).await.map(|_| ())
     }
@@ -1158,6 +1181,7 @@ impl EmailService {
             // confirmation) are transactional, the safe no-unsubscribe default.
             mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
             reply_to: None,
+            envelope_from: None,
         };
         self.send_outbound(&outbound).await.map(|_| ())
     }
@@ -1581,6 +1605,12 @@ pub struct OutboundEmailMessage<'a> {
     /// (verified-domain / relay mode). `None` emits no header, leaving the
     /// `From` as the implicit reply target.
     pub reply_to: Option<&'a str>,
+    /// VERP envelope-from / Return-Path (B1). When `Some`, the message is sent
+    /// with this `MAIL FROM` (distinct from the `From` header) so a bounce DSN
+    /// is addressed back to it and the inbound handler can link the bounce to
+    /// the originating row by its token. `None` (the default, and whenever
+    /// `SMTP_VERP_SECRET` is unset) uses lettre's From-derived envelope.
+    pub envelope_from: Option<&'a str>,
 }
 
 #[cfg(test)]
@@ -1652,6 +1682,7 @@ mod tests {
                 auto_submitted: None,
                 mail_class: "transactional",
                 reply_to: None,
+                envelope_from: None,
             })
             .unwrap();
         assert!(
@@ -1675,6 +1706,7 @@ mod tests {
                 auto_submitted: None,
                 mail_class: "transactional",
                 reply_to: None,
+                envelope_from: None,
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -1702,6 +1734,7 @@ mod tests {
                         auto_submitted: auto,
                         mail_class: "transactional",
                         reply_to: None,
+                        envelope_from: None,
                     })
                     .unwrap(),
             )
@@ -1779,6 +1812,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             auto_submitted: None,
             mail_class: "transactional",
             reply_to: None,
+            envelope_from: None,
         }
     }
 
@@ -1923,6 +1957,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
                 auto_submitted: None,
                 mail_class: "transactional",
                 reply_to: None,
+                envelope_from: None,
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -1946,6 +1981,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             auto_submitted: None,
             mail_class: "transactional",
             reply_to: Some("support@acme.com"),
+            envelope_from: None,
         };
         let with = rendered(&svc().build_ticket_reply_message(&base).unwrap());
         assert!(with.contains("Reply-To: support@acme.com"), "dump:\n{with}");
@@ -1954,6 +1990,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             &svc()
                 .build_ticket_reply_message(&OutboundEmailMessage {
                     reply_to: None,
+                    envelope_from: None,
                     ..base
                 })
                 .unwrap(),
@@ -1975,6 +2012,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
                 auto_submitted: None,
                 mail_class: "transactional",
                 reply_to: None,
+                envelope_from: None,
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -2006,6 +2044,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             auto_submitted: None,
             mail_class: "transactional",
             reply_to: None,
+            envelope_from: None,
         };
         let rt = tokio::runtime::Runtime::new().unwrap();
         let err = rt

--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -48,6 +48,39 @@ impl Header for XAutoResponseSuppress {
         HeaderValue::new(Self::name(), self.0.clone())
     }
 }
+
+/// `List-Unsubscribe` (RFC 2369 / 8058) — the unsubscribe URL(s), each in
+/// angle brackets. Emitted on opt-out-able notification mail only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ListUnsubscribe(String);
+impl Header for ListUnsubscribe {
+    fn name() -> HeaderName {
+        HeaderName::new_from_ascii_str("List-Unsubscribe")
+    }
+    fn parse(s: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(Self(s.into()))
+    }
+    fn display(&self) -> HeaderValue {
+        HeaderValue::new(Self::name(), self.0.clone())
+    }
+}
+
+/// `List-Unsubscribe-Post` (RFC 8058) — signals one-click support; the only
+/// valid value is `List-Unsubscribe=One-Click`. Pairs with an https
+/// `List-Unsubscribe` URL so the mail client POSTs it without loading a page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ListUnsubscribePost;
+impl Header for ListUnsubscribePost {
+    fn name() -> HeaderName {
+        HeaderName::new_from_ascii_str("List-Unsubscribe-Post")
+    }
+    fn parse(_s: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(Self)
+    }
+    fn display(&self) -> HeaderValue {
+        HeaderValue::new(Self::name(), "List-Unsubscribe=One-Click".to_string())
+    }
+}
 use std::env;
 use std::str::FromStr;
 
@@ -802,6 +835,13 @@ fn build_outbound_message(
             .map_err(|e| format!("Invalid Reply-To address: {e}"))?;
         builder = builder.reply_to(mailbox);
     }
+    // B2: one-click unsubscribe on notification mail. The producer only sets
+    // this on opt-out-able notification mail, never transactional.
+    if let Some(url) = outbound.list_unsubscribe {
+        builder = builder
+            .header(ListUnsubscribe(format!("<{url}>")))
+            .header(ListUnsubscribePost);
+    }
 
     // Prefer multipart/alternative when both text + html are given so
     // clients can pick; text-only falls back to a single part. Both
@@ -912,6 +952,10 @@ fn dkim_sign_message(message: &mut Message, signer: &DkimSigner) -> Result<(), S
         "In-Reply-To",
         "References",
         "Reply-To",
+        // RFC 8058 §3: the one-click headers MUST be covered by the DKIM
+        // signature the receiver validates, or the unsubscribe POST is refused.
+        "List-Unsubscribe",
+        "List-Unsubscribe-Post",
     ]
     .into_iter()
     .map(HeaderName::new_from_ascii_str)
@@ -1153,6 +1197,7 @@ impl EmailService {
             mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
             reply_to: None,
             envelope_from: None,
+            list_unsubscribe: None,
         };
         self.send_outbound(&outbound).await.map(|_| ())
     }
@@ -1182,6 +1227,7 @@ impl EmailService {
             mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
             reply_to: None,
             envelope_from: None,
+            list_unsubscribe: None,
         };
         self.send_outbound(&outbound).await.map(|_| ())
     }
@@ -1611,6 +1657,11 @@ pub struct OutboundEmailMessage<'a> {
     /// the originating row by its token. `None` (the default, and whenever
     /// `SMTP_VERP_SECRET` is unset) uses lettre's From-derived envelope.
     pub envelope_from: Option<&'a str>,
+    /// `List-Unsubscribe` URL (B2 / RFC 8058). Set on opt-out-able notification
+    /// mail to a signed one-click endpoint; emits `List-Unsubscribe` plus
+    /// `List-Unsubscribe-Post: List-Unsubscribe=One-Click`. `None` on
+    /// transactional mail (which must not advertise unsubscribe).
+    pub list_unsubscribe: Option<&'a str>,
 }
 
 #[cfg(test)]
@@ -1683,6 +1734,7 @@ mod tests {
                 mail_class: "transactional",
                 reply_to: None,
                 envelope_from: None,
+                list_unsubscribe: None,
             })
             .unwrap();
         assert!(
@@ -1707,6 +1759,7 @@ mod tests {
                 mail_class: "transactional",
                 reply_to: None,
                 envelope_from: None,
+                list_unsubscribe: None,
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -1735,6 +1788,7 @@ mod tests {
                         mail_class: "transactional",
                         reply_to: None,
                         envelope_from: None,
+                        list_unsubscribe: None,
                     })
                     .unwrap(),
             )
@@ -1813,6 +1867,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             mail_class: "transactional",
             reply_to: None,
             envelope_from: None,
+            list_unsubscribe: None,
         }
     }
 
@@ -1958,6 +2013,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
                 mail_class: "transactional",
                 reply_to: None,
                 envelope_from: None,
+                list_unsubscribe: None,
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -1982,6 +2038,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             mail_class: "transactional",
             reply_to: Some("support@acme.com"),
             envelope_from: None,
+            list_unsubscribe: None,
         };
         let with = rendered(&svc().build_ticket_reply_message(&base).unwrap());
         assert!(with.contains("Reply-To: support@acme.com"), "dump:\n{with}");
@@ -1991,11 +2048,51 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
                 .build_ticket_reply_message(&OutboundEmailMessage {
                     reply_to: None,
                     envelope_from: None,
+                    list_unsubscribe: None,
                     ..base
                 })
                 .unwrap(),
         );
         assert!(!without.contains("Reply-To:"), "dump:\n{without}");
+    }
+
+    #[test]
+    fn list_unsubscribe_headers_emitted_only_when_set() {
+        let base = OutboundEmailMessage {
+            to: "alice@example.com",
+            subject: "Ticket #42 updated",
+            body_text: "an update",
+            body_html: None,
+            message_id: "notify.cafef00d@yourco.com",
+            in_reply_to: None,
+            references: &[],
+            auto_submitted: None,
+            mail_class: "notification",
+            reply_to: None,
+            envelope_from: None,
+            list_unsubscribe: Some("https://acme.nosdesk.dev/api/public/unsubscribe?token=t.sig"),
+        };
+        let with = rendered(&svc().build_ticket_reply_message(&base).unwrap());
+        assert!(
+            with.contains(
+                "List-Unsubscribe: <https://acme.nosdesk.dev/api/public/unsubscribe?token=t.sig>"
+            ),
+            "dump:\n{with}"
+        );
+        assert!(
+            with.contains("List-Unsubscribe-Post: List-Unsubscribe=One-Click"),
+            "dump:\n{with}"
+        );
+
+        let without = rendered(
+            &svc()
+                .build_ticket_reply_message(&OutboundEmailMessage {
+                    list_unsubscribe: None,
+                    ..base
+                })
+                .unwrap(),
+        );
+        assert!(!without.contains("List-Unsubscribe"), "dump:\n{without}");
     }
 
     #[test]
@@ -2013,6 +2110,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
                 mail_class: "transactional",
                 reply_to: None,
                 envelope_from: None,
+                list_unsubscribe: None,
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -2045,6 +2143,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             mail_class: "transactional",
             reply_to: None,
             envelope_from: None,
+            list_unsubscribe: None,
         };
         let rt = tokio::runtime::Runtime::new().unwrap();
         let err = rt

--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -645,6 +645,65 @@ pub enum SmtpSecurity {
     Plaintext,
 }
 
+/// Result of checking whether an SMTP `(port, security)` pair is coherent (B4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SmtpCoherence {
+    /// Standard, no concerns.
+    Ok,
+    /// Reachable but worth surfacing (e.g. plaintext submission, port 25).
+    Warn(String),
+    /// Protocol-impossible: the pair physically cannot complete a connection.
+    Error(String),
+}
+
+/// Check an SMTP `(port, security)` pair for coherence (B4).
+///
+/// The load-bearing distinction is implicit-TLS-on-connect (465) vs a STARTTLS
+/// upgrade (587), per RFC 8314 / 6409 — the port itself is only a hint. So only
+/// the three pairs that physically can't connect are hard [`SmtpCoherence::Error`]s;
+/// non-standard ports (2525, custom relays) trust the operator's chosen mode and
+/// at most [`SmtpCoherence::Warn`]. This keeps legitimate corporate / alt-port
+/// relays working while still catching the cryptic-at-connect-time mistakes.
+pub fn check_port_security(port: u16, security: SmtpSecurity) -> SmtpCoherence {
+    use SmtpSecurity::*;
+    match (port, security) {
+        // Port 465 is implicit-TLS-on-connect: a STARTTLS handshake or plaintext
+        // EHLO is the wrong first bytes and the connection never establishes.
+        (465, StartTls) => SmtpCoherence::Error(
+            "Port 465 uses implicit TLS on connect, not STARTTLS. Use port 587 for STARTTLS, \
+             or keep 465 and set security to TLS."
+                .into(),
+        ),
+        (465, Plaintext) => SmtpCoherence::Error(
+            "Port 465 requires implicit TLS; plaintext is not possible on it.".into(),
+        ),
+        // Port 587 expects a cleartext EHLO first, then STARTTLS; an immediate
+        // TLS handshake is rejected.
+        (587, Tls) => SmtpCoherence::Error(
+            "Port 587 uses STARTTLS, not implicit TLS. Use port 465 for implicit TLS, \
+             or keep 587 and set security to STARTTLS."
+                .into(),
+        ),
+        (465, Tls) | (587, StartTls) => SmtpCoherence::Ok,
+        (587, Plaintext) => SmtpCoherence::Warn(
+            "Port 587 normally uses STARTTLS; plaintext submission sends mail unencrypted.".into(),
+        ),
+        // Port 25 is server-to-server relay, not authenticated submission.
+        (25, _) => SmtpCoherence::Warn(
+            "Port 25 is for server-to-server relay, not authenticated submission; prefer 587 \
+             (STARTTLS) or 465 (implicit TLS)."
+                .into(),
+        ),
+        // Any other port: trust the operator's explicit mode, but flag plaintext.
+        (_, Plaintext) => SmtpCoherence::Warn(
+            "Plaintext SMTP sends mail unencrypted; use TLS or STARTTLS unless this is a trusted \
+             local relay."
+                .into(),
+        ),
+        _ => SmtpCoherence::Ok,
+    }
+}
+
 impl EmailConfig {
     /// Load email configuration from environment variables
     pub fn from_env() -> Result<Self, String> {
@@ -708,6 +767,21 @@ impl EmailConfig {
                 ));
             }
         };
+
+        // B4: fail fast at startup on an incoherent port/security pair instead
+        // of a cryptic TLS error on the first send. Warnings are logged but
+        // don't block boot.
+        match check_port_security(smtp_port, security) {
+            SmtpCoherence::Error(msg) => {
+                return Err(format!(
+                    "SMTP_PORT {smtp_port} / SMTP_SECURITY mismatch: {msg}"
+                ));
+            }
+            SmtpCoherence::Warn(msg) => {
+                tracing::warn!(port = smtp_port, "SMTP config warning: {msg}");
+            }
+            SmtpCoherence::Ok => {}
+        }
 
         Ok(Self {
             smtp_host,
@@ -1667,6 +1741,44 @@ pub struct OutboundEmailMessage<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn smtp_coherence_matrix() {
+        use SmtpSecurity::*;
+        // The three protocol-impossible pairs are hard errors.
+        assert!(matches!(
+            check_port_security(465, StartTls),
+            SmtpCoherence::Error(_)
+        ));
+        assert!(matches!(
+            check_port_security(465, Plaintext),
+            SmtpCoherence::Error(_)
+        ));
+        assert!(matches!(
+            check_port_security(587, Tls),
+            SmtpCoherence::Error(_)
+        ));
+        // The standard coherent pairs are clean.
+        assert_eq!(check_port_security(465, Tls), SmtpCoherence::Ok);
+        assert_eq!(check_port_security(587, StartTls), SmtpCoherence::Ok);
+        // Insecure-but-reachable and relay-port configs warn, not error.
+        assert!(matches!(
+            check_port_security(587, Plaintext),
+            SmtpCoherence::Warn(_)
+        ));
+        assert!(matches!(
+            check_port_security(25, StartTls),
+            SmtpCoherence::Warn(_)
+        ));
+        // Non-standard ports trust the operator's explicit TLS mode.
+        assert_eq!(check_port_security(2525, StartTls), SmtpCoherence::Ok);
+        assert_eq!(check_port_security(10025, Tls), SmtpCoherence::Ok);
+        // ...but still flag plaintext on any port.
+        assert!(matches!(
+            check_port_security(2525, Plaintext),
+            SmtpCoherence::Warn(_)
+        ));
+    }
 
     #[test]
     fn test_email_config_disabled_by_default() {

--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -1119,6 +1119,9 @@ impl EmailService {
             in_reply_to: None,
             references: &[],
             auto_submitted: None,
+            // Generic direct-send path; its callers (test mail, guest ticket
+            // confirmation) are transactional, the safe no-unsubscribe default.
+            mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
         };
         self.send_outbound(&outbound).await.map(|_| ())
     }
@@ -1143,6 +1146,9 @@ impl EmailService {
             in_reply_to: None,
             references: &[],
             auto_submitted: None,
+            // Generic direct-send path; its callers (test mail, guest ticket
+            // confirmation) are transactional, the safe no-unsubscribe default.
+            mail_class: crate::models::outbound_email_mail_class::TRANSACTIONAL,
         };
         self.send_outbound(&outbound).await.map(|_| ())
     }
@@ -1554,6 +1560,12 @@ pub struct OutboundEmailMessage<'a> {
     /// (`Auto-Submitted` + `X-Auto-Response-Suppress`) are emitted so the
     /// recipient's OOO / auto-responder won't bounce back and ping-pong.
     pub auto_submitted: Option<&'a str>,
+    /// Mail class (see `models::outbound_email_mail_class`): `"notification"`
+    /// (opt-out-able) or `"transactional"` (must-deliver). Carried to the send
+    /// path so deliverability headers branch on it (List-Unsubscribe on
+    /// notification only). Defaults to transactional on any path that hasn't
+    /// classified itself, which is the safe, no-unsubscribe choice.
+    pub mail_class: &'a str,
 }
 
 #[cfg(test)]
@@ -1623,6 +1635,7 @@ mod tests {
                 in_reply_to: None,
                 references: &[],
                 auto_submitted: None,
+                mail_class: "transactional",
             })
             .unwrap();
         assert!(
@@ -1644,6 +1657,7 @@ mod tests {
                 in_reply_to: None,
                 references: &[],
                 auto_submitted: None,
+                mail_class: "transactional",
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -1669,6 +1683,7 @@ mod tests {
                         in_reply_to: None,
                         references: &[],
                         auto_submitted: auto,
+                        mail_class: "transactional",
                     })
                     .unwrap(),
             )
@@ -1744,6 +1759,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             in_reply_to: None,
             references: &[],
             auto_submitted: None,
+            mail_class: "transactional",
         }
     }
 
@@ -1886,6 +1902,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
                 in_reply_to: Some("<second@x>"),
                 references: &refs,
                 auto_submitted: None,
+                mail_class: "transactional",
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -1908,6 +1925,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
                 in_reply_to: None,
                 references: &[],
                 auto_submitted: None,
+                mail_class: "transactional",
             })
             .unwrap();
         let dump = rendered(&msg);
@@ -1937,6 +1955,7 @@ B88KQSZwPfTv4qlBKPZXpb3vrKIOynaKzM7b7aZYs3LPZwTUb1yq
             in_reply_to: None,
             references: &[],
             auto_submitted: None,
+            mail_class: "transactional",
         };
         let rt = tokio::runtime::Runtime::new().unwrap();
         let err = rt

--- a/backend/src/utils/jwt.rs
+++ b/backend/src/utils/jwt.rs
@@ -47,6 +47,7 @@ impl JwtUtils {
             platform_role: user.platform_role.clone(),
             scope: "full".to_string(),
             sid: Some(session_id.to_string()),
+            workspace_uuid: None,
             exp: now + 15 * 60, // 15 minutes
             iat: now,
         };
@@ -60,8 +61,15 @@ impl JwtUtils {
     }
 
     /// Create a short-lived SSE token (1 hour expiry)
-    /// These tokens are specifically for Server-Sent Events and have reduced scope
-    pub fn create_sse_token(user_id: &str, platform_role: &str) -> Result<String, JwtError> {
+    /// These tokens are specifically for Server-Sent Events and have reduced scope.
+    /// `workspace_uuid` binds the selected workspace into the token (Model C) so
+    /// the stream — which can't receive the selection header over EventSource —
+    /// authorizes against it; `None` for Host-derived / self-hosted callers.
+    pub fn create_sse_token(
+        user_id: &str,
+        platform_role: &str,
+        workspace_uuid: Option<uuid::Uuid>,
+    ) -> Result<String, JwtError> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(|_| JwtError::SystemTime)?
@@ -74,6 +82,7 @@ impl JwtUtils {
             platform_role: platform_role.to_string(),
             scope: "sse".to_string(),
             sid: None,
+            workspace_uuid,
             exp: now + 3600,
             iat: now,
         };
@@ -685,11 +694,17 @@ mod tests {
         let _ = &*JWT_SECRET;
 
         let user_id = uuid::Uuid::new_v4().to_string();
-        let token = JwtUtils::create_sse_token(&user_id, "platform_admin")
+        let ws = uuid::Uuid::new_v4();
+        let token = JwtUtils::create_sse_token(&user_id, "platform_admin", Some(ws))
             .expect("Failed to create SSE token");
         let claims = JwtUtils::validate_token(&token).expect("Failed to validate SSE token");
         assert_eq!(claims.scope, "sse");
         assert_eq!(claims.sub, user_id);
+        assert_eq!(
+            claims.workspace_uuid,
+            Some(ws),
+            "SSE token carries the workspace"
+        );
     }
 
     #[test]

--- a/backend/src/utils/jwt.rs
+++ b/backend/src/utils/jwt.rs
@@ -95,6 +95,45 @@ impl JwtUtils {
         .map_err(JwtError::EncodingError)
     }
 
+    /// Create a customer-portal session access token (15 minutes).
+    ///
+    /// Scope `portal` (refused on the agent surface) and the workspace UUID
+    /// bound into the token so the portal gate can confirm the session belongs
+    /// to the origin's workspace and reject a token replayed onto a different
+    /// tenant's portal. Mirrors [`create_token`] otherwise.
+    pub fn create_portal_token(
+        user: &User,
+        workspace_uuid: uuid::Uuid,
+        session_id: &uuid::Uuid,
+    ) -> Result<String, JwtError> {
+        if user.deleted_at.is_some() {
+            return Err(JwtError::UserNotFound);
+        }
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| JwtError::SystemTime)?
+            .as_secs() as usize;
+
+        let claims = Claims {
+            sub: uuid_to_string(&user.uuid),
+            name: user.name.clone(),
+            email: String::new(),
+            platform_role: user.platform_role.clone(),
+            scope: crate::middleware::cookie_auth::PORTAL_SCOPE.to_string(),
+            sid: Some(session_id.to_string()),
+            workspace_uuid: Some(workspace_uuid),
+            exp: now + 15 * 60, // 15 minutes
+            iat: now,
+        };
+
+        encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+        )
+        .map_err(JwtError::EncodingError)
+    }
+
     /// Validate a JWT token and return claims
     pub fn validate_token(token: &str) -> Result<Claims, JwtError> {
         let mut validation = Validation::new(Algorithm::HS256);
@@ -437,6 +476,55 @@ pub mod helpers {
         )
         .map_err(|e| {
             tracing::error!("Failed to store refresh token: {}", e);
+            HttpResponse::InternalServerError().json(json!({
+                "status": "error",
+                "message": "Failed to create refresh token"
+            }))
+        })?;
+
+        let csrf_token = crate::utils::csrf::generate_csrf_token();
+
+        Ok(LoginTokens {
+            access_token,
+            refresh_token,
+            csrf_token,
+        })
+    }
+
+    /// Customer-portal equivalent of [`create_tokens`]: a portal-scope access
+    /// token (workspace-bound) plus the same refresh + CSRF machinery. The
+    /// refresh row and CSRF token are issued identically to an agent session;
+    /// only the access token's scope and workspace binding differ.
+    pub fn create_portal_tokens(
+        user: &User,
+        workspace_uuid: uuid::Uuid,
+        session_id: &uuid::Uuid,
+        family_id: &uuid::Uuid,
+        conn: &mut DbConnection,
+    ) -> Result<LoginTokens, HttpResponse> {
+        let access_token = JwtUtils::create_portal_token(user, workspace_uuid, session_id)
+            .map_err(|_| {
+                HttpResponse::InternalServerError().json(json!({
+                    "status": "error",
+                    "message": "Error generating token"
+                }))
+            })?;
+
+        let refresh_token = JwtUtils::generate_refresh_token();
+        let refresh_token_hash = JwtUtils::hash_refresh_token(&refresh_token);
+        let refresh_expires = chrono::Utc::now().naive_utc() + chrono::Duration::days(7);
+        crate::repository::refresh_tokens::create_refresh_token(
+            conn,
+            crate::models::NewRefreshToken {
+                token_hash: refresh_token_hash,
+                user_uuid: user.uuid,
+                expires_at: refresh_expires,
+                session_id: Some(*session_id),
+                family_id: *family_id,
+            },
+        )
+        .map_err(|e| {
+            tracing::error!("Failed to store portal refresh token: {}", e);
             HttpResponse::InternalServerError().json(json!({
                 "status": "error",
                 "message": "Failed to create refresh token"

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -32,6 +32,7 @@ pub mod security_events;
 pub mod slug;
 pub mod storage;
 pub mod template_variables;
+pub mod tenant_origin;
 pub mod tracing_redact;
 pub mod user;
 pub mod utf8_trunc;

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -34,6 +34,7 @@ pub mod storage;
 pub mod template_variables;
 pub mod tenant_origin;
 pub mod tracing_redact;
+pub mod unsubscribe_token;
 pub mod user;
 pub mod utf8_trunc;
 pub mod verp;

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -36,6 +36,7 @@ pub mod tenant_origin;
 pub mod tracing_redact;
 pub mod user;
 pub mod utf8_trunc;
+pub mod verp;
 pub mod webauthn;
 pub mod workspace_slug;
 

--- a/backend/src/utils/rbac.rs
+++ b/backend/src/utils/rbac.rs
@@ -255,6 +255,7 @@ mod tests {
             platform_role: platform_role.to_string(),
             scope: "full".to_string(),
             sid: None,
+            workspace_uuid: None,
             exp: 0,
             iat: 0,
         }

--- a/backend/src/utils/reset_tokens.rs
+++ b/backend/src/utils/reset_tokens.rs
@@ -8,6 +8,10 @@ use uuid::Uuid;
 pub enum TokenType {
     PasswordReset,
     Invitation,
+    /// Customer-portal passwordless sign-in link. Short-lived and single-use;
+    /// possession of the emailed link proves the customer owns the address,
+    /// which is their whole identity in the portal.
+    PortalMagicLink,
 }
 
 impl TokenType {
@@ -15,6 +19,7 @@ impl TokenType {
         match self {
             TokenType::PasswordReset => "password_reset",
             TokenType::Invitation => "invitation",
+            TokenType::PortalMagicLink => "portal_magic_link",
         }
     }
 
@@ -23,6 +28,7 @@ impl TokenType {
         match self {
             TokenType::PasswordReset => Duration::hours(1), // 1 hour for password resets
             TokenType::Invitation => Duration::days(7),     // 7 days for user invitations
+            TokenType::PortalMagicLink => Duration::minutes(20), // short-lived sign-in link
         }
     }
 }

--- a/backend/src/utils/tenant_origin.rs
+++ b/backend/src/utils/tenant_origin.rs
@@ -39,7 +39,7 @@ pub fn canonical_host_for(
 
 /// A workspace's canonical host (no scheme), reading the configured tenant
 /// domain. `None` in self-hosted mode or when unconfigured.
-pub fn workspace_host(workspace: &Workspace) -> Option<String> {
+fn workspace_host(workspace: &Workspace) -> Option<String> {
     canonical_host_for(
         &workspace.slug,
         workspace.custom_domain.as_deref(),

--- a/backend/src/utils/tenant_origin.rs
+++ b/backend/src/utils/tenant_origin.rs
@@ -1,0 +1,110 @@
+//! Canonical host and origin for a tenant workspace.
+//!
+//! A hosted workspace lives at `<slug>.<NOSDESK_TENANT_DOMAIN>` or a verified
+//! `custom_domain`. This is the single source of truth for the workspace's
+//! host/origin, used to build tenant-facing URLs (password-reset / invite /
+//! notification links) and the per-workspace WebAuthn RP ID. Generation is
+//! workspace-derived so it works off the response path (the email queue has no
+//! `HttpRequest`) and always targets the canonical host even when the
+//! triggering request arrived on a different one.
+//!
+//! Validating an *incoming* request origin (CORS, collab WS) is the dual
+//! concern and lives in `utils::cors_allowlist` (the tenant-subdomain regex).
+//! Don't reimplement that here.
+
+use crate::models::Workspace;
+
+/// The configured hosted tenant base domain (`NOSDESK_TENANT_DOMAIN`), e.g.
+/// `nosdesk.dev`. `None` in self-hosted single-tenant deployments (or when set
+/// blank).
+pub fn tenant_domain() -> Option<String> {
+    non_empty(std::env::var("NOSDESK_TENANT_DOMAIN").ok())
+}
+
+/// Pure host builder: a non-empty `custom_domain` wins, else
+/// `<slug>.<tenant_domain>` when a non-empty `tenant_domain` is given, else
+/// `None`. Returns the bare host (no scheme). This host is also the workspace's
+/// WebAuthn RP ID.
+pub fn canonical_host_for(
+    slug: &str,
+    custom_domain: Option<&str>,
+    tenant_domain: Option<&str>,
+) -> Option<String> {
+    if let Some(domain) = custom_domain.map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(domain.to_string());
+    }
+    let tenant_domain = tenant_domain.map(str::trim).filter(|s| !s.is_empty())?;
+    Some(format!("{slug}.{tenant_domain}"))
+}
+
+/// A workspace's canonical host (no scheme), reading the configured tenant
+/// domain. `None` in self-hosted mode or when unconfigured.
+pub fn workspace_host(workspace: &Workspace) -> Option<String> {
+    canonical_host_for(
+        &workspace.slug,
+        workspace.custom_domain.as_deref(),
+        tenant_domain().as_deref(),
+    )
+}
+
+/// A workspace's canonical origin (`https://<host>`).
+pub fn workspace_origin(workspace: &Workspace) -> Option<String> {
+    workspace_host(workspace).map(|host| format!("https://{host}"))
+}
+
+/// `https://<host>` for a canonical host. Small helper so callers that already
+/// hold a host (e.g. a `WorkspaceContext`) don't reinvent the scheme join.
+pub fn origin_from_host(host: Option<String>) -> Option<String> {
+    host.map(|host| format!("https://{host}"))
+}
+
+/// Base URL for links emailed to a workspace's members (resets, invites,
+/// notifications): the workspace's canonical origin, else `FRONTEND_URL`.
+/// `None` only when neither is set (self-host without `FRONTEND_URL`); the
+/// caller supplies a last resort (typically the request host).
+pub fn email_link_base(canonical_origin: Option<String>) -> Option<String> {
+    canonical_origin.or_else(|| non_empty(std::env::var("FRONTEND_URL").ok()))
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canonical_host_for;
+
+    #[test]
+    fn custom_domain_wins_over_slug() {
+        assert_eq!(
+            canonical_host_for("acme", Some("help.acme.com"), Some("nosdesk.dev")),
+            Some("help.acme.com".to_string())
+        );
+    }
+
+    #[test]
+    fn slug_plus_tenant_domain_when_no_custom_domain() {
+        assert_eq!(
+            canonical_host_for("acme", None, Some("nosdesk.dev")),
+            Some("acme.nosdesk.dev".to_string())
+        );
+    }
+
+    #[test]
+    fn none_without_custom_domain_or_tenant_domain() {
+        assert_eq!(canonical_host_for("acme", None, None), None);
+    }
+
+    #[test]
+    fn blank_values_are_treated_as_unset() {
+        // Blank custom domain falls through to the tenant-domain form.
+        assert_eq!(
+            canonical_host_for("acme", Some("  "), Some("nosdesk.dev")),
+            Some("acme.nosdesk.dev".to_string())
+        );
+        // Blank tenant domain with no custom domain yields None.
+        assert_eq!(canonical_host_for("acme", None, Some("")), None);
+    }
+}

--- a/backend/src/utils/unsubscribe_token.rs
+++ b/backend/src/utils/unsubscribe_token.rs
@@ -1,0 +1,99 @@
+//! Signed, stateless tokens for one-click email unsubscribe (B2 / RFC 8058).
+//!
+//! A notification email's `List-Unsubscribe` URL carries a token naming the
+//! recipient. The token is HMAC-signed with the server's `JWT_SECRET` so the
+//! no-auth unsubscribe endpoint can trust it without a session or DB lookup, and
+//! a third party can't unsubscribe an arbitrary user by guessing a uuid. The
+//! token is not secret (it travels in mail headers); the signature is what makes
+//! it unforgeable.
+
+use ring::hmac;
+use uuid::Uuid;
+
+/// Hex HMAC-SHA256 of `body` under `secret`.
+fn hmac_hex(secret: &[u8], body: &str) -> String {
+    let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
+    let sig = hmac::sign(&key, body.as_bytes());
+    let mut hex = String::with_capacity(sig.as_ref().len() * 2);
+    for b in sig.as_ref() {
+        hex.push_str(&format!("{b:02x}"));
+    }
+    hex
+}
+
+/// Build an unsubscribe token for `user_uuid` under `secret`. Format is
+/// `<uuid-simple>.<hmac-hex>`, URL-safe as-is (hex + a dot).
+pub fn sign_with(secret: &[u8], user_uuid: &Uuid) -> String {
+    let body = user_uuid.as_simple().to_string();
+    let sig = hmac_hex(secret, &body);
+    format!("{body}.{sig}")
+}
+
+/// Verify `token` under `secret` and recover the user it unsubscribes, or
+/// `None` if the signature doesn't match (forged / wrong secret / malformed).
+pub fn verify_with(secret: &[u8], token: &str) -> Option<Uuid> {
+    let (body, sig) = token.split_once('.')?;
+    let expected = hmac_hex(secret, body);
+    if !constant_time_eq::constant_time_eq(expected.as_bytes(), sig.as_bytes()) {
+        return None;
+    }
+    Uuid::parse_str(body).ok()
+}
+
+/// The server's token-signing secret (`JWT_SECRET`), or `None` when unset.
+fn secret() -> Option<String> {
+    std::env::var("JWT_SECRET").ok().filter(|s| !s.is_empty())
+}
+
+/// [`sign_with`] keyed by the server's `JWT_SECRET`. `None` only when that's
+/// unset (never in a configured deployment).
+pub fn sign(user_uuid: &Uuid) -> Option<String> {
+    secret().map(|s| sign_with(s.as_bytes(), user_uuid))
+}
+
+/// [`verify_with`] keyed by the server's `JWT_SECRET`.
+pub fn verify(token: &str) -> Option<Uuid> {
+    verify_with(secret()?.as_bytes(), token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"unsub-test-secret";
+
+    #[test]
+    fn round_trips_user() {
+        let u = Uuid::now_v7();
+        let token = sign_with(SECRET, &u);
+        assert_eq!(verify_with(SECRET, &token), Some(u));
+    }
+
+    #[test]
+    fn rejects_tampered_signature() {
+        let u = Uuid::now_v7();
+        let token = sign_with(SECRET, &u);
+        let mut bytes: Vec<char> = token.chars().collect();
+        let last = bytes.len() - 1;
+        bytes[last] = if bytes[last] == 'a' { 'b' } else { 'a' };
+        let tampered: String = bytes.into_iter().collect();
+        assert_eq!(verify_with(SECRET, &tampered), None);
+    }
+
+    #[test]
+    fn rejects_swapped_user() {
+        // A body swapped to a different uuid no longer matches the signature.
+        let token = sign_with(SECRET, &Uuid::now_v7());
+        let other = Uuid::now_v7().as_simple().to_string();
+        let sig = token.split_once('.').unwrap().1;
+        assert_eq!(verify_with(SECRET, &format!("{other}.{sig}")), None);
+    }
+
+    #[test]
+    fn rejects_wrong_secret_and_malformed() {
+        let token = sign_with(SECRET, &Uuid::now_v7());
+        assert_eq!(verify_with(b"different", &token), None);
+        assert_eq!(verify_with(SECRET, "no-dot"), None);
+        assert_eq!(verify_with(SECRET, "not-a-uuid.deadbeef"), None);
+    }
+}

--- a/backend/src/utils/verp.rs
+++ b/backend/src/utils/verp.rs
@@ -1,0 +1,153 @@
+//! VERP (Variable Envelope Return Path) tokens for bounce correlation (B1).
+//!
+//! An outbound message can be sent with a dedicated SMTP envelope-from
+//! (`MAIL FROM` / Return-Path) distinct from the `From` header, carrying a
+//! token that names the originating `outbound_emails` row. A bounce DSN is
+//! addressed back to that Return-Path, so the inbound bounce handler can link
+//! it to the row directly instead of relying on the remote MTA echoing the
+//! original `Message-ID` (which many don't). Keeping the Return-Path on the
+//! sending mailbox's own domain also aligns SPF.
+//!
+//! The token is `nbx-<row_id>-<hmac8>` appended to the base mailbox's local
+//! part via plus-addressing: `support@acme.com` + row 42 ->
+//! `support+nbx-42-1a2b3c4d@acme.com`. The bounce still lands in the base
+//! mailbox (plus-addressing delivers to the base), so it arrives wherever
+//! ordinary replies already do. The truncated HMAC stops a third party forging
+//! a Return-Path that would mark an arbitrary row bounced.
+//!
+//! Opt-in: with no `SMTP_VERP_SECRET` configured, no Return-Path is built and
+//! the transport falls back to lettre's default (From-derived) envelope, so
+//! existing deployments are unchanged until an operator enables and
+//! deliverability-tests it.
+
+use ring::hmac;
+
+/// Local-part tag prefix, short and distinctive so the inbound decoder can
+/// recognise our VERP addresses among ordinary plus-addressed mail.
+const TAG_PREFIX: &str = "nbx";
+/// HMAC truncation: 8 hex chars (32 bits). Enough to make forging a valid
+/// `(row_id, tag)` pair impractical; the tag only routes a bounce to a row, it
+/// grants no access.
+const HMAC_HEX_LEN: usize = 8;
+
+/// Hex HMAC-SHA256 of the row id under `secret`, truncated to [`HMAC_HEX_LEN`].
+fn tag_hmac(secret: &[u8], row_id: i64) -> String {
+    let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
+    let sig = hmac::sign(&key, row_id.to_string().as_bytes());
+    let mut hex = String::with_capacity(HMAC_HEX_LEN);
+    for b in sig.as_ref().iter().take(HMAC_HEX_LEN / 2) {
+        hex.push_str(&format!("{b:02x}"));
+    }
+    hex
+}
+
+/// Build the VERP Return-Path for `row_id` by plus-tagging `base` (the polled
+/// mailbox a bounce should land in, e.g. the channel's IMAP address). Returns
+/// `None` when `base` isn't a bare `local@domain` address, or its local part is
+/// already plus-addressed (the decoder splits on the first `+`, so a second
+/// would be ambiguous) — the caller then leaves the default envelope in place
+/// rather than send a malformed `MAIL FROM`.
+pub fn tagged_return_path(base: &str, row_id: i64, secret: &[u8]) -> Option<String> {
+    let (local, domain) = base.split_once('@')?;
+    if local.is_empty() || domain.is_empty() || domain.contains('@') || local.contains('+') {
+        return None;
+    }
+    let tag = tag_hmac(secret, row_id);
+    Some(format!("{local}+{TAG_PREFIX}-{row_id}-{tag}@{domain}"))
+}
+
+/// Recover the `outbound_emails` row id from a VERP Return-Path produced by
+/// [`tagged_return_path`], verifying the HMAC under `secret`. Returns `None`
+/// for any address that isn't one of ours (ordinary mail, a forged tag, or a
+/// tag signed with a different secret). Used by the inbound bounce handler.
+pub fn row_id_from_address(address: &str, secret: &[u8]) -> Option<i64> {
+    let (local, _domain) = address.split_once('@')?;
+    let (_base, tag) = local.split_once('+')?;
+    // tag == "nbx-<row_id>-<hmac8>"
+    let rest = tag.strip_prefix(TAG_PREFIX)?.strip_prefix('-')?;
+    let (row_str, hmac_str) = rest.rsplit_once('-')?;
+    let row_id: i64 = row_str.parse().ok()?;
+    let expected = tag_hmac(secret, row_id);
+    // Constant-time compare so a timing side channel can't be used to forge the
+    // tag byte-by-byte (low stakes here, but free given the helper exists).
+    constant_time_eq::constant_time_eq(expected.as_bytes(), hmac_str.as_bytes()).then_some(row_id)
+}
+
+/// The configured VERP signing secret (`SMTP_VERP_SECRET`, hex-encoded), or
+/// `None` when unset / blank / not valid hex — which disables VERP entirely.
+/// Read fresh (not memoised) so it stays operationally toggleable and testable.
+pub fn configured_secret() -> Option<Vec<u8>> {
+    let hex = std::env::var("SMTP_VERP_SECRET").ok()?;
+    let hex = hex.trim();
+    if hex.is_empty() {
+        return None;
+    }
+    // Accept hex only; reject anything else rather than silently signing with a
+    // misconfigured key that would never verify on the inbound side.
+    hex_decode(hex)
+}
+
+fn hex_decode(s: &str) -> Option<Vec<u8>> {
+    if s.len() % 2 != 0 {
+        return None;
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"verp-test-secret";
+
+    #[test]
+    fn round_trips_row_id() {
+        let rp = tagged_return_path("support@acme.com", 42, SECRET).unwrap();
+        assert!(rp.starts_with("support+nbx-42-"));
+        assert!(rp.ends_with("@acme.com"));
+        assert_eq!(row_id_from_address(&rp, SECRET), Some(42));
+    }
+
+    #[test]
+    fn rejects_tampered_tag() {
+        let rp = tagged_return_path("support@acme.com", 42, SECRET).unwrap();
+        // Flip the last hex char of the HMAC.
+        let mut chars: Vec<char> = rp.chars().collect();
+        let at = rp.find('@').unwrap();
+        chars[at - 1] = if chars[at - 1] == 'a' { 'b' } else { 'a' };
+        let tampered: String = chars.into_iter().collect();
+        assert_eq!(row_id_from_address(&tampered, SECRET), None);
+    }
+
+    #[test]
+    fn rejects_wrong_secret() {
+        let rp = tagged_return_path("support@acme.com", 42, SECRET).unwrap();
+        assert_eq!(row_id_from_address(&rp, b"different-secret"), None);
+    }
+
+    #[test]
+    fn ignores_non_verp_addresses() {
+        assert_eq!(row_id_from_address("support@acme.com", SECRET), None);
+        assert_eq!(row_id_from_address("support+other@acme.com", SECRET), None);
+        assert_eq!(row_id_from_address("not-an-address", SECRET), None);
+    }
+
+    #[test]
+    fn refuses_bad_base() {
+        assert_eq!(tagged_return_path("not-an-address", 1, SECRET), None);
+        assert_eq!(tagged_return_path("@acme.com", 1, SECRET), None);
+        assert_eq!(tagged_return_path("support@", 1, SECRET), None);
+        // Already plus-addressed: refuse to stack a second tag.
+        assert_eq!(tagged_return_path("support+x@acme.com", 1, SECRET), None);
+    }
+
+    #[test]
+    fn hex_decode_validates() {
+        assert_eq!(hex_decode("00ff"), Some(vec![0x00, 0xff]));
+        assert_eq!(hex_decode("abc"), None); // odd length
+        assert_eq!(hex_decode("zz"), None); // non-hex
+    }
+}

--- a/backend/src/utils/webauthn.rs
+++ b/backend/src/utils/webauthn.rs
@@ -119,13 +119,66 @@ impl WebAuthnConfig {
     }
 }
 
-// Lazy static WebAuthn instance
-lazy_static::lazy_static! {
-    static ref WEBAUTHN_CONFIG: WebAuthnConfig = WebAuthnConfig::from_env()
-        .expect("Failed to load WebAuthn configuration");
+// =============================================================================
+// Per-request verifier (per-workspace RP)
+// =============================================================================
+//
+// Hosted multi-tenant: RP ID + origin are the host the request is served on
+// (`mercury.nosdesk.dev` or a tenant's custom domain), so passkeys are scoped
+// per host/workspace and custom domains work without a shared RP ID (which
+// would leak credentials across tenants). Self-hosted single-tenant: the
+// env-configured RP (`WEBAUTHN_RP_ID` / `WEBAUTHN_RP_ORIGIN`). Building per
+// request is cheap. Rationale + spec research: docs/plans/tenant-origin-awareness.md.
 
-    pub static ref WEBAUTHN: Webauthn = WEBAUTHN_CONFIG.build_webauthn()
-        .expect("Failed to build WebAuthn instance");
+/// Build the WebAuthn verifier for the current request. RP ID is the request's
+/// (validated) workspace host in hosted mode, or the env config in self-hosted
+/// mode. Returns an owned `Webauthn`; cheap to construct per call. Errors
+/// surface per request (not as a startup panic), so a hosted deploy needs no
+/// `WEBAUTHN_RP_*` env at all.
+pub fn webauthn_for_request(req: &actix_web::HttpRequest) -> Result<Webauthn> {
+    match request_workspace_host(req) {
+        Some(host) => build_webauthn_for_host(&host),
+        None => WebAuthnConfig::from_env()?.build_webauthn(),
+    }
+}
+
+/// The host this request is actually served on (= the WebAuthn RP ID), when it
+/// resolved to a hosted workspace. This is the **request host**, not the
+/// workspace's canonical-preference host: `rp_origin` must equal the browser's
+/// real origin, which differs from the canonical host when a workspace has a
+/// custom domain but is reached via its subdomain. The `WorkspaceContext` gate
+/// means the middleware already validated this host belongs to a workspace, and
+/// the browser independently enforces RP-ID/origin matching. Mirrors OIDC's
+/// `oauth_callback_redirect_uri`, the sibling request-origin concern.
+fn request_workspace_host(req: &actix_web::HttpRequest) -> Option<String> {
+    use actix_web::HttpMessage;
+    // Gate: only build a per-workspace verifier for a resolved hosted workspace.
+    // Drop the extensions borrow before reading headers.
+    if req
+        .extensions()
+        .get::<crate::extractors::WorkspaceContext>()
+        .is_none()
+    {
+        return None;
+    }
+    let host = req
+        .headers()
+        .get(actix_web::http::header::HOST)
+        .and_then(|h| h.to_str().ok())?;
+    let host = host.split(':').next().unwrap_or(host).trim().to_lowercase();
+    (!host.is_empty()).then_some(host)
+}
+
+/// Build a verifier whose RP ID and origin are the workspace canonical `host`.
+fn build_webauthn_for_host(host: &str) -> Result<Webauthn> {
+    let rp_origin = Url::parse(&format!("https://{host}"))
+        .map_err(|e| anyhow!("Invalid WebAuthn origin for host {host}: {e}"))?;
+    let rp_name = env::var("WEBAUTHN_RP_NAME").unwrap_or_else(|_| "Nosdesk".to_string());
+    WebauthnBuilder::new(host, &rp_origin)
+        .map_err(|e| anyhow!("Failed to create WebAuthn builder: {e:?}"))?
+        .rp_name(&rp_name)
+        .build()
+        .map_err(|e| anyhow!("Failed to build WebAuthn: {e:?}"))
 }
 
 // =============================================================================

--- a/backend/src/utils/webauthn.rs
+++ b/backend/src/utils/webauthn.rs
@@ -756,4 +756,71 @@ mod tests {
         let bumped = sync_counter_into_credential_blob(blob, 0);
         assert_eq!(bumped["cred"]["counter"], serde_json::json!(0));
     }
+
+    mod request_workspace_host {
+        use super::super::request_workspace_host;
+        use crate::extractors::WorkspaceContext;
+        use actix_web::{test::TestRequest, HttpMessage, HttpRequest};
+
+        fn req(host: &str, ctx: Option<WorkspaceContext>) -> HttpRequest {
+            let req = TestRequest::default()
+                .insert_header(("host", host))
+                .to_http_request();
+            if let Some(c) = ctx {
+                req.extensions_mut().insert(c);
+            }
+            req
+        }
+
+        fn ctx(slug: &str, custom_domain: Option<&str>) -> WorkspaceContext {
+            WorkspaceContext {
+                workspace_id: 1,
+                workspace_uuid: uuid::Uuid::nil(),
+                slug: slug.to_string(),
+                name: "Test".to_string(),
+                custom_domain: custom_domain.map(str::to_string),
+                organisation_id: None,
+            }
+        }
+
+        #[test]
+        fn uses_request_host_for_a_resolved_workspace() {
+            let r = req("mercury.nosdesk.dev", Some(ctx("mercury", None)));
+            assert_eq!(
+                request_workspace_host(&r),
+                Some("mercury.nosdesk.dev".to_string())
+            );
+        }
+
+        #[test]
+        fn uses_request_host_not_canonical_when_custom_domain_differs() {
+            // Workspace has a custom domain but the browser is on the subdomain.
+            // rp_origin must equal the browser origin, so the RP host is the
+            // request host, NOT the canonical (custom-domain) host.
+            let r = req(
+                "mercury.nosdesk.dev",
+                Some(ctx("mercury", Some("help.acme.com"))),
+            );
+            assert_eq!(
+                request_workspace_host(&r),
+                Some("mercury.nosdesk.dev".to_string())
+            );
+        }
+
+        #[test]
+        fn none_without_workspace_context() {
+            // Self-hosted / unresolved: fall back to the env-configured RP.
+            let r = req("mercury.nosdesk.dev", None);
+            assert_eq!(request_workspace_host(&r), None);
+        }
+
+        #[test]
+        fn strips_port_and_lowercases() {
+            let r = req("Mercury.Nosdesk.Dev:8443", Some(ctx("mercury", None)));
+            assert_eq!(
+                request_workspace_host(&r),
+                Some("mercury.nosdesk.dev".to_string())
+            );
+        }
+    }
 }

--- a/backend/tests/collaboration_ws.rs
+++ b/backend/tests/collaboration_ws.rs
@@ -149,6 +149,7 @@ fn test_workspace() -> WorkspaceContext {
         slug: "default".into(),
         name: "Default".into(),
         organisation_id: None,
+        custom_domain: None,
     }
 }
 
@@ -189,6 +190,24 @@ async fn handshake_broadcast_and_clean_disconnect() {
 
     // Seed a user so JWT validation finds a real row to attach to.
     let user = common::insert_user(&mut pool.get().expect("conn"), "WSAlice");
+
+    // The collab WS handshake runs the workspace-membership gate, so the user
+    // must be a member of the request workspace (id 1 here). Production reaches
+    // this handshake only for members; mirror that. Pinned via the actor because
+    // workspace_members is RLS-isolated and the pooled conn carries no GUC.
+    {
+        let mut conn = pool.get().expect("conn");
+        let actor = backend::sync::actor::ActorContext::user(user.uuid, None).with_workspace(1);
+        backend::sync::session::with_actor_context::<_, diesel::result::Error>(
+            &mut conn,
+            &actor,
+            |c| {
+                backend::repository::workspaces::add_membership(c, 1, user.uuid, "admin")?;
+                Ok(())
+            },
+        )
+        .expect("seed workspace membership");
+    }
 
     // ws_handler's JWT validation also checks `active_sessions`: the
     // token's `sid` claim must reference a live session row owned by

--- a/backend/tests/collaboration_ws.rs
+++ b/backend/tests/collaboration_ws.rs
@@ -384,3 +384,103 @@ async fn handshake_broadcast_and_clean_disconnect() {
     .expect("client B Pong timeout after A disconnect");
     assert!(got_pong, "client B never received Pong for its probe Ping");
 }
+
+/// Selection-path handshake (Model C, increment 2): with NO Host-derived
+/// WorkspaceContext on the request (the single-origin agent app), the collab WS
+/// resolves the workspace from the docId's embedded workspace_uuid and
+/// membership-gates it. The WS can't send the selection header, so the docId is
+/// the carrier. A member of the docId's workspace connects; a non-member is
+/// rejected at the handshake.
+#[actix_web::test]
+async fn handshake_resolves_workspace_from_doc_id_without_host_context() {
+    install_fast_heartbeat();
+
+    let test_db = common::TestDb::new();
+    let pool = build_pool(test_db.url());
+
+    // Bootstrap workspace 1's real uuid is the docId's tenancy anchor.
+    let ws1_uuid = backend::repository::workspaces::find_by_id(&mut pool.get().expect("conn"), 1)
+        .expect("ws lookup")
+        .expect("bootstrap workspace exists")
+        .uuid;
+
+    // A member of workspace 1 and a stranger who belongs to no workspace.
+    let member = common::insert_user(&mut pool.get().expect("conn"), "DocSel Member");
+    let stranger = common::insert_user(&mut pool.get().expect("conn"), "DocSel Stranger");
+    {
+        let mut conn = pool.get().expect("conn");
+        let actor = backend::sync::actor::ActorContext::user(member.uuid, None).with_workspace(1);
+        backend::sync::session::with_actor_context::<_, diesel::result::Error>(
+            &mut conn,
+            &actor,
+            |c| {
+                backend::repository::workspaces::add_membership(c, 1, member.uuid, "admin")?;
+                Ok(())
+            },
+        )
+        .expect("seed membership");
+    }
+
+    let cookie_for = |user: &backend::models::User| {
+        let session = backend::repository::active_sessions::create_session(
+            &mut pool.get().expect("conn"),
+            backend::models::NewActiveSession {
+                user_uuid: user.uuid,
+                device_name: Some("ws-sel".into()),
+                ip_address: None,
+                user_agent: Some("ws-sel-client".into()),
+                location: None,
+                expires_at: (chrono::Utc::now() + chrono::Duration::hours(1)).naive_utc(),
+                is_current: true,
+            },
+        )
+        .expect("create session");
+        let token = JwtUtils::create_token(user, &session.session_id).expect("mint JWT");
+        awc::cookie::Cookie::new(ACCESS_TOKEN_COOKIE, token)
+    };
+    let member_cookie = cookie_for(&member);
+    let stranger_cookie = cookie_for(&stranger);
+
+    let ticket_uuid = seed_ticket(&mut pool.get().expect("conn"));
+
+    let state_pool_inner = pool.clone();
+    let srv = actix_test::start(move || {
+        let (state, _tmp) = build_app_state(&state_pool_inner);
+        std::mem::forget(_tmp);
+        // No WorkspaceContext injected: the handler must derive the workspace
+        // from the docId, exercising the selection (None-context) branch.
+        App::new()
+            .app_data(web::Data::new(state))
+            .app_data(web::Data::new(state_pool_inner.clone()))
+            .route("/ws/{doc}", web::get().to(ws_handler))
+    });
+
+    // docId carries workspace 1's real uuid so find_by_uuid resolves it.
+    let doc_id = format!("ws-{ws1_uuid}_ticket-{ticket_uuid}");
+    let url = srv.url(&format!("/ws/{doc_id}"));
+    let client = awc::Client::new();
+
+    // Member: handshake succeeds and the initial SyncStep1 frame arrives.
+    let (_resp, mut conn) = client
+        .ws(&url)
+        .cookie(member_cookie)
+        .connect()
+        .await
+        .expect("member handshake should succeed via docId-derived workspace");
+    let first = tokio::time::timeout(Duration::from_secs(2), conn.next())
+        .await
+        .expect("initial frame timeout")
+        .expect("stream ended before initial frame")
+        .expect("initial frame error");
+    assert!(
+        matches!(first, ws::Frame::Binary(_)),
+        "expected Binary SyncStep1, got {first:?}"
+    );
+
+    // Non-member: rejected at the handshake (403 -> connect errors).
+    let denied = client.ws(&url).cookie(stranger_cookie).connect().await;
+    assert!(
+        denied.is_err(),
+        "non-member must be rejected at the docId-derived handshake"
+    );
+}

--- a/backend/tests/handler_tenant_read_lint.rs
+++ b/backend/tests/handler_tenant_read_lint.rs
@@ -1,0 +1,293 @@
+//! Lint (defense-in-depth): a handler should not make an authorization-relevant
+//! tenant read on a raw (un-pinned) database connection.
+//!
+//! This is a DEV-TIME CORRECTNESS guardrail, NOT the tenant-isolation control.
+//! Isolation is enforced structurally below the app and does not depend on this
+//! lint:
+//!   - FORCE row-level security scopes every tenant query by `app.workspace_id`,
+//!     so a read on a raw `pool.get()` / `db_conn()` connection (the pool clears
+//!     the GUC on checkout) returns ZERO rows under the NOBYPASSRLS `nosdesk_app`
+//!     role, and
+//!   - the P0.2 startup guard (`main.rs`) refuses to boot a hosted PRODUCTION
+//!     deployment connected as a role that bypasses RLS, so RLS is guaranteed
+//!     active there. An unpinned tenant read therefore cannot leak cross-tenant
+//!     in production — for every reader, not just the ones named below.
+//!
+//! What this lint catches is the CORRECTNESS bug that slips under those
+//! guarantees: a handler that does an ad-hoc tenant read on a raw connection to
+//! make an authorization decision fails closed (the read finds nothing, so it
+//! 404s even for the caller's own resource) and skips the app-layer membership /
+//! visibility gate entirely. That is how `upload_ticket_note_image` regressed:
+//! it called `get_ticket_by_id` on a raw connection instead of going through
+//! `TenantConn` + `authorize_ticket_access`. `audit_context_lint` is the
+//! write-side equivalent (emitting repo fns); this is its read-side companion.
+//!
+//! ## What is matched
+//!
+//! A handler is flagged when it holds a raw connection (`pool.get()` /
+//! `db_conn(`), does NOT pin it (`with_actor_context` / `with_actor_bypass_context`
+//! / `pin_workspace` / `pin_request_workspace` / `run_in_workspace` /
+//! `background_run`), is NOT exempt, AND calls one of:
+//!   - the access-check family, matched by naming convention: `authorize_*`,
+//!     `can_view_*`, `can_access_*`, `can_user_access_*` (these MUST run pinned),
+//!   - a known handler-level tenant existence reader (see `TENANT_READERS`).
+//!
+//! ## Escape hatch
+//!
+//! Put `// tenant-read-exempt: <reason>` directly above the `pub [async] fn`
+//! when the read is provably safe (e.g. the conn is pinned in a helper the
+//! scanner can't see, or the read is a platform/global table, not tenant data).
+
+use regex::Regex;
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Handler-level tenant readers that produce an authorization-relevant result.
+/// Extend this when a new handler does an ad-hoc tenant existence/lookup check
+/// on a connection it holds (prefer routing through `authorize_*` instead).
+const TENANT_READERS: &[&str] = &["get_ticket_by_id", "get_complete_ticket"];
+
+/// Access-check fns are matched by these name prefixes, so the list never drifts
+/// as new ones are added — any `authorize_*` / `can_view_*` etc. must run pinned.
+const ACCESS_PREFIXES: &[&str] = &["authorize_", "can_view_", "can_access_", "can_user_access_"];
+
+#[derive(Debug)]
+struct Violation {
+    relpath: String,
+    handler: String,
+    called: String,
+}
+
+#[test]
+fn handler_authz_reads_run_on_a_pinned_connection() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let handler_root = manifest.join("src/handlers");
+    assert!(handler_root.exists());
+
+    let fn_re = Regex::new(
+        r"(?m)^(?P<indent>[ \t]*)pub(?:\s*\([^)]*\))?\s+(?:async\s+)?fn\s+(?P<name>\w+)\s*[<(]",
+    )
+    .unwrap();
+    let raw_conn_re = Regex::new(r"\bdb_conn\s*\(|\bpool\s*\.\s*get\s*\(").unwrap();
+    let pin_re = Regex::new(
+        r"with_actor_context|with_actor_bypass_context|pin_workspace|pin_request_workspace|run_in_workspace|background_run",
+    )
+    .unwrap();
+    // Calls to a matched authorization read: any access-prefix fn, or one of the
+    // explicit tenant readers. `\bNAME\s*(`.
+    let mut patterns: Vec<String> = ACCESS_PREFIXES
+        .iter()
+        .map(|p| format!(r"\b{}\w+\s*\(", regex::escape(p)))
+        .collect();
+    patterns.extend(
+        TENANT_READERS
+            .iter()
+            .map(|n| format!(r"\b{}\s*\(", regex::escape(n))),
+    );
+    let call_re = Regex::new(&patterns.join("|")).unwrap();
+    // Extract which name actually matched, for the error message.
+    let name_re = Regex::new(r"\b(\w+)\s*\(").unwrap();
+
+    let mut violations: Vec<Violation> = Vec::new();
+
+    for entry in WalkDir::new(&handler_root)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+    {
+        let path = entry.path();
+        let raw = match fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let src = strip_block_comments(&strip_test_modules(&raw));
+        let relpath = format!(
+            "handlers/{}",
+            path.strip_prefix(&handler_root)
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/")
+        );
+
+        for func in iter_pub_fns(&src, &fn_re) {
+            if func.exempt || !raw_conn_re.is_match(&func.body) || pin_re.is_match(&func.body) {
+                continue;
+            }
+            if let Some(m) = call_re.find(&func.body) {
+                let called = name_re
+                    .captures(m.as_str())
+                    .and_then(|c| c.get(1))
+                    .map(|g| g.as_str().to_string())
+                    .unwrap_or_else(|| m.as_str().to_string());
+                violations.push(Violation {
+                    relpath: relpath.clone(),
+                    handler: func.name.clone(),
+                    called,
+                });
+            }
+        }
+    }
+
+    if !violations.is_empty() {
+        let mut msg = String::from(
+            "\nHandlers make an authorization-relevant tenant read on a RAW (un-pinned)\n\
+             connection. Under the NOBYPASSRLS app role this fails closed (RLS-zero),\n\
+             so it 404s in production and bypasses the app-layer membership/visibility\n\
+             gate. (Isolation itself is RLS + the P0.2 boot guard; this is a\n\
+             correctness/defense-in-depth nudge.) Fix by either:\n\
+             - taking the `TenantConn` extractor and routing the read through it\n\
+               (preferred: `authorize_ticket_access(&mut tc, &auth, id)`), or\n\
+             - pinning the connection (`pin_workspace` / `with_actor_context`),\n\
+             or, if provably safe, add directly above the fn:\n  \
+             // tenant-read-exempt: <reason>\n\n\
+             Offending handlers:\n\n",
+        );
+        for v in &violations {
+            msg.push_str(&format!(
+                "  {}::{}  (calls `{}` on a raw conn)\n",
+                v.relpath, v.handler, v.called
+            ));
+        }
+        panic!("{msg}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scanning helpers (mirrors audit_context_lint.rs / sync_emit_lint.rs;
+// integration-test crates can't share private items, so the small scanners
+// are duplicated.)
+// ---------------------------------------------------------------------------
+
+struct PubFn {
+    name: String,
+    body: String,
+    exempt: bool,
+}
+
+fn iter_pub_fns(src: &str, fn_re: &Regex) -> Vec<PubFn> {
+    let mut out = Vec::new();
+    let lines: Vec<&str> = src.lines().collect();
+    let mut line_starts = Vec::with_capacity(lines.len() + 1);
+    let mut off = 0usize;
+    for line in &lines {
+        line_starts.push(off);
+        off += line.len() + 1;
+    }
+    line_starts.push(off);
+
+    for caps in fn_re.captures_iter(src) {
+        let name = caps.name("name").unwrap().as_str().to_string();
+        let match_start = caps.get(0).unwrap().start();
+        let header_end = caps.get(0).unwrap().end();
+
+        let Some(open_brace) = src[header_end..].find('{') else {
+            continue;
+        };
+        let body_start = header_end + open_brace + 1;
+        let mut depth = 1usize;
+        let mut i = body_start;
+        let bytes = src.as_bytes();
+        while i < bytes.len() && depth > 0 {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => depth -= 1,
+                _ => {}
+            }
+            i += 1;
+        }
+        let body = src[body_start..i.saturating_sub(1)].to_string();
+
+        let pub_line = line_starts.partition_point(|&start| start <= match_start) - 1;
+        let mut cursor = pub_line;
+        while cursor > 0 {
+            let prev = lines[cursor - 1].trim_start();
+            if prev.starts_with("///")
+                || prev.starts_with("//!")
+                || prev.starts_with("#[")
+                || prev.is_empty()
+            {
+                cursor -= 1;
+                continue;
+            }
+            break;
+        }
+        let exempt = cursor > 0
+            && lines[cursor - 1]
+                .trim_start()
+                .starts_with("// tenant-read-exempt:");
+
+        out.push(PubFn { name, body, exempt });
+    }
+    out
+}
+
+fn strip_test_modules(src: &str) -> String {
+    let lines: Vec<&str> = src.lines().collect();
+    let mut keep: Vec<&str> = Vec::with_capacity(lines.len());
+    let mut i = 0usize;
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if trimmed.starts_with("#[cfg(test)]") {
+            let mut j = i + 1;
+            while j < lines.len() && lines[j].trim().is_empty() {
+                j += 1;
+            }
+            let next = lines.get(j).map(|l| l.trim_start()).unwrap_or("");
+            if next.starts_with("mod ") || next.starts_with("pub mod ") {
+                let mut depth = 0i32;
+                let mut started = false;
+                let mut k = j;
+                while k < lines.len() {
+                    for &b in lines[k].as_bytes() {
+                        match b {
+                            b'{' => {
+                                depth += 1;
+                                started = true;
+                            }
+                            b'}' => depth -= 1,
+                            _ => {}
+                        }
+                    }
+                    k += 1;
+                    if started && depth == 0 {
+                        break;
+                    }
+                }
+                i = k;
+                continue;
+            }
+        }
+        keep.push(lines[i]);
+        i += 1;
+    }
+    keep.join("\n")
+}
+
+fn strip_block_comments(src: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let mut i = 0usize;
+    let bytes = src.as_bytes();
+    while i < bytes.len() {
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            if let Some(end) = src[i + 2..].find("*/") {
+                for c in src[i..i + 2 + end + 2].chars() {
+                    if c == '\n' {
+                        out.push('\n');
+                    }
+                }
+                i = i + 2 + end + 2;
+                continue;
+            }
+            out.push_str(&src[i..]);
+            break;
+        }
+        let ch = src[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+#[allow(dead_code)]
+fn _unused(_: &Path) {}

--- a/backend/tests/portal_session.rs
+++ b/backend/tests/portal_session.rs
@@ -161,4 +161,38 @@ fn portal_session_establishment_and_gate() {
             .expect_err("an unbound portal token must be denied");
         assert_eq!(status_of(&err), 403, "unbound portal token must be 403");
     }
+
+    // --- magic-link token is single-use and resolves to the customer ---
+    {
+        use backend::utils::reset_tokens::{ResetTokenUtils, TokenType};
+        let mut conn = pool.get().expect("conn");
+        let token = ResetTokenUtils::create_reset_token(customer.uuid, TokenType::PortalMagicLink);
+        backend::repository::reset_tokens::create_reset_token(
+            &mut conn,
+            &token.token_hash,
+            customer.uuid,
+            TokenType::PortalMagicLink.as_str(),
+            None,
+            None,
+            token.expires_at,
+            None,
+        )
+        .expect("issue magic-link token");
+
+        let resolved = backend::repository::reset_tokens::validate_and_consume_token(
+            &mut conn,
+            &token.raw_token,
+            TokenType::PortalMagicLink.as_str(),
+        )
+        .expect("a fresh magic-link token resolves to its user");
+        assert_eq!(resolved, customer.uuid, "token resolves to the customer");
+
+        // Single-use: a second consume of the same token fails.
+        backend::repository::reset_tokens::validate_and_consume_token(
+            &mut conn,
+            &token.raw_token,
+            TokenType::PortalMagicLink.as_str(),
+        )
+        .expect_err("a consumed magic-link token cannot be reused");
+    }
 }

--- a/backend/tests/portal_session.rs
+++ b/backend/tests/portal_session.rs
@@ -1,0 +1,164 @@
+//! Customer-portal session primitive: establishment + the authorization gate.
+//!
+//! The portal is a separate principal realm. These tests exercise the two
+//! security-critical primitives directly (the way `workspace_selection_resolution`
+//! exercises the agent gate), independent of the actix middleware that will
+//! later wrap them:
+//!
+//! - `establish_portal_session` sets the three portal cookies.
+//! - `authorize_portal_request` admits a portal token only when it is
+//!   portal-scoped, bound to the origin's workspace, and the subject is a
+//!   member; every other case is a uniform 403.
+
+#![allow(clippy::expect_used)]
+
+use actix_web::test::TestRequest;
+use actix_web::HttpMessage as _;
+
+use backend::extractors::WorkspaceContext;
+use backend::handlers::portal::{authorize_portal_request, establish_portal_session};
+use backend::middleware::cookie_auth::PORTAL_SCOPE;
+use backend::models::Claims;
+use backend::repository::workspaces::{add_membership, find_by_id};
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+
+mod common;
+
+fn context_of(conn: &mut backend::db::DbConnection, workspace_id: i32) -> WorkspaceContext {
+    let ws = find_by_id(conn, workspace_id)
+        .expect("workspace lookup")
+        .expect("workspace exists");
+    WorkspaceContext {
+        workspace_id: ws.id,
+        workspace_uuid: ws.uuid,
+        slug: ws.slug,
+        name: ws.name,
+        custom_domain: ws.custom_domain,
+        organisation_id: ws.organisation_id,
+    }
+}
+
+/// Portal-scope claims bound to `workspace_uuid` (or `None` to omit the
+/// binding), with the given scope so we can also exercise a non-portal token.
+fn portal_claims(user_uuid: uuid::Uuid, scope: &str, workspace_uuid: Option<uuid::Uuid>) -> Claims {
+    Claims {
+        sub: user_uuid.to_string(),
+        name: "Customer".to_string(),
+        email: String::new(),
+        platform_role: "user".to_string(),
+        scope: scope.to_string(),
+        sid: Some(uuid::Uuid::new_v4().to_string()),
+        workspace_uuid,
+        exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as usize,
+        iat: chrono::Utc::now().timestamp() as usize,
+    }
+}
+
+fn status_of(err: &actix_web::Error) -> u16 {
+    err.as_response_error().status_code().as_u16()
+}
+
+#[test]
+fn portal_session_establishment_and_gate() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+
+    // acme (the customer's workspace) and other (a different tenant). The
+    // customer is a baseline Member of acme only.
+    let (acme_id, other_id, customer, stranger_uuid) = {
+        let mut conn = pool.get().expect("conn");
+        let acme = common::mint_workspace(&mut conn, "acme-portal", "Acme Portal");
+        let other = common::mint_workspace(&mut conn, "other-portal", "Other Portal");
+        let customer = common::insert_user(&mut conn, "Portal Customer");
+        let stranger = common::insert_user(&mut conn, "Portal Stranger");
+        (acme, other, customer, stranger.uuid)
+    };
+    {
+        let mut conn = pool.get().expect("conn");
+        let actor = ActorContext::user(customer.uuid, None).with_workspace(acme_id);
+        with_actor_context::<_, diesel::result::Error>(&mut conn, &actor, |c| {
+            add_membership(c, acme_id, customer.uuid, "member")?;
+            Ok(())
+        })
+        .expect("add acme membership");
+    }
+
+    let acme = {
+        let mut conn = pool.get().expect("conn");
+        context_of(&mut conn, acme_id)
+    };
+
+    // --- establish_portal_session sets the three portal cookies ---
+    {
+        let mut conn = pool.get().expect("conn");
+        let http_req = TestRequest::default().to_http_request();
+        let resp = establish_portal_session(&customer, acme.workspace_uuid, &http_req, &mut conn)
+            .expect("establishing a portal session succeeds");
+        let names: Vec<String> = resp.cookies().map(|c| c.name().to_string()).collect();
+        for expected in ["portal_access", "portal_refresh", "portal_csrf"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "missing portal cookie {expected}; got {names:?}"
+            );
+        }
+    }
+
+    // --- authorize: member with a portal token bound to the origin workspace ---
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut().insert(acme.clone());
+        let claims = portal_claims(customer.uuid, PORTAL_SCOPE, Some(acme.workspace_uuid));
+        let ctx = authorize_portal_request(&req, &mut conn, &claims)
+            .expect("member on a matching origin must be authorized");
+        assert_eq!(ctx.user_uuid, customer.uuid);
+        assert_eq!(ctx.workspace_id, acme_id);
+    }
+
+    // --- binding mismatch: token bound to acme, origin serves other ---
+    {
+        let mut conn = pool.get().expect("conn");
+        let other = context_of(&mut pool.get().expect("conn"), other_id);
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut().insert(other);
+        let claims = portal_claims(customer.uuid, PORTAL_SCOPE, Some(acme.workspace_uuid));
+        let err = authorize_portal_request(&req, &mut conn, &claims)
+            .expect_err("a token bound to another tenant must be denied");
+        assert_eq!(status_of(&err), 403, "binding mismatch must be 403");
+    }
+
+    // --- non-member: portal token for the right origin, but not a member ---
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut().insert(acme.clone());
+        let claims = portal_claims(stranger_uuid, PORTAL_SCOPE, Some(acme.workspace_uuid));
+        let err = authorize_portal_request(&req, &mut conn, &claims)
+            .expect_err("a non-member must be denied");
+        assert_eq!(status_of(&err), 403, "non-member must be 403");
+    }
+
+    // --- non-portal token is refused by the portal gate ---
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut().insert(acme.clone());
+        let claims = portal_claims(customer.uuid, "full", Some(acme.workspace_uuid));
+        let err = authorize_portal_request(&req, &mut conn, &claims)
+            .expect_err("a non-portal token must not act as a customer");
+        assert_eq!(status_of(&err), 403, "non-portal scope must be 403");
+    }
+
+    // --- portal token with no workspace binding is refused ---
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut().insert(acme.clone());
+        let claims = portal_claims(customer.uuid, PORTAL_SCOPE, None);
+        let err = authorize_portal_request(&req, &mut conn, &claims)
+            .expect_err("an unbound portal token must be denied");
+        assert_eq!(status_of(&err), 403, "unbound portal token must be 403");
+    }
+}

--- a/backend/tests/sse_workspace_binding.rs
+++ b/backend/tests/sse_workspace_binding.rs
@@ -1,0 +1,101 @@
+//! SSE workspace binding (Model C, increment 2).
+//!
+//! EventSource can't send the `X-Nosdesk-Workspace` selection header, so the
+//! selected workspace is bound into the SSE token at mint time and the stream
+//! authorizes against it. This proves the stream derives the workspace from the
+//! token and membership-gates it: a member streams, a non-member and an unknown
+//! workspace are both denied (no existence leak). It's the same tenant boundary
+//! the REST gate enforces, reached over a different transport.
+
+#![allow(clippy::expect_used)]
+
+use actix_web::{web, App};
+
+use backend::handlers::sse::{sse_events_stream, SseState};
+use backend::repository::workspaces::{add_membership, find_by_id};
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+use backend::utils::jwt::JwtUtils;
+
+mod common;
+
+fn sse_token_for(user_uuid: uuid::Uuid, workspace_uuid: Option<uuid::Uuid>) -> String {
+    if std::env::var("JWT_SECRET").is_err() {
+        std::env::set_var("JWT_SECRET", "test-secret-key-for-testing-only-32chars");
+    }
+    // common::insert_user seeds platform_role = platform_admin; the token's
+    // platform_role must match or validation rejects it (demotion guard).
+    JwtUtils::create_sse_token(&user_uuid.to_string(), "platform_admin", workspace_uuid)
+        .expect("mint sse token")
+}
+
+#[actix_web::test]
+async fn stream_authorizes_against_the_token_bound_workspace() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(4);
+
+    // Workspace `acme`; a member and a non-member.
+    let (acme_uuid, member_uuid, stranger_uuid) = {
+        let mut conn = pool.get().expect("conn");
+        let acme = common::mint_workspace(&mut conn, "acme-sse", "Acme SSE");
+        let member = common::insert_user(&mut conn, "SSE Member");
+        let stranger = common::insert_user(&mut conn, "SSE Stranger");
+        let acme_uuid = find_by_id(&mut conn, acme)
+            .expect("ws lookup")
+            .expect("ws exists")
+            .uuid;
+        let actor = ActorContext::user(member.uuid, None).with_workspace(acme);
+        with_actor_context::<_, diesel::result::Error>(&mut conn, &actor, |c| {
+            add_membership(c, acme, member.uuid, "member")?;
+            Ok(())
+        })
+        .expect("add membership");
+        (acme_uuid, member.uuid, stranger.uuid)
+    };
+
+    let server_pool = pool.clone();
+    let srv = actix_test::start(move || {
+        App::new()
+            .app_data(web::Data::new(server_pool.clone()))
+            .app_data(web::Data::new(SseState::new()))
+            .route("/api/events/stream", web::get().to(sse_events_stream))
+    });
+
+    let client = awc::Client::new();
+    let get_status = |token: String| {
+        let url = srv.url(&format!("/api/events/stream?sse_token={token}"));
+        let client = client.clone();
+        async move {
+            client
+                .get(url)
+                .send()
+                .await
+                .expect("stream request")
+                .status()
+                .as_u16()
+        }
+    };
+
+    // Member: the token's workspace resolves and they belong to it -> stream opens.
+    assert_eq!(
+        get_status(sse_token_for(member_uuid, Some(acme_uuid))).await,
+        200,
+        "member's token-bound workspace must stream"
+    );
+
+    // Non-member with a token bound to acme: denied.
+    assert_eq!(
+        get_status(sse_token_for(stranger_uuid, Some(acme_uuid))).await,
+        403,
+        "non-member's token-bound workspace must be denied"
+    );
+
+    // Token bound to an unknown workspace: denied, indistinguishable from a
+    // non-member (no workspace-existence leak).
+    assert_eq!(
+        get_status(sse_token_for(member_uuid, Some(uuid::Uuid::new_v4()))).await,
+        403,
+        "unknown token-bound workspace must be denied"
+    );
+}

--- a/backend/tests/ticket_merge.rs
+++ b/backend/tests/ticket_merge.rs
@@ -90,6 +90,7 @@ fn claims_for(user: &User) -> Claims {
         platform_role: "user".to_string(),
         scope: "full".to_string(),
         sid: None,
+        workspace_uuid: None,
         exp: (chrono::Utc::now().timestamp() + 3600) as usize,
         iat: chrono::Utc::now().timestamp() as usize,
     }

--- a/backend/tests/ticket_merge.rs
+++ b/backend/tests/ticket_merge.rs
@@ -121,6 +121,7 @@ fn spawn(pool: &common::TestPool, user: &User) -> (actix_test::TestServer, Arc<S
             slug: "default".to_string(),
             name: "Default".to_string(),
             organisation_id: None,
+            custom_domain: None,
         };
         App::new()
             .app_data(web::Data::new(pool))

--- a/backend/tests/workspace_membership_gate.rs
+++ b/backend/tests/workspace_membership_gate.rs
@@ -1,0 +1,116 @@
+//! The membership gate is the primary tenant-authorization boundary once the
+//! workspace stops being Host-derived (the v1.1 single-origin agent app, where
+//! the workspace is a client selection). Before then it was defense-in-depth.
+//!
+//! `require_workspace_membership` is the shared fail-closed check the request
+//! middleware AND the out-of-band auth paths (SSE stream, collab WS) all call,
+//! since those authenticate outside the middleware and the RLS GUC is pinned to
+//! the selected workspace *before* any check runs. So a missed gate is a
+//! cross-tenant breach, not a degraded query.
+//!
+//! These prove the invariants the gate must hold:
+//!  - a member of the pinned workspace passes,
+//!  - a non-member is denied with 403 (not 500, not a silent pass),
+//!  - the check reads correctly even on a raw pooled connection whose GUC is
+//!    cleared (the SSE/collab entry condition), because it pins via the actor,
+//!  - a member of a *different* workspace is still denied (the cross-tenant
+//!    case the single-origin app exposes).
+
+#![allow(clippy::expect_used)]
+
+use backend::middleware::cookie_auth::require_workspace_membership;
+use backend::repository::workspaces::add_membership;
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+
+mod common;
+
+fn status_of(err: &actix_web::Error) -> u16 {
+    err.as_response_error().status_code().as_u16()
+}
+
+#[test]
+fn member_passes_non_member_gets_403() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+
+    let (ws, member_uuid, stranger_uuid) = {
+        let mut conn = pool.get().expect("conn");
+        let ws = common::mint_workspace(&mut conn, "acme-gate", "Acme Gate");
+        let member = common::insert_user(&mut conn, "Gate Member");
+        let stranger = common::insert_user(&mut conn, "Gate Stranger");
+        (ws, member.uuid, stranger.uuid)
+    };
+    assert_ne!(ws, 1, "test needs a non-bootstrap workspace");
+
+    // Grant the member a row in `ws` only. The stranger gets none.
+    {
+        let mut conn = pool.get().expect("conn");
+        let actor = ActorContext::user(member_uuid, None).with_workspace(ws);
+        with_actor_context::<_, diesel::result::Error>(&mut conn, &actor, |c| {
+            add_membership(c, ws, member_uuid, "member")?;
+            Ok(())
+        })
+        .expect("add membership");
+    }
+
+    // A raw pooled connection with the GUC cleared (the SSE/collab entry
+    // condition): the member still resolves because the check pins via the
+    // actor, not the ambient request GUC.
+    {
+        let mut conn = pool.get().expect("conn");
+        require_workspace_membership(&mut conn, ws, member_uuid)
+            .expect("member of the pinned workspace must pass the gate");
+    }
+
+    // The stranger is denied, and specifically with 403 (a tenant-boundary
+    // refusal), not 500 (a lookup failure that could be retried or ignored).
+    {
+        let mut conn = pool.get().expect("conn");
+        let err = require_workspace_membership(&mut conn, ws, stranger_uuid)
+            .expect_err("non-member must be denied");
+        assert_eq!(status_of(&err), 403, "non-member must get 403, not {err}");
+    }
+}
+
+#[test]
+fn member_of_another_workspace_is_denied() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+
+    // A user who is a legitimate member of ws_a, attempting to select ws_b.
+    // This is the exact cross-tenant case the single-origin app exposes: the
+    // session is valid, the workspace selection is not.
+    let (ws_a, ws_b, user_uuid) = {
+        let mut conn = pool.get().expect("conn");
+        let ws_a = common::mint_workspace(&mut conn, "tenant-a", "Tenant A");
+        let ws_b = common::mint_workspace(&mut conn, "tenant-b", "Tenant B");
+        let user = common::insert_user(&mut conn, "A Member");
+        (ws_a, ws_b, user.uuid)
+    };
+
+    {
+        let mut conn = pool.get().expect("conn");
+        let actor = ActorContext::user(user_uuid, None).with_workspace(ws_a);
+        with_actor_context::<_, diesel::result::Error>(&mut conn, &actor, |c| {
+            add_membership(c, ws_a, user_uuid, "member")?;
+            Ok(())
+        })
+        .expect("add ws_a membership");
+    }
+
+    {
+        let mut conn = pool.get().expect("conn");
+        require_workspace_membership(&mut conn, ws_a, user_uuid)
+            .expect("member passes for their own workspace");
+    }
+
+    {
+        let mut conn = pool.get().expect("conn");
+        let err = require_workspace_membership(&mut conn, ws_b, user_uuid)
+            .expect_err("a member of ws_a must not pass for ws_b");
+        assert_eq!(status_of(&err), 403, "cross-tenant selection must get 403");
+    }
+}

--- a/backend/tests/workspace_selection_resolution.rs
+++ b/backend/tests/workspace_selection_resolution.rs
@@ -63,16 +63,17 @@ fn selection_header_resolves_and_gates() {
     let test_db = common::TestDb::new();
     let pool = test_db.pool_with_size(2);
 
-    // Two workspaces; a user who is a member of `acme` only.
-    let (acme_id, acme_uuid, member_uuid, stranger_uuid) = {
+    // Two workspaces; a user who is a member of `acme` only. The header carries
+    // the slug, the way the agent app URL does.
+    let (acme_id, member_uuid, stranger_uuid) = {
         let mut conn = pool.get().expect("conn");
         let acme = common::mint_workspace(&mut conn, "acme-sel", "Acme Sel");
         let _other = common::mint_workspace(&mut conn, "other-sel", "Other Sel");
         let member = common::insert_user(&mut conn, "Sel Member");
         let stranger = common::insert_user(&mut conn, "Sel Stranger");
-        let acme_uuid = context_of(&mut conn, acme).workspace_uuid;
-        (acme, acme_uuid, member.uuid, stranger.uuid)
+        (acme, member.uuid, stranger.uuid)
     };
+    let acme_slug = "acme-sel";
     {
         let mut conn = pool.get().expect("conn");
         let actor = ActorContext::user(member_uuid, None).with_workspace(acme_id);
@@ -92,7 +93,7 @@ fn selection_header_resolves_and_gates() {
     {
         let mut conn = pool.get().expect("conn");
         let req = TestRequest::default()
-            .insert_header((WORKSPACE_SELECTION_HEADER, acme_uuid.to_string()))
+            .insert_header((WORKSPACE_SELECTION_HEADER, acme_slug))
             .to_srv_request();
         enforce_workspace_membership(&req, &mut conn, &claims_for(member_uuid))
             .expect("member selecting their workspace must pass");
@@ -111,33 +112,37 @@ fn selection_header_resolves_and_gates() {
     {
         let mut conn = pool.get().expect("conn");
         let req = TestRequest::default()
-            .insert_header((WORKSPACE_SELECTION_HEADER, acme_uuid.to_string()))
+            .insert_header((WORKSPACE_SELECTION_HEADER, acme_slug))
             .to_srv_request();
         let err = enforce_workspace_membership(&req, &mut conn, &claims_for(stranger_uuid))
             .expect_err("non-member selection must be denied");
         assert_eq!(status_of(&err), 403, "non-member selection must be 403");
     }
 
-    // Unknown workspace uuid: 403, indistinguishable from non-member (no leak).
+    // Unknown slug: 403, indistinguishable from non-member (no existence leak).
     {
         let mut conn = pool.get().expect("conn");
         let req = TestRequest::default()
-            .insert_header((WORKSPACE_SELECTION_HEADER, uuid::Uuid::new_v4().to_string()))
+            .insert_header((WORKSPACE_SELECTION_HEADER, "no-such-workspace"))
             .to_srv_request();
         let err = enforce_workspace_membership(&req, &mut conn, &claims_for(member_uuid))
             .expect_err("unknown workspace must be denied");
         assert_eq!(status_of(&err), 403, "unknown workspace must be 403");
     }
 
-    // Malformed header: 400, a client error distinct from the 403 boundary.
+    // Blank header: treated as no selection (not an error). With no Host context
+    // either, there is nothing to authorize, so it passes and publishes nothing.
     {
         let mut conn = pool.get().expect("conn");
         let req = TestRequest::default()
-            .insert_header((WORKSPACE_SELECTION_HEADER, "not-a-uuid"))
+            .insert_header((WORKSPACE_SELECTION_HEADER, "   "))
             .to_srv_request();
-        let err = enforce_workspace_membership(&req, &mut conn, &claims_for(member_uuid))
-            .expect_err("malformed selection header must be rejected");
-        assert_eq!(status_of(&err), 400, "malformed header must be 400");
+        enforce_workspace_membership(&req, &mut conn, &claims_for(member_uuid))
+            .expect("blank selection header is ignored, nothing to gate");
+        assert!(
+            req.extensions().get::<WorkspaceContext>().is_none(),
+            "blank header must not publish a context"
+        );
     }
 
     // No header in selection mode: falls back to the Host-derived context the
@@ -156,7 +161,7 @@ fn selection_header_resolves_and_gates() {
     {
         let mut conn = pool.get().expect("conn");
         let req = TestRequest::default()
-            .insert_header((WORKSPACE_SELECTION_HEADER, acme_uuid.to_string()))
+            .insert_header((WORKSPACE_SELECTION_HEADER, acme_slug))
             .to_srv_request();
         // No Host-derived context either, so there is nothing to authorize: Ok,
         // and crucially no selection-derived context is published from the header.

--- a/backend/tests/workspace_selection_resolution.rs
+++ b/backend/tests/workspace_selection_resolution.rs
@@ -1,0 +1,171 @@
+//! Selection-based workspace resolution (Model C, increment 1).
+//!
+//! Under `NOSDESK_WORKSPACE_SELECTION` (hosted only) the single-origin agent
+//! app names its workspace in the `X-Nosdesk-Workspace` header instead of the
+//! Host subdomain. The auth gate (`enforce_workspace_membership`) resolves the
+//! header, membership-gates it, and publishes the selection-derived
+//! `WorkspaceContext`. This is the security-critical glue: the workspace becomes
+//! client-supplied, so the gate is the tenant boundary.
+//!
+//! Everything here runs in one `#[test]` because it mutates process-wide env;
+//! keeping it single means the toggles can't race a sibling test.
+
+#![allow(clippy::expect_used)]
+
+use actix_web::test::TestRequest;
+use actix_web::HttpMessage as _;
+
+use backend::extractors::WorkspaceContext;
+use backend::middleware::cookie_auth::enforce_workspace_membership;
+use backend::middleware::workspace_context::WORKSPACE_SELECTION_HEADER;
+use backend::models::Claims;
+use backend::repository::workspaces::{add_membership, find_by_id};
+use backend::sync::actor::ActorContext;
+use backend::sync::session::with_actor_context;
+
+mod common;
+
+fn claims_for(user_uuid: uuid::Uuid) -> Claims {
+    Claims {
+        sub: user_uuid.to_string(),
+        name: "Selector".to_string(),
+        email: String::new(),
+        platform_role: "user".to_string(),
+        scope: "full".to_string(),
+        sid: None,
+        exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as usize,
+        iat: chrono::Utc::now().timestamp() as usize,
+    }
+}
+
+fn context_of(conn: &mut backend::db::DbConnection, workspace_id: i32) -> WorkspaceContext {
+    let ws = find_by_id(conn, workspace_id)
+        .expect("workspace lookup")
+        .expect("workspace exists");
+    WorkspaceContext {
+        workspace_id: ws.id,
+        workspace_uuid: ws.uuid,
+        slug: ws.slug,
+        name: ws.name,
+        custom_domain: ws.custom_domain,
+        organisation_id: ws.organisation_id,
+    }
+}
+
+fn status_of(err: &actix_web::Error) -> u16 {
+    err.as_response_error().status_code().as_u16()
+}
+
+#[test]
+fn selection_header_resolves_and_gates() {
+    common::ensure_test_keyring();
+    let test_db = common::TestDb::new();
+    let pool = test_db.pool_with_size(2);
+
+    // Two workspaces; a user who is a member of `acme` only.
+    let (acme_id, acme_uuid, member_uuid, stranger_uuid) = {
+        let mut conn = pool.get().expect("conn");
+        let acme = common::mint_workspace(&mut conn, "acme-sel", "Acme Sel");
+        let _other = common::mint_workspace(&mut conn, "other-sel", "Other Sel");
+        let member = common::insert_user(&mut conn, "Sel Member");
+        let stranger = common::insert_user(&mut conn, "Sel Stranger");
+        let acme_uuid = context_of(&mut conn, acme).workspace_uuid;
+        (acme, acme_uuid, member.uuid, stranger.uuid)
+    };
+    {
+        let mut conn = pool.get().expect("conn");
+        let actor = ActorContext::user(member_uuid, None).with_workspace(acme_id);
+        with_actor_context::<_, diesel::result::Error>(&mut conn, &actor, |c| {
+            add_membership(c, acme_id, member_uuid, "member")?;
+            Ok(())
+        })
+        .expect("add acme membership");
+    }
+
+    // --- Selection mode ON ---
+    std::env::set_var("NOSDESK_DEPLOYMENT_MODE", "hosted");
+    std::env::set_var("NOSDESK_WORKSPACE_SELECTION", "1");
+
+    // Member selecting acme via header: allowed, and the selection-derived
+    // context is published for downstream handlers.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default()
+            .insert_header((WORKSPACE_SELECTION_HEADER, acme_uuid.to_string()))
+            .to_srv_request();
+        enforce_workspace_membership(&req, &mut conn, &claims_for(member_uuid))
+            .expect("member selecting their workspace must pass");
+        let published = req
+            .extensions()
+            .get::<WorkspaceContext>()
+            .map(|w| w.workspace_id);
+        assert_eq!(
+            published,
+            Some(acme_id),
+            "selection-derived context must be published"
+        );
+    }
+
+    // Non-member selecting acme: 403.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default()
+            .insert_header((WORKSPACE_SELECTION_HEADER, acme_uuid.to_string()))
+            .to_srv_request();
+        let err = enforce_workspace_membership(&req, &mut conn, &claims_for(stranger_uuid))
+            .expect_err("non-member selection must be denied");
+        assert_eq!(status_of(&err), 403, "non-member selection must be 403");
+    }
+
+    // Unknown workspace uuid: 403, indistinguishable from non-member (no leak).
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default()
+            .insert_header((WORKSPACE_SELECTION_HEADER, uuid::Uuid::new_v4().to_string()))
+            .to_srv_request();
+        let err = enforce_workspace_membership(&req, &mut conn, &claims_for(member_uuid))
+            .expect_err("unknown workspace must be denied");
+        assert_eq!(status_of(&err), 403, "unknown workspace must be 403");
+    }
+
+    // Malformed header: 400, a client error distinct from the 403 boundary.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default()
+            .insert_header((WORKSPACE_SELECTION_HEADER, "not-a-uuid"))
+            .to_srv_request();
+        let err = enforce_workspace_membership(&req, &mut conn, &claims_for(member_uuid))
+            .expect_err("malformed selection header must be rejected");
+        assert_eq!(status_of(&err), 400, "malformed header must be 400");
+    }
+
+    // No header in selection mode: falls back to the Host-derived context the
+    // middleware would have inserted. Member passes against it.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut()
+            .insert(context_of(&mut pool.get().expect("conn"), acme_id));
+        enforce_workspace_membership(&req, &mut conn, &claims_for(member_uuid))
+            .expect("host-derived fallback still gates members through");
+    }
+
+    // --- Selection mode OFF: header is ignored entirely ---
+    std::env::remove_var("NOSDESK_WORKSPACE_SELECTION");
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default()
+            .insert_header((WORKSPACE_SELECTION_HEADER, acme_uuid.to_string()))
+            .to_srv_request();
+        // No Host-derived context either, so there is nothing to authorize: Ok,
+        // and crucially no selection-derived context is published from the header.
+        enforce_workspace_membership(&req, &mut conn, &claims_for(stranger_uuid))
+            .expect("flag off: header is ignored, no tenant scope to gate");
+        assert!(
+            req.extensions().get::<WorkspaceContext>().is_none(),
+            "flag off must not publish a context from the header"
+        );
+    }
+
+    std::env::remove_var("NOSDESK_DEPLOYMENT_MODE");
+}

--- a/backend/tests/workspace_selection_resolution.rs
+++ b/backend/tests/workspace_selection_resolution.rs
@@ -156,6 +156,33 @@ fn selection_header_resolves_and_gates() {
             .expect("host-derived fallback still gates members through");
     }
 
+    // Origin wins over a stray selection header. A tenant-origin request (Host
+    // resolved to acme, the member's workspace) carries a header naming a
+    // DIFFERENT workspace the user is not a member of. If selection were
+    // consulted here it would 403 (non-member of other-sel); instead the
+    // origin is authoritative, the member passes against acme, and the header
+    // is ignored. This is the cross-tenant-confinement invariant: a client
+    // cannot override its own origin's tenant via a header.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default()
+            .insert_header((WORKSPACE_SELECTION_HEADER, "other-sel"))
+            .to_srv_request();
+        req.extensions_mut()
+            .insert(context_of(&mut pool.get().expect("conn"), acme_id));
+        enforce_workspace_membership(&req, &mut conn, &claims_for(member_uuid))
+            .expect("origin-derived workspace wins; stray selection header is ignored");
+        let published = req
+            .extensions()
+            .get::<WorkspaceContext>()
+            .map(|w| w.workspace_id);
+        assert_eq!(
+            published,
+            Some(acme_id),
+            "origin-derived context must remain authoritative, not the header"
+        );
+    }
+
     // --- Selection mode OFF: header is ignored entirely ---
     std::env::remove_var("NOSDESK_WORKSPACE_SELECTION");
     {

--- a/backend/tests/workspace_selection_resolution.rs
+++ b/backend/tests/workspace_selection_resolution.rs
@@ -33,6 +33,7 @@ fn claims_for(user_uuid: uuid::Uuid) -> Claims {
         platform_role: "user".to_string(),
         scope: "full".to_string(),
         sid: None,
+        workspace_uuid: None,
         exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as usize,
         iat: chrono::Utc::now().timestamp() as usize,
     }

--- a/backend/tests/workspace_selection_resolution.rs
+++ b/backend/tests/workspace_selection_resolution.rs
@@ -26,12 +26,16 @@ use backend::sync::session::with_actor_context;
 mod common;
 
 fn claims_for(user_uuid: uuid::Uuid) -> Claims {
+    claims_scoped(user_uuid, "full")
+}
+
+fn claims_scoped(user_uuid: uuid::Uuid, scope: &str) -> Claims {
     Claims {
         sub: user_uuid.to_string(),
         name: "Selector".to_string(),
         email: String::new(),
         platform_role: "user".to_string(),
-        scope: "full".to_string(),
+        scope: scope.to_string(),
         sid: None,
         workspace_uuid: None,
         exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as usize,
@@ -180,6 +184,24 @@ fn selection_header_resolves_and_gates() {
             published,
             Some(acme_id),
             "origin-derived context must remain authoritative, not the header"
+        );
+    }
+
+    // A portal-scope token is refused on the agent surface outright, even for a
+    // real member on a resolved origin. The portal is a separate principal
+    // realm; its session must never authenticate an agent request.
+    {
+        let mut conn = pool.get().expect("conn");
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut()
+            .insert(context_of(&mut pool.get().expect("conn"), acme_id));
+        let err =
+            enforce_workspace_membership(&req, &mut conn, &claims_scoped(member_uuid, "portal"))
+                .expect_err("portal-scope token must be denied on the agent surface");
+        assert_eq!(
+            status_of(&err),
+            403,
+            "portal-scope token on the agent surface must be 403"
         );
     }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2711,9 +2711,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/portal.html
+++ b/frontend/portal.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=yes, viewport-fit=cover, interactive-widget=resizes-content">
+    <meta name="HandheldFriendly" content="true">
+    <title>Support</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/portal/main.ts"></script>
+  </body>
+</html>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,7 +9,7 @@ import MobileSearchBar from './components/MobileSearchBar.vue'
 import ToastContainer from './components/common/ToastContainer.vue'
 import RouteProgress from './components/common/RouteProgress.vue'
 import LoadingSpinner from './components/common/LoadingSpinner.vue'
-import { workspaceSwitchingRef } from '@/composables/useWorkspaceSwitch'
+import { useWorkspaceSwitch } from '@/composables/useWorkspaceSwitch'
 import { GlobalSearchModal } from './components/GlobalSearch'
 import { useTitleManager } from '@/composables/useTitleManager'
 import { useMobileSearch } from '@/composables/useMobileSearch'
@@ -36,7 +36,7 @@ const brandingStore = useBrandingStore()
 useFavicon(() => brandingStore.faviconUrl)
 
 const route = useRoute()
-const isSwitchingWorkspace = workspaceSwitchingRef()
+const { isSwitchingWorkspace } = useWorkspaceSwitch()
 const router = useRouter()
 const isBlankLayout = computed(() => route.meta.layout === 'blank')
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,6 +8,8 @@ import PageHeader from './components/SiteHeader.vue'
 import MobileSearchBar from './components/MobileSearchBar.vue'
 import ToastContainer from './components/common/ToastContainer.vue'
 import RouteProgress from './components/common/RouteProgress.vue'
+import LoadingSpinner from './components/common/LoadingSpinner.vue'
+import { workspaceSwitchingRef } from '@/composables/useWorkspaceSwitch'
 import { GlobalSearchModal } from './components/GlobalSearch'
 import { useTitleManager } from '@/composables/useTitleManager'
 import { useMobileSearch } from '@/composables/useMobileSearch'
@@ -34,6 +36,7 @@ const brandingStore = useBrandingStore()
 useFavicon(() => brandingStore.faviconUrl)
 
 const route = useRoute()
+const isSwitchingWorkspace = workspaceSwitchingRef()
 const router = useRouter()
 const isBlankLayout = computed(() => route.meta.layout === 'blank')
 
@@ -234,7 +237,17 @@ onMounted(async () => {
         class="flex-1 overflow-hidden sm:pb-0"
         :class="isMobileSearchActive ? 'pb-[calc(6.5rem+env(safe-area-inset-bottom))]' : 'pb-[calc(3rem+env(safe-area-inset-bottom))]'"
       >
+        <!-- Workspace switch in flight: mask the content so neither the old
+             workspace's data (being torn down) nor the new one's empty state
+             flashes while the sync pool re-hydrates. -->
+        <div
+          v-if="isSwitchingWorkspace"
+          class="flex h-full w-full items-center justify-center text-secondary"
+        >
+          <LoadingSpinner size="md" />
+        </div>
         <RouterView
+          v-else
           v-slot="{ Component, route: viewRoute }"
           @update:ticket="titleManager.setTicket"
           @update:device="titleManager.setDevice"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,7 @@
 // App.vue
 <script setup lang="ts">
 import { RouterView, useRoute, useRouter } from 'vue-router'
+import { effectiveRouteName } from '@/router/workspaceRouting'
 import { computed, ref, onMounted, watch, nextTick } from 'vue'
 import { useFluent } from 'fluent-vue'
 import Navbar from './components/Navbar.vue'
@@ -87,13 +88,14 @@ useTicketDeletionCleanup();
 
 // Computed property to determine if on a documentation page
 const isDocumentationPage = computed(() => {
-  return route.name === 'documentation-article';
+  return effectiveRouteName(route) === 'documentation-article';
 });
 
 // Computed property for the current page URL (for display purposes)
 const currentPageUrl = computed(() => {
   // Only show URL for certain pages
-  if (route.name === 'settings' || route.name === 'profile') {
+  const name = effectiveRouteName(route);
+  if (name === 'settings' || name === 'profile') {
     return window.location.href;
   }
   return undefined;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,6 @@
 // App.vue
 <script setup lang="ts">
 import { RouterView, useRoute, useRouter } from 'vue-router'
-import { effectiveRouteName } from '@/router/workspaceRouting'
 import { computed, ref, onMounted, watch, nextTick } from 'vue'
 import { useFluent } from 'fluent-vue'
 import Navbar from './components/Navbar.vue'
@@ -88,14 +87,13 @@ useTicketDeletionCleanup();
 
 // Computed property to determine if on a documentation page
 const isDocumentationPage = computed(() => {
-  return effectiveRouteName(route) === 'documentation-article';
+  return route.name === 'documentation-article';
 });
 
 // Computed property for the current page URL (for display purposes)
 const currentPageUrl = computed(() => {
   // Only show URL for certain pages
-  const name = effectiveRouteName(route);
-  if (name === 'settings' || name === 'profile') {
+  if (route.name === 'settings' || route.name === 'profile') {
     return window.location.href;
   }
   return undefined;

--- a/frontend/src/components/RecentTickets.vue
+++ b/frontend/src/components/RecentTickets.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
+import { shareableRouteUrl } from '@/utils/shareUrl'
 import { useRecentTicketsStore } from '@/stores/recentTickets'
 import { useWorkflowStatesStore } from '@/stores/workflowStates'
 import { ref, onMounted, computed } from 'vue'
@@ -58,7 +59,8 @@ const handleTicketContextMenuSelect = async (actionId: string) => {
   const ticket = contextMenuTicket.value
   if (!ticket) return
 
-  const ticketUrl = `/tickets/${ticket.id}`
+  // Workspace-scoped in path mode so the link/new-tab opens the right tenant.
+  const ticketUrl = shareableRouteUrl('ticket-view', { id: String(ticket.id) })
 
   switch (actionId) {
     case 'open-new-tab':
@@ -66,7 +68,7 @@ const handleTicketContextMenuSelect = async (actionId: string) => {
       break
 
     case 'copy-link':
-      await copy(`${window.location.origin}${ticketUrl}`)
+      await copy(ticketUrl)
       break
 
     case 'remove-recent':

--- a/frontend/src/components/WorkspaceSwitcher.vue
+++ b/frontend/src/components/WorkspaceSwitcher.vue
@@ -12,6 +12,7 @@ import ResponsiveMenu from '@/components/common/ResponsiveMenu.vue';
 import Spinner from '@/components/common/Spinner.vue';
 import type { PopoverAnchor } from '@/composables/usePopover';
 import { useMyWorkspacesStore } from '@/stores/myWorkspaces';
+import { useWorkspaceSwitch } from '@/composables/useWorkspaceSwitch';
 
 withDefaults(
   defineProps<{
@@ -25,6 +26,7 @@ const fluent = useFluent();
 const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
 
 const store = useMyWorkspacesStore();
+const { switchWorkspace } = useWorkspaceSwitch();
 
 const open = ref(false);
 const triggerRef = ref<HTMLElement | null>(null);
@@ -54,8 +56,12 @@ function handleSelect(id: string): void {
   const workspaceId = Number(id.slice(3));
   const entry = store.workspaces.find((w) => w.workspace_id === workspaceId);
   if (!entry) return;
+  if (entry.workspace_id === store.activeWorkspaceId) {
+    open.value = false;
+    return;
+  }
   open.value = false;
-  store.switchTo(entry);
+  void switchWorkspace(entry);
 }
 
 const triggerTitle = computed(() => {

--- a/frontend/src/components/editor/ticketLinkPlugin.ts
+++ b/frontend/src/components/editor/ticketLinkPlugin.ts
@@ -5,6 +5,7 @@ import { Node as ProseMirrorNode } from 'prosemirror-model'
 import { InputRule } from 'prosemirror-inputrules'
 import { getTicketById } from '@/services/ticketService'
 import { translate } from '@/i18n'
+import { shareableRouteUrl } from '@/utils/shareUrl'
 import {
   type TicketCardData,
   renderTicketCardHtml
@@ -219,7 +220,7 @@ export function createTicketLinkPlugin(): Plugin {
               const data = JSON.parse(jsonData)
               if (data.ticketId) {
                 ticketId = data.ticketId
-                href = `${window.location.origin}/tickets/${ticketId}`
+                href = shareableRouteUrl('ticket-view', { id: String(ticketId) })
               }
             } catch {
               // Invalid JSON, ignore

--- a/frontend/src/components/ticketComponents/TicketDetails.vue
+++ b/frontend/src/components/ticketComponents/TicketDetails.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watchEffect, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
+import { shareableRouteUrl } from '@/utils/shareUrl';
 import { useFluent } from 'fluent-vue';
 import { stripHtml } from '@/composables/useSanitise';
 import type { TicketPriority } from '@/constants/ticketOptions';
@@ -639,10 +640,10 @@ const hasReferences = computed<boolean>(
     linkedDocLinks.value.length > 0,
 );
 
-// Generate QR code for ticket URL (for print)
+// Generate QR code for ticket URL (for print). Workspace-scoped in path mode.
 const ticketUrl = computed(() => {
   if (typeof window === 'undefined') return '';
-  return `${window.location.origin}/tickets/${props.ticket.id}`;
+  return shareableRouteUrl('ticket-view', { id: String(props.ticket.id) });
 });
 
 watchEffect(async () => {

--- a/frontend/src/composables/useTicketDeletionCleanup.ts
+++ b/frontend/src/composables/useTicketDeletionCleanup.ts
@@ -32,6 +32,7 @@
  */
 import { useRoute, useRouter } from 'vue-router'
 import { useQueryCache } from '@pinia/colada'
+import { effectiveRouteName } from '@/router/workspaceRouting'
 
 import { useSyncActions } from '@/composables/useSyncActions'
 import { useCollabSessionStore } from '@/stores/collabSession'
@@ -77,7 +78,7 @@ export function useTicketDeletionCleanup(): void {
     // If we're currently viewing the ticket that just got deleted,
     // navigate away before the next render tries to read from
     // half-purged state.
-    if (route.name === 'ticket-view' && Number(route.params.id) === id) {
+    if (effectiveRouteName(route) === 'ticket-view' && Number(route.params.id) === id) {
       void router.push('/tickets')
     }
   }

--- a/frontend/src/composables/useTicketDeletionCleanup.ts
+++ b/frontend/src/composables/useTicketDeletionCleanup.ts
@@ -32,7 +32,6 @@
  */
 import { useRoute, useRouter } from 'vue-router'
 import { useQueryCache } from '@pinia/colada'
-import { effectiveRouteName } from '@/router/workspaceRouting'
 
 import { useSyncActions } from '@/composables/useSyncActions'
 import { useCollabSessionStore } from '@/stores/collabSession'
@@ -78,7 +77,7 @@ export function useTicketDeletionCleanup(): void {
     // If we're currently viewing the ticket that just got deleted,
     // navigate away before the next render tries to read from
     // half-purged state.
-    if (effectiveRouteName(route) === 'ticket-view' && Number(route.params.id) === id) {
+    if (route.name === 'ticket-view' && Number(route.params.id) === id) {
       void router.push('/tickets')
     }
   }

--- a/frontend/src/composables/useTicketDrag.ts
+++ b/frontend/src/composables/useTicketDrag.ts
@@ -1,5 +1,6 @@
 import { ref, readonly } from 'vue'
 import type { WorkflowStateCategory } from '@/types/workflow'
+import { shareableRouteUrl } from '@/utils/shareUrl'
 import { createDragEdgeScroller } from '@/composables/useDragEdgeScroll'
 
 export interface DraggableTicket {
@@ -170,8 +171,8 @@ export function useTicketDrag() {
       // Allow all effects for maximum compatibility with external apps
       event.dataTransfer.effectAllowed = 'all'
 
-      // Build ticket URL
-      const ticketUrl = `${window.location.origin}/tickets/${ticket.id}`
+      // Build ticket URL (workspace-scoped in path mode)
+      const ticketUrl = shareableRouteUrl('ticket-view', { id: String(ticket.id) })
       const ticketLabel = `#${ticket.id} ${ticket.title}`
 
       // Set multiple data formats for maximum compatibility

--- a/frontend/src/composables/useWorkspaceSwitch.ts
+++ b/frontend/src/composables/useWorkspaceSwitch.ts
@@ -52,8 +52,3 @@ export function useWorkspaceSwitch() {
 
   return { isSwitchingWorkspace, switchWorkspace };
 }
-
-/** The switch-in-flight flag, for the app shell. */
-export function workspaceSwitchingRef() {
-  return isSwitchingWorkspace;
-}

--- a/frontend/src/composables/useWorkspaceSwitch.ts
+++ b/frontend/src/composables/useWorkspaceSwitch.ts
@@ -1,0 +1,59 @@
+/**
+ * Workspace switching (Model C, increment 3, stage 5).
+ *
+ * In `path` mode (single origin) switching is an in-app teardown + re-hydrate:
+ * reset all workspace-scoped state, navigate to the new slug, and let the
+ * router's hydrate guard re-establish the sync pool + SSE for the new workspace
+ * (its IDB handle was just closed, so it bootstraps fresh), then re-fetch the
+ * new workspace's branding. `isSwitchingWorkspace` covers the gap so no stale or
+ * empty data flashes between the two workspaces.
+ *
+ * In `host` mode each workspace is a separate origin, so switching stays a full
+ * navigation to the other subdomain (today's behaviour).
+ */
+import { ref, nextTick } from 'vue';
+import { useRouter } from 'vue-router';
+import { getWorkspaceRouting } from '@/services/instanceConfig';
+import { navigateToWorkspace } from '@/utils/workspaceNavigation';
+import { logger } from '@/utils/logger';
+import type { MyWorkspaceEntry } from '@/types/workspace';
+
+/** Shared so the app shell can mask the content while a switch is in flight. */
+const isSwitchingWorkspace = ref(false);
+
+export function useWorkspaceSwitch() {
+  const router = useRouter();
+
+  async function switchWorkspace(entry: MyWorkspaceEntry): Promise<void> {
+    if (getWorkspaceRouting() !== 'path') {
+      navigateToWorkspace(entry);
+      return;
+    }
+    if (isSwitchingWorkspace.value) return;
+    isSwitchingWorkspace.value = true;
+    try {
+      // Let the shell mask the content (and unmount the current view) before we
+      // tear its data out from under it.
+      await nextTick();
+      const { resetWorkspaceScopedState } = await import('@/stores/workspaceReset');
+      await resetWorkspaceScopedState();
+      // Navigate to the new workspace's home. The prefix guard sets the active
+      // slug and the hydrate guard re-bootstraps + re-attaches SSE for it (the
+      // pool's IDB handle was closed by the reset, so it starts clean).
+      await router.push(`/${entry.slug}`);
+      const { useBrandingStore } = await import('@/stores/branding');
+      await useBrandingStore().loadBranding();
+    } catch (e) {
+      logger.error('Workspace switch failed', e);
+    } finally {
+      isSwitchingWorkspace.value = false;
+    }
+  }
+
+  return { isSwitchingWorkspace, switchWorkspace };
+}
+
+/** The switch-in-flight flag, for the app shell. */
+export function workspaceSwitchingRef() {
+  return isSwitchingWorkspace;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -52,7 +52,11 @@ app.use(router)
 import { useThemeStore } from './stores/theme'
 useThemeStore(pinia)
 
-// Wait for initial route resolution before mounting
-router.isReady().then(() => {
+// Fetch instance config (routing topology) in parallel with the initial route
+// resolution so its value is settled before first paint. The fetch defaults to
+// 'host' and never rejects, so it can't block or break the mount.
+import { fetchInstanceConfig } from './services/instanceConfig'
+
+Promise.all([fetchInstanceConfig(), router.isReady()]).then(() => {
   app.mount('#app')
 })

--- a/frontend/src/portal/App.vue
+++ b/frontend/src/portal/App.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts"></script>
+
+<template>
+  <RouterView />
+</template>

--- a/frontend/src/portal/api.ts
+++ b/frontend/src/portal/api.ts
@@ -1,0 +1,43 @@
+// Axios client for the customer portal.
+//
+// Separate from the agent `apiClient`: the portal is its own session realm
+// with its own cookies. Sends the portal cookies (withCredentials) and echoes
+// the non-httpOnly `portal_csrf` cookie as the double-submit header, which the
+// backend validates via `csrf_cookie_for_path` for `/api/portal/*`.
+import axios from 'axios'
+
+function portalCsrfToken(): string | null {
+  const match = document.cookie.match(/portal_csrf=([^;]+)/)
+  return match ? match[1] : null
+}
+
+const portalApi = axios.create({
+  baseURL: '/api/portal',
+  withCredentials: true,
+  headers: { 'Content-Type': 'application/json' },
+})
+
+portalApi.interceptors.request.use((config) => {
+  const token = portalCsrfToken()
+  if (token) {
+    config.headers['X-CSRF-Token'] = token
+  }
+  return config
+})
+
+// On an expired / missing portal session, bounce to the sign-in page (unless
+// we're already there). Dynamic import avoids a router <-> api cycle.
+portalApi.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (error?.response?.status === 401) {
+      const { default: router } = await import('./router')
+      if (router.currentRoute.value.name !== 'login') {
+        router.push('/login')
+      }
+    }
+    return Promise.reject(error)
+  },
+)
+
+export default portalApi

--- a/frontend/src/portal/main.ts
+++ b/frontend/src/portal/main.ts
@@ -1,0 +1,8 @@
+import '../assets/main.css'
+
+import { createApp } from 'vue'
+
+import App from './App.vue'
+import router from './router'
+
+createApp(App).use(router).mount('#app')

--- a/frontend/src/portal/router.ts
+++ b/frontend/src/portal/router.ts
@@ -1,0 +1,19 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+import LoginView from './views/LoginView.vue'
+import TicketsView from './views/TicketsView.vue'
+import TicketView from './views/TicketView.vue'
+
+// The portal is served at the root of its own per-tenant origin
+// (`<slug>.nosdesk.app`), so history base is '/'.
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: '/', redirect: '/tickets' },
+    { path: '/login', name: 'login', component: LoginView },
+    { path: '/tickets', name: 'tickets', component: TicketsView },
+    { path: '/tickets/:id', name: 'ticket', component: TicketView, props: true },
+  ],
+})
+
+export default router

--- a/frontend/src/portal/router.ts
+++ b/frontend/src/portal/router.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
 import LoginView from './views/LoginView.vue'
+import NewTicketView from './views/NewTicketView.vue'
 import TicketsView from './views/TicketsView.vue'
 import TicketView from './views/TicketView.vue'
 
@@ -12,6 +13,9 @@ const router = createRouter({
     { path: '/', redirect: '/tickets' },
     { path: '/login', name: 'login', component: LoginView },
     { path: '/tickets', name: 'tickets', component: TicketsView },
+    // Static `/tickets/new` before the dynamic `/tickets/:id` so it isn't
+    // captured as an id.
+    { path: '/tickets/new', name: 'ticket-new', component: NewTicketView },
     { path: '/tickets/:id', name: 'ticket', component: TicketView, props: true },
   ],
 })

--- a/frontend/src/portal/service.ts
+++ b/frontend/src/portal/service.ts
@@ -1,0 +1,52 @@
+// Customer-portal API calls. Thin wrappers over the portal axios client; the
+// shapes mirror what the backend `/api/portal` handlers return.
+import portalApi from './api'
+
+export interface PortalTicket {
+  id: number
+  title: string
+  workflow_state_id: number
+  created_at: string
+  updated_at: string
+}
+
+export interface PortalComment {
+  id: number
+  content: string
+  user_uuid: string
+  created_at: string
+}
+
+export interface PortalTicketDetail {
+  ticket: PortalTicket
+  comments: PortalComment[]
+}
+
+/** Request a passwordless sign-in link. Always resolves (uniform response). */
+export async function requestMagicLink(email: string): Promise<void> {
+  await portalApi.post('/auth/magic-link', { email })
+}
+
+/** The signed-in customer's own tickets. */
+export async function listMyTickets(): Promise<PortalTicket[]> {
+  const { data } = await portalApi.get<PortalTicket[]>('/tickets')
+  return data
+}
+
+/** One of the customer's tickets with its customer-visible thread. */
+export async function getMyTicket(id: number): Promise<PortalTicketDetail> {
+  const { data } = await portalApi.get<PortalTicketDetail>(`/tickets/${id}`)
+  return data
+}
+
+/** Open a new ticket; the description becomes the first comment. */
+export async function createMyTicket(title: string, description: string): Promise<PortalTicket> {
+  const { data } = await portalApi.post<PortalTicket>('/tickets', { title, description })
+  return data
+}
+
+/** Reply on one of the customer's own tickets. */
+export async function replyToMyTicket(id: number, content: string): Promise<PortalComment> {
+  const { data } = await portalApi.post<PortalComment>(`/tickets/${id}/comments`, { content })
+  return data
+}

--- a/frontend/src/portal/views/LoginView.vue
+++ b/frontend/src/portal/views/LoginView.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import Button from '@/components/common/Button.vue'
+import FormInput from '@/components/common/FormInput.vue'
+
+import { requestMagicLink } from '../service'
+
+const email = ref('')
+const sent = ref(false)
+const submitting = ref(false)
+
+async function submit(): Promise<void> {
+  if (!email.value.trim()) return
+  submitting.value = true
+  try {
+    await requestMagicLink(email.value.trim())
+  } finally {
+    // Uniform outcome: we always show the "check your email" state, never
+    // revealing whether the address is a known customer.
+    sent.value = true
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center p-4">
+    <div class="w-full max-w-sm">
+      <h1 class="text-xl font-semibold mb-2">Sign in to support</h1>
+      <p class="text-sm text-secondary mb-6">
+        Enter your email and we'll send you a sign-in link.
+      </p>
+
+      <p v-if="sent" class="text-sm">
+        If an account exists for that email, a sign-in link is on its way. Check
+        your inbox.
+      </p>
+      <form v-else class="flex flex-col gap-4" @submit.prevent="submit">
+        <FormInput
+          v-model="email"
+          type="email"
+          label="Email"
+          placeholder="you@example.com"
+          required
+          :disabled="submitting"
+        />
+        <Button type="submit" :loading="submitting">Send sign-in link</Button>
+      </form>
+    </div>
+  </div>
+</template>

--- a/frontend/src/portal/views/NewTicketView.vue
+++ b/frontend/src/portal/views/NewTicketView.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import Button from '@/components/common/Button.vue'
+import FormInput from '@/components/common/FormInput.vue'
+import FormTextarea from '@/components/common/FormTextarea.vue'
+
+import { createMyTicket } from '../service'
+
+const router = useRouter()
+
+const title = ref('')
+const description = ref('')
+const submitting = ref(false)
+const failed = ref(false)
+
+async function submit(): Promise<void> {
+  if (!title.value.trim()) return
+  submitting.value = true
+  failed.value = false
+  try {
+    const ticket = await createMyTicket(title.value.trim(), description.value.trim())
+    router.push(`/tickets/${ticket.id}`)
+  } catch {
+    failed.value = true
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto p-4">
+    <RouterLink to="/tickets" class="text-sm text-accent hover:underline">
+      &larr; Back to my tickets
+    </RouterLink>
+
+    <h1 class="text-xl font-semibold mt-4 mb-4">New ticket</h1>
+
+    <form class="flex flex-col gap-4" @submit.prevent="submit">
+      <FormInput
+        v-model="title"
+        label="Subject"
+        placeholder="A short summary"
+        required
+        :disabled="submitting"
+      />
+      <FormTextarea
+        v-model="description"
+        label="How can we help?"
+        placeholder="Describe your issue"
+        :rows="5"
+        :disabled="submitting"
+      />
+      <p v-if="failed" class="text-sm text-status-error">
+        Something went wrong. Please try again.
+      </p>
+      <div class="flex">
+        <Button type="submit" :loading="submitting" class="ml-auto">
+          Submit ticket
+        </Button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/frontend/src/portal/views/TicketView.vue
+++ b/frontend/src/portal/views/TicketView.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+
+import { getMyTicket, type PortalComment, type PortalTicket } from '../service'
+
+const props = defineProps<{ id: string }>()
+
+const ticket = ref<PortalTicket | null>(null)
+const comments = ref<PortalComment[]>([])
+const loading = ref(true)
+const failed = ref(false)
+
+onMounted(async () => {
+  try {
+    const detail = await getMyTicket(Number(props.id))
+    ticket.value = detail.ticket
+    comments.value = detail.comments
+  } catch {
+    failed.value = true
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto p-4">
+    <RouterLink to="/tickets" class="text-sm text-accent hover:underline">
+      &larr; Back to my tickets
+    </RouterLink>
+
+    <p v-if="loading" class="text-sm text-secondary mt-4">Loading…</p>
+    <p v-else-if="failed || !ticket" class="text-sm text-status-error mt-4">
+      This ticket couldn't be loaded.
+    </p>
+    <div v-else class="mt-4">
+      <h1 class="text-xl font-semibold mb-4">{{ ticket.title }}</h1>
+      <ul class="flex flex-col gap-3">
+        <li
+          v-for="c in comments"
+          :key="c.id"
+          class="border border-border rounded-md p-3"
+        >
+          <p class="whitespace-pre-wrap text-sm">{{ c.content }}</p>
+          <p class="text-xs text-secondary mt-2">{{ c.created_at }}</p>
+        </li>
+      </ul>
+      <p v-if="!comments.length" class="text-sm text-secondary">
+        No messages on this ticket yet.
+      </p>
+    </div>
+  </div>
+</template>

--- a/frontend/src/portal/views/TicketView.vue
+++ b/frontend/src/portal/views/TicketView.vue
@@ -2,7 +2,15 @@
 import { onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 
-import { getMyTicket, type PortalComment, type PortalTicket } from '../service'
+import Button from '@/components/common/Button.vue'
+import FormTextarea from '@/components/common/FormTextarea.vue'
+
+import {
+  getMyTicket,
+  replyToMyTicket,
+  type PortalComment,
+  type PortalTicket,
+} from '../service'
 
 const props = defineProps<{ id: string }>()
 
@@ -10,6 +18,10 @@ const ticket = ref<PortalTicket | null>(null)
 const comments = ref<PortalComment[]>([])
 const loading = ref(true)
 const failed = ref(false)
+
+const reply = ref('')
+const sending = ref(false)
+const replyFailed = ref(false)
 
 onMounted(async () => {
   try {
@@ -22,6 +34,21 @@ onMounted(async () => {
     loading.value = false
   }
 })
+
+async function sendReply(): Promise<void> {
+  if (!reply.value.trim()) return
+  sending.value = true
+  replyFailed.value = false
+  try {
+    const comment = await replyToMyTicket(Number(props.id), reply.value.trim())
+    comments.value.push(comment)
+    reply.value = ''
+  } catch {
+    replyFailed.value = true
+  } finally {
+    sending.value = false
+  }
+}
 </script>
 
 <template>
@@ -49,6 +76,24 @@ onMounted(async () => {
       <p v-if="!comments.length" class="text-sm text-secondary">
         No messages on this ticket yet.
       </p>
+
+      <form class="mt-6 flex flex-col gap-2" @submit.prevent="sendReply">
+        <FormTextarea
+          v-model="reply"
+          label="Add a reply"
+          placeholder="Type your message"
+          :rows="3"
+          :disabled="sending"
+        />
+        <p v-if="replyFailed" class="text-sm text-status-error">
+          Your reply couldn't be sent. Please try again.
+        </p>
+        <div class="flex">
+          <Button type="submit" :loading="sending" :disabled="!reply.trim()" class="ml-auto">
+            Send reply
+          </Button>
+        </div>
+      </form>
     </div>
   </div>
 </template>

--- a/frontend/src/portal/views/TicketsView.vue
+++ b/frontend/src/portal/views/TicketsView.vue
@@ -21,7 +21,12 @@ onMounted(async () => {
 
 <template>
   <div class="max-w-2xl mx-auto p-4">
-    <h1 class="text-xl font-semibold mb-4">My tickets</h1>
+    <div class="flex items-center mb-4">
+      <h1 class="text-xl font-semibold">My tickets</h1>
+      <RouterLink to="/tickets/new" class="ml-auto text-sm text-accent hover:underline">
+        New ticket
+      </RouterLink>
+    </div>
 
     <p v-if="loading" class="text-sm text-secondary">Loading your tickets…</p>
     <p v-else-if="failed" class="text-sm text-status-error">

--- a/frontend/src/portal/views/TicketsView.vue
+++ b/frontend/src/portal/views/TicketsView.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+
+import { listMyTickets, type PortalTicket } from '../service'
+
+const tickets = ref<PortalTicket[]>([])
+const loading = ref(true)
+const failed = ref(false)
+
+onMounted(async () => {
+  try {
+    tickets.value = await listMyTickets()
+  } catch {
+    failed.value = true
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto p-4">
+    <h1 class="text-xl font-semibold mb-4">My tickets</h1>
+
+    <p v-if="loading" class="text-sm text-secondary">Loading your tickets…</p>
+    <p v-else-if="failed" class="text-sm text-status-error">
+      We couldn't load your tickets. Please try again.
+    </p>
+    <ul v-else-if="tickets.length" class="flex flex-col gap-2">
+      <li v-for="t in tickets" :key="t.id">
+        <RouterLink
+          :to="`/tickets/${t.id}`"
+          class="block border border-border rounded-md p-3 hover:bg-surface-hover"
+        >
+          <span class="font-medium">{{ t.title }}</span>
+        </RouterLink>
+      </li>
+    </ul>
+    <p v-else class="text-sm text-secondary">You have no tickets yet.</p>
+  </div>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -110,6 +110,20 @@ const router = createRouter({
       }
     },
     {
+      path: '/no-workspace-access',
+      name: 'no-workspace-access',
+      component: () => import('@/views/NoWorkspaceAccessView.vue'),
+      // requiresAuth:false keeps this route bare (no `/:workspace?` prefix) so
+      // the post-login landing guard, which only fires on requiresAuth routes,
+      // never re-redirects here and loops. The user is authenticated; they just
+      // have no workspace to land on.
+      meta: {
+        layout: 'blank',
+        requiresAuth: false,
+        titleKey: 'route-title-no-workspace-access',
+      },
+    },
+    {
       path: '/submit-ticket',
       name: 'guest-submit-ticket',
       component: () => import('@/views/public/GuestTicketSubmitView.vue'),
@@ -1053,6 +1067,9 @@ async function checkAuthentication(to: RouteLocationNormalized, _from: RouteLoca
       const sub = to.fullPath === '/' ? '' : to.fullPath;
       return { path: `/${slug}${sub}` };
     }
+    // Authenticated but member of no workspace: land on a clear "no access"
+    // page rather than falling through to a workspace-required route that 404s.
+    return { name: 'no-workspace-access' };
   }
 
   // Load feature flags once per session for any authenticated route. Failures

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,7 @@
 import { createRouter, createWebHistory, type RouteLocationNormalized } from 'vue-router'
-import { withWorkspaceRouting, installWorkspaceGuard } from './workspaceRouting'
+import { withWorkspaceRouting, installWorkspaceGuard, workspaceSlugOf } from './workspaceRouting'
+import { getWorkspaceRouting } from '@/services/instanceConfig'
+import { lastWorkspaceSlug } from '@/services/activeWorkspace'
 import DashboardView from '../views/DashboardView.vue'
 import TicketView from '../views/TicketView.vue'
 import LoginView from '../views/LoginView.vue'
@@ -962,6 +964,28 @@ async function checkOnboarding(to: RouteLocationNormalized, _from: RouteLocation
 }
 
 /**
+ * Pick the workspace to land an authenticated bare-route request on (path
+ * mode). Prefer the device's last workspace when the user is still a member of
+ * it, otherwise their first membership. Loads the membership list if it isn't
+ * cached yet.
+ */
+async function defaultWorkspaceSlug(): Promise<string | null> {
+  const { useMyWorkspacesStore } = await import('@/stores/myWorkspaces');
+  const store = useMyWorkspacesStore();
+  if (store.workspaces.length === 0) {
+    try {
+      await store.refetch();
+    } catch {
+      // fall through: nothing to land on, the caller passes through
+    }
+  }
+  const slugs = store.workspaces.map((w) => w.slug);
+  const last = lastWorkspaceSlug();
+  if (last && slugs.includes(last)) return last;
+  return store.workspaces[0]?.slug ?? null;
+}
+
+/**
  * Fetch user data if authenticated but not yet loaded
  * Handles authentication state and redirects
  */
@@ -1009,6 +1033,25 @@ async function checkAuthentication(to: RouteLocationNormalized, _from: RouteLoca
   if (authStore.isAuthenticated && authStore.user) {
     if (to.path === '/login' || to.name === 'onboarding') {
       return { name: 'home' };
+    }
+  }
+
+  // Post-login landing (path mode): an authenticated request to a bare
+  // authenticated route carries no workspace in the URL (a fresh login, a
+  // bookmark to `/`, a hard reload at the apex). Send it to a concrete
+  // workspace so the slug routing, the selection header, and the per-workspace
+  // cache all engage. Host mode never has a bare-vs-slugged distinction.
+  if (
+    getWorkspaceRouting() === 'path' &&
+    requiresAuth &&
+    authStore.isAuthenticated &&
+    authStore.user &&
+    !workspaceSlugOf(to)
+  ) {
+    const slug = await defaultWorkspaceSlug();
+    if (slug) {
+      const sub = to.fullPath === '/' ? '' : to.fullPath;
+      return { path: `/${slug}${sub}` };
     }
   }
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,5 @@
 import { createRouter, createWebHistory, type RouteLocationNormalized } from 'vue-router'
-import { withWorkspaceRouting, installWorkspacePrefixGuard, effectiveRouteName } from './workspaceRouting'
+import { withWorkspaceRouting, installWorkspaceGuard } from './workspaceRouting'
 import DashboardView from '../views/DashboardView.vue'
 import TicketView from '../views/TicketView.vue'
 import LoginView from '../views/LoginView.vue'
@@ -51,10 +51,6 @@ declare module 'vue-router' {
     createButtonTextKey?: string;
     createButtonIcon?: 'plus' | 'ticket' | 'user' | 'device' | 'project' | 'document';
     preloadedDocument?: unknown;
-    /** Logical route name preserved on the anonymous `/:workspace` nested
-     * copies (slug-in-path mode), where `route.name` is undefined. Read via
-     * `effectiveRouteName` so name checks hold in both routing modes. */
-    routeName?: string;
   }
 }
 
@@ -880,9 +876,9 @@ const router = createRouter({
   ]),
 })
 
-// Slug-in-path prefix guard (Model C, path mode). Registered first so it runs
-// before the auth guards; inert in host mode. See ./workspaceRouting.
-installWorkspacePrefixGuard(router)
+// Slug-in-path workspace guard (Model C). Registered first so it runs before
+// the auth guards; inert for bare paths in host mode. See ./workspaceRouting.
+installWorkspaceGuard(router)
 
 // Update document title on navigation
 // Routes where useTitleManager handles document.title (skip generic title-setting)
@@ -890,11 +886,8 @@ const titleManagedRoutes = ['ticket', 'device', 'documentation-article'];
 
 router.beforeResolve((to) => {
   // Skip title-setting for routes managed by useTitleManager —
-  // those views set their own specific title (e.g. "#123 Fix the bug").
-  // `effectiveRouteName` so this still matches under the anonymous
-  // `/:workspace` nested copies (slug-in-path mode).
-  const routeName = effectiveRouteName(to);
-  if (routeName && titleManagedRoutes.includes(routeName)) {
+  // those views set their own specific title (e.g. "#123 Fix the bug")
+  if (titleManagedRoutes.includes(to.name as string)) {
     return;
   }
 
@@ -917,8 +910,8 @@ router.beforeResolve((to) => {
     title = translate(titleKey, titleKeyArgs);
   } else if (to.meta?.title) {
     title = to.meta.title as string;
-  } else if (routeName) {
-    title = routeName
+  } else if (to.name) {
+    title = to.name.toString()
       .split('-')
       .map(word => word.charAt(0).toUpperCase() + word.slice(1))
       .join(' ');

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory, type RouteLocationNormalized } from 'vue-router'
+import { withWorkspaceRouting, installWorkspacePrefixGuard, effectiveRouteName } from './workspaceRouting'
 import DashboardView from '../views/DashboardView.vue'
 import TicketView from '../views/TicketView.vue'
 import LoginView from '../views/LoginView.vue'
@@ -50,12 +51,16 @@ declare module 'vue-router' {
     createButtonTextKey?: string;
     createButtonIcon?: 'plus' | 'ticket' | 'user' | 'device' | 'project' | 'document';
     preloadedDocument?: unknown;
+    /** Logical route name preserved on the anonymous `/:workspace` nested
+     * copies (slug-in-path mode), where `route.name` is undefined. Read via
+     * `effectiveRouteName` so name checks hold in both routing modes. */
+    routeName?: string;
   }
 }
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  routes: [
+  routes: withWorkspaceRouting([
     {
       path: '/login',
       name: 'login',
@@ -872,8 +877,12 @@ const router = createRouter({
       path: '/:pathMatch(.*)*',
       redirect: '/error/404'
     }
-  ],
+  ]),
 })
+
+// Slug-in-path prefix guard (Model C, path mode). Registered first so it runs
+// before the auth guards; inert in host mode. See ./workspaceRouting.
+installWorkspacePrefixGuard(router)
 
 // Update document title on navigation
 // Routes where useTitleManager handles document.title (skip generic title-setting)
@@ -881,8 +890,11 @@ const titleManagedRoutes = ['ticket', 'device', 'documentation-article'];
 
 router.beforeResolve((to) => {
   // Skip title-setting for routes managed by useTitleManager —
-  // those views set their own specific title (e.g. "#123 Fix the bug")
-  if (titleManagedRoutes.includes(to.name as string)) {
+  // those views set their own specific title (e.g. "#123 Fix the bug").
+  // `effectiveRouteName` so this still matches under the anonymous
+  // `/:workspace` nested copies (slug-in-path mode).
+  const routeName = effectiveRouteName(to);
+  if (routeName && titleManagedRoutes.includes(routeName)) {
     return;
   }
 
@@ -905,8 +917,8 @@ router.beforeResolve((to) => {
     title = translate(titleKey, titleKeyArgs);
   } else if (to.meta?.title) {
     title = to.meta.title as string;
-  } else if (to.name) {
-    title = to.name.toString()
+  } else if (routeName) {
+    title = routeName
       .split('-')
       .map(word => word.charAt(0).toUpperCase() + word.slice(1))
       .join(' ');

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1039,7 +1039,10 @@ async function checkAuthentication(to: RouteLocationNormalized, _from: RouteLoca
           import('@/sync/sseBridge'),
         ]);
         const { schemaHash, instanceId } = await fetchServerIdentity();
-        await hydrate(authStore.user.uuid, schemaHash, instanceId);
+        // Key the local cache per workspace in path mode (null in host mode).
+        // The prefix guard runs before this one, so the slug is already set.
+        const { activeWorkspaceSlug } = await import('@/services/activeWorkspace');
+        await hydrate(authStore.user.uuid, schemaHash, instanceId, activeWorkspaceSlug());
         attachSseBridge();
       } catch (e) {
          

--- a/frontend/src/router/workspaceRouting.ts
+++ b/frontend/src/router/workspaceRouting.ts
@@ -26,7 +26,7 @@ import type {
   Router,
   RouteLocationNormalized,
 } from 'vue-router';
-import { getWorkspaceRouting } from '@/services/instanceConfig';
+import { fetchInstanceConfig, getWorkspaceRouting } from '@/services/instanceConfig';
 import { setActiveWorkspaceSlug } from '@/services/activeWorkspace';
 
 const WORKSPACE_PARAM = 'workspace';
@@ -80,7 +80,12 @@ function isAuthed(route: RouteLocationNormalized): boolean {
  *   routes it to a concrete workspace.
  */
 export function installWorkspaceGuard(router: Router): void {
-  router.beforeEach((to, from) => {
+  router.beforeEach(async (to, from) => {
+    // Resolve the routing mode before deciding. Memoised, so this awaits the
+    // bootstrap fetch only on the very first navigation (a cold load); every
+    // later navigation sees a settled promise. Without it a hard refresh of a
+    // slugged URL is judged in the 'host' default and 404'd mid-fetch.
+    await fetchInstanceConfig();
     const slug = workspaceSlugOf(to);
     if (getWorkspaceRouting() !== 'path') {
       return slug ? { path: '/error/404', replace: true } : true;

--- a/frontend/src/router/workspaceRouting.ts
+++ b/frontend/src/router/workspaceRouting.ts
@@ -1,0 +1,120 @@
+/**
+ * Slug-in-path workspace routing (Model C, increment 3, stage 2b).
+ *
+ * The single-origin agent app puts the selected workspace in the URL path
+ * (`app.nosdesk.com/acme/tickets/123`), Linear-style. We get there without
+ * touching the ~170 navigation call sites by keeping every route flat AND
+ * registering the authenticated ones a second time under a `/:workspace`
+ * parent (dual-mount), then redirecting bare authenticated paths onto the
+ * prefixed copy with a single guard.
+ *
+ * How a navigation flows in `path` mode:
+ *   router.push('/tickets/123')  ->  resolves to the FLAT /tickets/:id route
+ *     ->  prefix guard sees a flat authed route with no `workspace` param
+ *     ->  redirects to /<activeSlug>/tickets/123
+ *     ->  matches the nested copy and renders.
+ * Named pushes and string `<RouterLink>`s resolve to the same flat routes, so
+ * the one guard covers all of them. In `host` mode the guard is inert and the
+ * flat routes serve directly, exactly as today.
+ *
+ * Bootstrap note: both shapes are registered unconditionally, so this needs no
+ * async config at router-creation time. The routing *mode* is read at runtime
+ * by the guard, by which point `/api/config` has resolved.
+ */
+import type {
+  RouteRecordRaw,
+  Router,
+  RouteLocationNormalized,
+} from 'vue-router';
+import { getWorkspaceRouting } from '@/services/instanceConfig';
+
+const WORKSPACE_PARAM = 'workspace';
+
+/** Authenticated app routes are workspace-scoped; public routes (login, auth
+ *  callbacks, guest portal) and the catch-all stay un-prefixed. Routes default
+ *  to authenticated unless they opt out with `requiresAuth: false`. */
+function isWorkspaceScoped(r: RouteRecordRaw): boolean {
+  const requiresAuth = (r.meta?.requiresAuth ?? true) !== false;
+  const isCatchAll = typeof r.path === 'string' && r.path.includes(':pathMatch');
+  return requiresAuth && !isCatchAll;
+}
+
+/** A nested copy of a flat route: same component/meta/children, path made
+ *  relative, and the name dropped (names live on the flat copies; duplicate
+ *  names are a Vue Router error). Navigation resolves to the named flat route
+ *  and the guard redirects it onto this copy. The flat name is preserved in
+ *  `meta.routeName` so logical-page checks survive the rename to anonymous
+ *  (read it via `effectiveRouteName`). */
+function toNestedChild(r: RouteRecordRaw): RouteRecordRaw {
+  const child = {
+    ...r,
+    path: r.path.replace(/^\//, ''),
+    meta: { ...r.meta, routeName: r.name },
+  } as RouteRecordRaw;
+  delete (child as { name?: unknown }).name;
+  return child;
+}
+
+/** Logical page name regardless of dual-mount: the route record's `name` on a
+ *  flat route, or the preserved `meta.routeName` on a nested copy. Use this
+ *  instead of `route.name` anywhere a check must hold in both routing modes. */
+export function effectiveRouteName(route: RouteLocationNormalized): string | null {
+  if (typeof route.name === 'string' && route.name) return route.name;
+  const metaName = route.meta?.routeName;
+  return typeof metaName === 'string' && metaName ? metaName : null;
+}
+
+/**
+ * Dual-mount the route table: flat routes as-is (host mode), plus the
+ * authenticated ones under a component-less `/:workspace` parent (path mode).
+ * The parent has no component, so its children render in App.vue's
+ * `<router-view>` exactly as the flat copies do.
+ */
+export function withWorkspaceRouting(routes: RouteRecordRaw[]): RouteRecordRaw[] {
+  const nested: RouteRecordRaw = {
+    path: `/:${WORKSPACE_PARAM}`,
+    // Inert in host mode. The nested copies only ever exist to serve `path`
+    // mode; in `host` mode (self-hosted / subdomain) a stray slug-shaped URL
+    // must 404 exactly as the catch-all does, never render a nested copy. This
+    // is what guarantees a single-workspace self-hosted instance never shows a
+    // slug in the URL: there is no reachable nested route there at all.
+    beforeEnter: () =>
+      getWorkspaceRouting() === 'path' ? true : { path: '/error/404' },
+    children: routes.filter(isWorkspaceScoped).map(toNestedChild),
+  };
+  return [...routes, nested];
+}
+
+/** The workspace slug carried by a route, or null. */
+export function workspaceSlugOf(route: RouteLocationNormalized): string | null {
+  const slug = route.params[WORKSPACE_PARAM];
+  return typeof slug === 'string' && slug ? slug : null;
+}
+
+/**
+ * Redirect bare authenticated paths onto their `/:workspace`-prefixed copy when
+ * routing in `path` mode. Inert in `host` mode. Register before the auth guards
+ * so they evaluate the final, prefixed route (a redirect re-runs the chain
+ * anyway, but ordering keeps it to one pass).
+ *
+ * The slug to prefix with comes from the route you're *currently* on (`from`):
+ * a link to `/tickets/5` clicked while on `/acme/...` becomes `/acme/tickets/5`.
+ * When `from` carries no workspace (a deep link's first navigation, or host->
+ * path transition) the navigation passes through unprefixed; the post-login
+ * landing (stage 5) is what routes a bare entry to a concrete workspace.
+ */
+export function installWorkspacePrefixGuard(router: Router): void {
+  router.beforeEach((to, from) => {
+    if (getWorkspaceRouting() !== 'path') return true;
+    // Already on a nested (prefixed) route.
+    if (workspaceSlugOf(to)) return true;
+    // Only authenticated app routes get a workspace; public routes stay bare.
+    const requiresAuth = to.matched.some(
+      (r) => (r.meta?.requiresAuth ?? true) !== false,
+    );
+    if (!requiresAuth) return true;
+    const slug = workspaceSlugOf(from);
+    if (!slug) return true;
+    return { path: `/${slug}${to.fullPath}`, replace: true };
+  });
+}

--- a/frontend/src/router/workspaceRouting.ts
+++ b/frontend/src/router/workspaceRouting.ts
@@ -2,24 +2,24 @@
  * Slug-in-path workspace routing (Model C, increment 3, stage 2b).
  *
  * The single-origin agent app puts the selected workspace in the URL path
- * (`app.nosdesk.com/acme/tickets/123`), Linear-style. We get there without
- * touching the ~170 navigation call sites by keeping every route flat AND
- * registering the authenticated ones a second time under a `/:workspace`
- * parent (dual-mount), then redirecting bare authenticated paths onto the
- * prefixed copy with a single guard.
+ * (`app.nosdesk.com/acme/tickets/123`), Linear-style, while self-hosted /
+ * subdomain installs keep bare paths (`/tickets/123`). Both come from ONE named
+ * route per page: each authenticated route gets an *optional* leading
+ * `/:workspace?` segment, so the same record matches the bare and the
+ * slug-prefixed URL. `route.name`, children, and meta all work unchanged in both
+ * modes, so nothing downstream has to special-case the routing.
  *
  * How a navigation flows in `path` mode:
- *   router.push('/tickets/123')  ->  resolves to the FLAT /tickets/:id route
- *     ->  prefix guard sees a flat authed route with no `workspace` param
- *     ->  redirects to /<activeSlug>/tickets/123
- *     ->  matches the nested copy and renders.
- * Named pushes and string `<RouterLink>`s resolve to the same flat routes, so
- * the one guard covers all of them. In `host` mode the guard is inert and the
- * flat routes serve directly, exactly as today.
+ *   router.push('/tickets/123')  ->  resolves to /:workspace?/tickets/:id with
+ *     the workspace absent  ->  the guard prefixes it with the workspace of the
+ *     route you're currently on  ->  /acme/tickets/123.
+ * Every `router.push`, named push, and string `<RouterLink>` resolves to the
+ * same record, so the one guard covers all ~170 call sites untouched. In `host`
+ * mode the optional segment must never be exercised: a URL that resolved a
+ * workspace slug is a stray path and is 404'd, preserving today's behaviour.
  *
- * Bootstrap note: both shapes are registered unconditionally, so this needs no
- * async config at router-creation time. The routing *mode* is read at runtime
- * by the guard, by which point `/api/config` has resolved.
+ * Both shapes come from one route table, so this needs no async config at
+ * router-creation time; the routing *mode* is read at runtime by the guard.
  */
 import type {
   RouteRecordRaw,
@@ -31,58 +31,27 @@ import { getWorkspaceRouting } from '@/services/instanceConfig';
 const WORKSPACE_PARAM = 'workspace';
 
 /** Authenticated app routes are workspace-scoped; public routes (login, auth
- *  callbacks, guest portal) and the catch-all stay un-prefixed. Routes default
- *  to authenticated unless they opt out with `requiresAuth: false`. */
+ *  callbacks, guest portal) and the catch-all stay bare. Routes default to
+ *  authenticated unless they opt out with `requiresAuth: false`. */
 function isWorkspaceScoped(r: RouteRecordRaw): boolean {
   const requiresAuth = (r.meta?.requiresAuth ?? true) !== false;
   const isCatchAll = typeof r.path === 'string' && r.path.includes(':pathMatch');
   return requiresAuth && !isCatchAll;
 }
 
-/** A nested copy of a flat route: same component/meta/children, path made
- *  relative, and the name dropped (names live on the flat copies; duplicate
- *  names are a Vue Router error). Navigation resolves to the named flat route
- *  and the guard redirects it onto this copy. The flat name is preserved in
- *  `meta.routeName` so logical-page checks survive the rename to anonymous
- *  (read it via `effectiveRouteName`). */
-function toNestedChild(r: RouteRecordRaw): RouteRecordRaw {
-  const child = {
-    ...r,
-    path: r.path.replace(/^\//, ''),
-    meta: { ...r.meta, routeName: r.name },
-  } as RouteRecordRaw;
-  delete (child as { name?: unknown }).name;
-  return child;
-}
-
-/** Logical page name regardless of dual-mount: the route record's `name` on a
- *  flat route, or the preserved `meta.routeName` on a nested copy. Use this
- *  instead of `route.name` anywhere a check must hold in both routing modes. */
-export function effectiveRouteName(route: RouteLocationNormalized): string | null {
-  if (typeof route.name === 'string' && route.name) return route.name;
-  const metaName = route.meta?.routeName;
-  return typeof metaName === 'string' && metaName ? metaName : null;
-}
-
 /**
- * Dual-mount the route table: flat routes as-is (host mode), plus the
- * authenticated ones under a component-less `/:workspace` parent (path mode).
- * The parent has no component, so its children render in App.vue's
- * `<router-view>` exactly as the flat copies do.
+ * Give every authenticated route an optional leading `/:workspace?` so one
+ * named record serves both the bare and the slug-prefixed URL. The home route
+ * (`/`) becomes `/:workspace?`; everything else is prefixed in place. Children
+ * are relative, so they ride along under both forms automatically.
  */
 export function withWorkspaceRouting(routes: RouteRecordRaw[]): RouteRecordRaw[] {
-  const nested: RouteRecordRaw = {
-    path: `/:${WORKSPACE_PARAM}`,
-    // Inert in host mode. The nested copies only ever exist to serve `path`
-    // mode; in `host` mode (self-hosted / subdomain) a stray slug-shaped URL
-    // must 404 exactly as the catch-all does, never render a nested copy. This
-    // is what guarantees a single-workspace self-hosted instance never shows a
-    // slug in the URL: there is no reachable nested route there at all.
-    beforeEnter: () =>
-      getWorkspaceRouting() === 'path' ? true : { path: '/error/404' },
-    children: routes.filter(isWorkspaceScoped).map(toNestedChild),
-  };
-  return [...routes, nested];
+  return routes.map((r) => {
+    if (!isWorkspaceScoped(r)) return r;
+    const path =
+      r.path === '/' ? `/:${WORKSPACE_PARAM}?` : `/:${WORKSPACE_PARAM}?${r.path}`;
+    return { ...r, path };
+  });
 }
 
 /** The workspace slug carried by a route, or null. */
@@ -91,30 +60,34 @@ export function workspaceSlugOf(route: RouteLocationNormalized): string | null {
   return typeof slug === 'string' && slug ? slug : null;
 }
 
+function isAuthed(route: RouteLocationNormalized): boolean {
+  return route.matched.some((r) => (r.meta?.requiresAuth ?? true) !== false);
+}
+
 /**
- * Redirect bare authenticated paths onto their `/:workspace`-prefixed copy when
- * routing in `path` mode. Inert in `host` mode. Register before the auth guards
- * so they evaluate the final, prefixed route (a redirect re-runs the chain
- * anyway, but ordering keeps it to one pass).
+ * Workspace URL guard. Register before the auth guards so they evaluate the
+ * final route (a redirect re-runs the chain anyway, but ordering keeps it to
+ * one pass).
  *
- * The slug to prefix with comes from the route you're *currently* on (`from`):
- * a link to `/tickets/5` clicked while on `/acme/...` becomes `/acme/tickets/5`.
- * When `from` carries no workspace (a deep link's first navigation, or host->
- * path transition) the navigation passes through unprefixed; the post-login
- * landing (stage 5) is what routes a bare entry to a concrete workspace.
+ * - **host mode**: the optional segment must never be exercised. A URL that
+ *   resolved a workspace slug is a stray path; 404 it, matching the behaviour
+ *   from before slug routing existed. Self-hosted thus never shows a slug.
+ * - **path mode**: a bare authenticated path is prefixed with the workspace of
+ *   the route you're currently on (`from`), so `/tickets/5` clicked while on
+ *   `/acme/...` becomes `/acme/tickets/5`. A bare entry with no `from` workspace
+ *   (a deep link's first hop) passes through; the post-login landing (stage 5)
+ *   routes it to a concrete workspace.
  */
-export function installWorkspacePrefixGuard(router: Router): void {
+export function installWorkspaceGuard(router: Router): void {
   router.beforeEach((to, from) => {
-    if (getWorkspaceRouting() !== 'path') return true;
-    // Already on a nested (prefixed) route.
-    if (workspaceSlugOf(to)) return true;
-    // Only authenticated app routes get a workspace; public routes stay bare.
-    const requiresAuth = to.matched.some(
-      (r) => (r.meta?.requiresAuth ?? true) !== false,
-    );
-    if (!requiresAuth) return true;
-    const slug = workspaceSlugOf(from);
-    if (!slug) return true;
-    return { path: `/${slug}${to.fullPath}`, replace: true };
+    const slug = workspaceSlugOf(to);
+    if (getWorkspaceRouting() !== 'path') {
+      return slug ? { path: '/error/404', replace: true } : true;
+    }
+    if (slug) return true;
+    if (!isAuthed(to)) return true;
+    const fromSlug = workspaceSlugOf(from);
+    if (!fromSlug) return true;
+    return { path: `/${fromSlug}${to.fullPath}`, replace: true };
   });
 }

--- a/frontend/src/router/workspaceRouting.ts
+++ b/frontend/src/router/workspaceRouting.ts
@@ -27,6 +27,7 @@ import type {
   RouteLocationNormalized,
 } from 'vue-router';
 import { getWorkspaceRouting } from '@/services/instanceConfig';
+import { setActiveWorkspaceSlug } from '@/services/activeWorkspace';
 
 const WORKSPACE_PARAM = 'workspace';
 
@@ -84,7 +85,13 @@ export function installWorkspaceGuard(router: Router): void {
     if (getWorkspaceRouting() !== 'path') {
       return slug ? { path: '/error/404', replace: true } : true;
     }
-    if (slug) return true;
+    if (slug) {
+      // On a workspace route: publish the slug so the axios interceptor sends
+      // it as the selection header. Set here (beforeEach), before route loaders
+      // fire, so the first data fetch on a fresh navigation already carries it.
+      setActiveWorkspaceSlug(slug);
+      return true;
+    }
     if (!isAuthed(to)) return true;
     const fromSlug = workspaceSlugOf(from);
     if (!fromSlug) return true;

--- a/frontend/src/services/activeWorkspace.ts
+++ b/frontend/src/services/activeWorkspace.ts
@@ -37,6 +37,15 @@ export function activeWorkspaceSlug(): string | null {
 /** Reactive read, for UI (the workspace switcher's active-workspace highlight). */
 export const activeWorkspaceSlugRef: Readonly<Ref<string | null>> = readonly(slug);
 
+/**
+ * The selection header to attach to a request, or `{}` when none. One place for
+ * the header name + slug read, shared by the axios interceptor and the sync
+ * engine's raw `fetch` calls (which the interceptor doesn't see).
+ */
+export function workspaceHeaders(): Record<string, string> {
+  return slug.value ? { 'X-Nosdesk-Workspace': slug.value } : {};
+}
+
 /** The last workspace slug this device was on, for the post-login landing. */
 export function lastWorkspaceSlug(): string | null {
   try {

--- a/frontend/src/services/activeWorkspace.ts
+++ b/frontend/src/services/activeWorkspace.ts
@@ -1,18 +1,22 @@
 /**
- * The active workspace slug, as a plain module value.
+ * The active workspace slug — the single source of truth for which workspace
+ * the agent app is on in path mode.
  *
- * Decoupled on purpose (no imports): the router keeps it in sync on navigation
- * and the axios interceptor reads it to set the `X-Nosdesk-Workspace` header,
- * without either side importing the other (which would cycle through the store
- * and router). Only set in path mode; `null` in host mode means no header is
- * sent and the backend resolves the workspace from the Host, as today.
+ * Deliberately depends only on `vue` (a leaf): the router keeps it in sync on
+ * navigation, the axios interceptor reads it to set the `X-Nosdesk-Workspace`
+ * header, and reactive consumers (the switcher via the myWorkspaces store) read
+ * the ref, all without importing the router or store (which would cycle). Only
+ * set in path mode; `null` in host mode means no header is sent and the backend
+ * resolves the workspace from the Host, as today.
  */
+import { readonly, ref, type Ref } from 'vue';
+
 const LAST_WORKSPACE_KEY = 'nosdesk:last-workspace';
 
-let slug: string | null = null;
+const slug = ref<string | null>(null);
 
 export function setActiveWorkspaceSlug(next: string | null): void {
-  slug = next;
+  slug.value = next;
   // Remember the last workspace the user was on so the post-login landing can
   // return them there. Only persist a real slug; clearing on logout/switch
   // (null) must not erase the memory.
@@ -25,9 +29,13 @@ export function setActiveWorkspaceSlug(next: string | null): void {
   }
 }
 
+/** Non-reactive read, for the axios interceptor / sync engine (outside Vue). */
 export function activeWorkspaceSlug(): string | null {
-  return slug;
+  return slug.value;
 }
+
+/** Reactive read, for UI (the workspace switcher's active-workspace highlight). */
+export const activeWorkspaceSlugRef: Readonly<Ref<string | null>> = readonly(slug);
 
 /** The last workspace slug this device was on, for the post-login landing. */
 export function lastWorkspaceSlug(): string | null {

--- a/frontend/src/services/activeWorkspace.ts
+++ b/frontend/src/services/activeWorkspace.ts
@@ -7,12 +7,33 @@
  * and router). Only set in path mode; `null` in host mode means no header is
  * sent and the backend resolves the workspace from the Host, as today.
  */
+const LAST_WORKSPACE_KEY = 'nosdesk:last-workspace';
+
 let slug: string | null = null;
 
 export function setActiveWorkspaceSlug(next: string | null): void {
   slug = next;
+  // Remember the last workspace the user was on so the post-login landing can
+  // return them there. Only persist a real slug; clearing on logout/switch
+  // (null) must not erase the memory.
+  if (next) {
+    try {
+      localStorage.setItem(LAST_WORKSPACE_KEY, next);
+    } catch {
+      // ignore (private mode / quota)
+    }
+  }
 }
 
 export function activeWorkspaceSlug(): string | null {
   return slug;
+}
+
+/** The last workspace slug this device was on, for the post-login landing. */
+export function lastWorkspaceSlug(): string | null {
+  try {
+    return localStorage.getItem(LAST_WORKSPACE_KEY);
+  } catch {
+    return null;
+  }
 }

--- a/frontend/src/services/activeWorkspace.ts
+++ b/frontend/src/services/activeWorkspace.ts
@@ -1,0 +1,18 @@
+/**
+ * The active workspace slug, as a plain module value.
+ *
+ * Decoupled on purpose (no imports): the router keeps it in sync on navigation
+ * and the axios interceptor reads it to set the `X-Nosdesk-Workspace` header,
+ * without either side importing the other (which would cycle through the store
+ * and router). Only set in path mode; `null` in host mode means no header is
+ * sent and the backend resolves the workspace from the Host, as today.
+ */
+let slug: string | null = null;
+
+export function setActiveWorkspaceSlug(next: string | null): void {
+  slug = next;
+}
+
+export function activeWorkspaceSlug(): string | null {
+  return slug;
+}

--- a/frontend/src/services/apiConfig.ts
+++ b/frontend/src/services/apiConfig.ts
@@ -3,7 +3,7 @@ import { logger } from '@/utils/logger';
 import { createErrorFromResponse } from '@/utils/errors';
 import { ErrorTracker } from '@/utils/errorTracking';
 import { getSSEClientId } from '@/services/sseService';
-import { activeWorkspaceSlug as getActiveWorkspaceSlug } from '@/services/activeWorkspace';
+import { workspaceHeaders } from '@/services/activeWorkspace';
 import { getSessionId as getDiagnosticsSessionId } from '@/services/diagnostics/session';
 import { pushApi as pushApiBreadcrumb } from '@/services/diagnostics/breadcrumbs';
 import { getCsrfToken } from '@/utils/csrf';
@@ -133,12 +133,9 @@ apiClient.interceptors.request.use(
     }
 
     // Selected workspace (Model C single-origin / path mode). The router keeps
-    // this in sync with the URL slug; it's null in host mode, where the backend
+    // this in sync with the URL slug; it's empty in host mode, where the backend
     // resolves the workspace from the Host instead and ignores this header.
-    const workspaceSlug = getActiveWorkspaceSlug();
-    if (workspaceSlug) {
-      config.headers['X-Nosdesk-Workspace'] = workspaceSlug;
-    }
+    Object.assign(config.headers, workspaceHeaders());
 
     // Verbose logging (development only)
     if (import.meta.env.DEV && localStorage.getItem('api-verbose-logging') === 'true') {

--- a/frontend/src/services/apiConfig.ts
+++ b/frontend/src/services/apiConfig.ts
@@ -3,6 +3,7 @@ import { logger } from '@/utils/logger';
 import { createErrorFromResponse } from '@/utils/errors';
 import { ErrorTracker } from '@/utils/errorTracking';
 import { getSSEClientId } from '@/services/sseService';
+import { activeWorkspaceSlug as getActiveWorkspaceSlug } from '@/services/activeWorkspace';
 import { getSessionId as getDiagnosticsSessionId } from '@/services/diagnostics/session';
 import { pushApi as pushApiBreadcrumb } from '@/services/diagnostics/breadcrumbs';
 import { getCsrfToken } from '@/utils/csrf';
@@ -129,6 +130,14 @@ apiClient.interceptors.request.use(
     const sseClientId = getSSEClientId();
     if (sseClientId) {
       config.headers['X-SSE-Client-Id'] = sseClientId;
+    }
+
+    // Selected workspace (Model C single-origin / path mode). The router keeps
+    // this in sync with the URL slug; it's null in host mode, where the backend
+    // resolves the workspace from the Host instead and ignores this header.
+    const workspaceSlug = getActiveWorkspaceSlug();
+    if (workspaceSlug) {
+      config.headers['X-Nosdesk-Workspace'] = workspaceSlug;
     }
 
     // Verbose logging (development only)

--- a/frontend/src/services/instanceConfig.ts
+++ b/frontend/src/services/instanceConfig.ts
@@ -1,0 +1,42 @@
+/**
+ * Instance-level frontend config (`GET /api/config`).
+ *
+ * Fetched once at startup so the SPA knows where the selected workspace lives in
+ * the URL before it wires up routing. Instance-global (identical for every
+ * workspace); per-workspace config lives behind auth.
+ */
+import apiClient from './apiConfig';
+import { logger } from '@/utils/logger';
+
+/** Where the selected workspace lives in the URL. */
+export type WorkspaceRouting = 'host' | 'path';
+
+interface InstanceConfig {
+  workspace_routing: WorkspaceRouting;
+}
+
+// Default 'host': the subdomain / self-hosted model every current deployment
+// runs. A pending or failed fetch keeps today's behaviour and never activates
+// the single-origin slug-in-path routing.
+let workspaceRouting: WorkspaceRouting = 'host';
+
+/**
+ * Fetch instance config once at bootstrap. The endpoint is public, so this is
+ * safe before auth. Failures are swallowed and leave the 'host' default, so a
+ * config blip can never strand the app on a route topology it can't serve.
+ */
+export async function fetchInstanceConfig(): Promise<void> {
+  try {
+    const { data } = await apiClient.get<InstanceConfig>('/config');
+    if (data?.workspace_routing === 'path' || data?.workspace_routing === 'host') {
+      workspaceRouting = data.workspace_routing;
+    }
+  } catch (e) {
+    logger.error('Failed to fetch instance config; defaulting workspace_routing=host', e);
+  }
+}
+
+/** Where the workspace lives in the URL. 'host' until the config resolves. */
+export function getWorkspaceRouting(): WorkspaceRouting {
+  return workspaceRouting;
+}

--- a/frontend/src/services/instanceConfig.ts
+++ b/frontend/src/services/instanceConfig.ts
@@ -20,20 +20,32 @@ interface InstanceConfig {
 // the single-origin slug-in-path routing.
 let workspaceRouting: WorkspaceRouting = 'host';
 
+// Memoised so bootstrap and the router guard share one fetch. The guard awaits
+// this before reading the routing mode, so a cold load (hard refresh, deep link)
+// resolves the mode BEFORE the workspace guard decides. Otherwise a slugged URL
+// is judged in the 'host' default and wrongly 404'd while the fetch is in flight.
+let configPromise: Promise<void> | null = null;
+
 /**
  * Fetch instance config once at bootstrap. The endpoint is public, so this is
  * safe before auth. Failures are swallowed and leave the 'host' default, so a
  * config blip can never strand the app on a route topology it can't serve.
+ * Idempotent: repeat calls return the same in-flight/settled promise.
  */
-export async function fetchInstanceConfig(): Promise<void> {
-  try {
-    const { data } = await apiClient.get<InstanceConfig>('/config');
-    if (data?.workspace_routing === 'path' || data?.workspace_routing === 'host') {
-      workspaceRouting = data.workspace_routing;
-    }
-  } catch (e) {
-    logger.error('Failed to fetch instance config; defaulting workspace_routing=host', e);
+export function fetchInstanceConfig(): Promise<void> {
+  if (!configPromise) {
+    configPromise = (async () => {
+      try {
+        const { data } = await apiClient.get<InstanceConfig>('/config');
+        if (data?.workspace_routing === 'path' || data?.workspace_routing === 'host') {
+          workspaceRouting = data.workspace_routing;
+        }
+      } catch (e) {
+        logger.error('Failed to fetch instance config; defaulting workspace_routing=host', e);
+      }
+    })();
   }
+  return configPromise;
 }
 
 /** Where the workspace lives in the URL. 'host' until the config resolves. */

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -435,62 +435,28 @@ export const useAuthStore = defineStore('auth', () => {
     user.value = null;
     authProvider.value = null;
 
-    // Drop cached feature flags so a different user logging in afterwards
-    // doesn't briefly see the previous user's resolved flag set.
+    // Tear down everything workspace-scoped (config stores, query cache, sync
+    // pool, SSE bridge, collab caches) so a different user signing in afterwards
+    // doesn't briefly see the previous session's data. The same routine backs
+    // the in-app workspace switch. myWorkspaces needs no explicit reset: its
+    // query key is account-scoped, so clearing `user` switches it to `anon`.
     try {
-      const { useFeatureFlagsStore } = await import('@/stores/featureFlags');
-      useFeatureFlagsStore().reset();
+      const { resetWorkspaceScopedState } = await import('@/stores/workspaceReset');
+      await resetWorkspaceScopedState();
     } catch (e) {
-      logger.error('Failed to reset feature flags on logout', e);
+      logger.error('Failed to reset workspace-scoped state on logout', e);
     }
 
-    try {
-      const { useWorkflowStatesStore } = await import('@/stores/workflowStates');
-      useWorkflowStatesStore().reset();
-    } catch (e) {
-      logger.error('Failed to reset workflow states on logout', e);
-    }
-
-    // myWorkspaces no longer needs an explicit reset: its query key is
-    // scoped to the signed-in account, so clearing `user` switches it to
-    // the empty `anon` key automatically.
-
-    try {
-      const { resetWorkspaceCapabilities } = await import('@/composables/useWorkspaceCapabilities');
-      resetWorkspaceCapabilities();
-    } catch (e) {
-      logger.error('Failed to reset workspace capabilities on logout', e);
-    }
-
-    // Reset appearance to the application default so the login page shows
-    // the brand theme rather than the signed-out user's personal
-    // theme/accent. Device-level settings (device-local theme pin,
-    // colour-blind mode) are deliberately kept.
+    // Account/session teardown that does NOT belong to the workspace-scoped
+    // routine: reset appearance to the application default so the login page
+    // shows the brand theme rather than the signed-out user's personal
+    // theme/accent. Device-level settings (device-local theme pin, colour-blind
+    // mode) are deliberately kept.
     try {
       const { useThemeStore } = await import('@/stores/theme');
       useThemeStore().resetToDefault();
     } catch (e) {
       logger.error('Failed to reset theme on logout', e);
-    }
-
-    // Tear down the sync runtime so a different user signing in
-    // afterwards doesn't briefly see the previous user's pool. The
-    // IDB handle is closed here; per-user database scoping means a
-    // re-login under a different account opens a different DB.
-    try {
-      const [{ tearDown }, { detachSseBridge }, { purgeAllCollabDocs }] = await Promise.all([
-        import('@/sync/lifecycle'),
-        import('@/sync/sseBridge'),
-        import('@/utils/collabLocalCache'),
-      ]);
-      detachSseBridge();
-      await tearDown();
-      // Collab caches are keyed by workspace, not user, so unlike the
-      // sync pool they'd otherwise outlive the session and be readable
-      // by the next account on a shared machine. Purge them on logout.
-      await purgeAllCollabDocs();
-    } catch (e) {
-      logger.error('Failed to tear down sync runtime on logout', e);
     }
 
     // Remove from localStorage

--- a/frontend/src/stores/myWorkspaces.ts
+++ b/frontend/src/stores/myWorkspaces.ts
@@ -7,10 +7,7 @@ import { computed } from 'vue';
 import { useQuery } from '@pinia/colada';
 import workspacesService from '@/services/workspacesService';
 import type { MyWorkspaceEntry } from '@/types/workspace';
-import {
-  navigateToWorkspace,
-  resolveActiveWorkspaceId,
-} from '@/utils/workspaceNavigation';
+import { resolveActiveWorkspaceId } from '@/utils/workspaceNavigation';
 import { useAuthStore } from '@/stores/auth';
 import { getWorkspaceRouting } from '@/services/instanceConfig';
 import { activeWorkspaceSlugRef } from '@/services/activeWorkspace';
@@ -62,17 +59,12 @@ export const useMyWorkspacesStore = defineStore('myWorkspaces', () => {
     () => query.status.value === 'pending' && query.data.value === undefined,
   );
 
-  function switchTo(entry: MyWorkspaceEntry): void {
-    navigateToWorkspace(entry);
-  }
-
   return {
     workspaces,
     activeWorkspace,
     activeWorkspaceId,
     showSwitcher,
     isLoading,
-    switchTo,
     refetch: query.refetch,
   };
 });

--- a/frontend/src/stores/myWorkspaces.ts
+++ b/frontend/src/stores/myWorkspaces.ts
@@ -12,6 +12,8 @@ import {
   resolveActiveWorkspaceId,
 } from '@/utils/workspaceNavigation';
 import { useAuthStore } from '@/stores/auth';
+import { getWorkspaceRouting } from '@/services/instanceConfig';
+import { activeWorkspaceSlugRef } from '@/services/activeWorkspace';
 
 export const MY_WORKSPACES_KEY = ['my-workspaces'] as const;
 
@@ -34,13 +36,24 @@ export const useMyWorkspacesStore = defineStore('myWorkspaces', () => {
     () => (Array.isArray(query.data.value) ? query.data.value : []),
   );
 
-  const activeWorkspaceId = computed(() => resolveActiveWorkspaceId(workspaces.value));
-
+  // The active workspace is whichever one the URL points at, resolved
+  // mode-appropriately: in path mode the route slug (the single source of truth
+  // the router keeps in `activeWorkspace` and the carrier header read from), and
+  // in host mode the subdomain. Both feed one `activeWorkspace`, so the switcher
+  // and the carrier never disagree.
   const activeWorkspace = computed<MyWorkspaceEntry | null>(() => {
-    const id = activeWorkspaceId.value;
-    if (id == null) return workspaces.value[0] ?? null;
-    return workspaces.value.find((w) => w.workspace_id === id) ?? workspaces.value[0] ?? null;
+    const fallback = () => workspaces.value[0] ?? null;
+    if (getWorkspaceRouting() === 'path') {
+      const slug = activeWorkspaceSlugRef.value;
+      if (!slug) return fallback();
+      return workspaces.value.find((w) => w.slug === slug) ?? fallback();
+    }
+    const id = resolveActiveWorkspaceId(workspaces.value);
+    if (id == null) return fallback();
+    return workspaces.value.find((w) => w.workspace_id === id) ?? fallback();
   });
+
+  const activeWorkspaceId = computed(() => activeWorkspace.value?.workspace_id ?? null);
 
   /** Hide the switcher when the operator only belongs to one tenant. */
   const showSwitcher = computed(() => workspaces.value.length > 1);

--- a/frontend/src/stores/workspaceReset.ts
+++ b/frontend/src/stores/workspaceReset.ts
@@ -53,6 +53,15 @@ export async function resetWorkspaceScopedState(): Promise<void> {
     logger.error('Failed to clear the query cache', e);
   }
 
+  // Drop the selected-workspace slug so the axios interceptor stops sending a
+  // stale `X-Nosdesk-Workspace` header; the next workspace navigation re-sets it.
+  try {
+    const { setActiveWorkspaceSlug } = await import('@/services/activeWorkspace');
+    setActiveWorkspaceSlug(null);
+  } catch (e) {
+    logger.error('Failed to clear the active workspace slug', e);
+  }
+
   // Sync runtime, SSE bridge, and collab IndexedDB. The sync pool's IDB is keyed
   // by (user, schema) with no workspace today, so a full teardown is the only
   // way to keep one workspace's rows from bleeding into the next; re-hydration

--- a/frontend/src/stores/workspaceReset.ts
+++ b/frontend/src/stores/workspaceReset.ts
@@ -1,0 +1,72 @@
+/**
+ * Tear down all *workspace-scoped* client state.
+ *
+ * One routine shared by two callers:
+ *   - `logout()` (account/session teardown layers this on top), and
+ *   - the in-app workspace switch (Model C), which resets + re-hydrates
+ *     instead of reloading to another subdomain.
+ *
+ * Scope boundary: this resets state that belongs to the *current workspace*
+ * (config stores, the sync pool, SSE, collab, cached queries). It deliberately
+ * does NOT touch account/session state (the signed-in user, cookies, the
+ * device-level theme, recent tickets), which is account-scoped and survives a
+ * workspace switch — `logout()` owns clearing those. Branding is also out of
+ * scope on purpose: logout keeps the current workspace's brand so the login
+ * page stays branded, and the switch re-fetches the new workspace's brand
+ * directly (no flash to default), so it is re-applied at each hydration
+ * boundary rather than reset here.
+ *
+ * Modules are imported dynamically (like `logout()`), keeping load order loose
+ * and avoiding static import cycles with the stores this touches.
+ */
+import { logger } from '@/utils/logger';
+
+export async function resetWorkspaceScopedState(): Promise<void> {
+  // Config stores that cache a slow-moving, workspace-scoped set. Reset
+  // independently so one failure doesn't skip the rest.
+  const storeResets = await Promise.allSettled([
+    import('@/stores/featureFlags').then((m) => m.useFeatureFlagsStore().reset()),
+    import('@/stores/workflowStates').then((m) => m.useWorkflowStatesStore().reset()),
+    import('@/composables/useWorkspaceCapabilities').then((m) =>
+      m.resetWorkspaceCapabilities(),
+    ),
+    import('@/stores/cycles').then((m) => m.useCyclesStore().reset()),
+    import('@/stores/savedViews').then((m) => m.useSavedViewsStore().reset()),
+  ]);
+  for (const r of storeResets) {
+    if (r.status === 'rejected') {
+      logger.error('Failed to reset a workspace-scoped store', r.reason);
+    }
+  }
+
+  // Pinia Colada query cache. Drop every entry rather than invalidate: an
+  // invalidated-but-not-removed entry keeps the previous workspace's data, which
+  // a cache-first read on the next workspace would serve before refetching. v1.2
+  // has no clear(), so remove entries explicitly.
+  try {
+    const { useQueryCache } = await import('@pinia/colada');
+    const cache = useQueryCache();
+    for (const entry of cache.getEntries()) {
+      cache.remove(entry);
+    }
+  } catch (e) {
+    logger.error('Failed to clear the query cache', e);
+  }
+
+  // Sync runtime, SSE bridge, and collab IndexedDB. The sync pool's IDB is keyed
+  // by (user, schema) with no workspace today, so a full teardown is the only
+  // way to keep one workspace's rows from bleeding into the next; re-hydration
+  // is the caller's job.
+  try {
+    const [{ tearDown }, { detachSseBridge }, { purgeAllCollabDocs }] = await Promise.all([
+      import('@/sync/lifecycle'),
+      import('@/sync/sseBridge'),
+      import('@/utils/collabLocalCache'),
+    ]);
+    detachSseBridge();
+    await tearDown();
+    await purgeAllCollabDocs();
+  } catch (e) {
+    logger.error('Failed to tear down the sync runtime', e);
+  }
+}

--- a/frontend/src/sync/idb.ts
+++ b/frontend/src/sync/idb.ts
@@ -48,11 +48,23 @@ export interface IdbHandle {
 }
 
 /**
- * Open the per-user / per-schema database. Creates the object
+ * Open the per-user / per-workspace / per-schema database. Creates the object
  * stores on first run.
+ *
+ * `workspaceSlug` enters the name only in single-origin path mode, where one
+ * origin serves several workspaces and the cache must not be shared between
+ * them. Host mode passes no slug and keeps the original name (subdomain installs
+ * are already isolated per-origin by the browser). The slug is a safe cache key
+ * because retired slugs are never reused, so it never points at two workspaces.
  */
-export function open(userUuid: string, schemaHash: string): Promise<IdbHandle> {
-  const name = `nosdesk-sync-${userUuid}-${schemaHash}`
+export function open(
+  userUuid: string,
+  schemaHash: string,
+  workspaceSlug?: string | null,
+): Promise<IdbHandle> {
+  const name = ['nosdesk-sync', userUuid, workspaceSlug || null, schemaHash]
+    .filter(Boolean)
+    .join('-')
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(name, 1)
     req.onupgradeneeded = () => {

--- a/frontend/src/sync/lifecycle.ts
+++ b/frontend/src/sync/lifecycle.ts
@@ -20,7 +20,7 @@ import { notifySyncActions } from './observers'
 import { applyWorkspaceCapabilities } from '@/composables/useWorkspaceCapabilities'
 import { purgeAllCollabDocs } from '@/utils/collabLocalCache'
 import { refreshAccessToken } from '@/services/authRefresh'
-import { activeWorkspaceSlug } from '@/services/activeWorkspace'
+import { workspaceHeaders } from '@/services/activeWorkspace'
 import type {
   BootstrapLine,
   BootstrapMeta,
@@ -239,11 +239,8 @@ export async function hydrate(
  */
 async function syncFetch(url: string): Promise<Response> {
   // The sync engine uses raw fetch (streaming JSONL), so the axios interceptor's
-  // selection header doesn't apply here; add it explicitly. Null in host mode,
-  // where the backend resolves the workspace from the Host.
-  const headers: Record<string, string> = {}
-  const slug = activeWorkspaceSlug()
-  if (slug) headers['X-Nosdesk-Workspace'] = slug
+  // selection header doesn't apply here; add it explicitly (empty in host mode).
+  const headers = workspaceHeaders()
   const res = await fetch(url, { credentials: 'include', headers })
   if (res.status !== 401) return res
   const refreshed = await refreshAccessToken()

--- a/frontend/src/sync/lifecycle.ts
+++ b/frontend/src/sync/lifecycle.ts
@@ -20,6 +20,7 @@ import { notifySyncActions } from './observers'
 import { applyWorkspaceCapabilities } from '@/composables/useWorkspaceCapabilities'
 import { purgeAllCollabDocs } from '@/utils/collabLocalCache'
 import { refreshAccessToken } from '@/services/authRefresh'
+import { activeWorkspaceSlug } from '@/services/activeWorkspace'
 import type {
   BootstrapLine,
   BootstrapMeta,
@@ -128,6 +129,7 @@ export async function hydrate(
   userUuid: string,
   schemaHash: string,
   instanceId = '',
+  workspaceSlug: string | null = null,
 ): Promise<void> {
   if (state.handle || state.memoryOnly) return
   pool.setSchemaHash(schemaHash)
@@ -140,7 +142,7 @@ export async function hydrate(
   // still holds rows, optimistic writes still apply — just
   // without warm-start persistence.
   try {
-    state.handle = await idb.open(userUuid, schemaHash)
+    state.handle = await idb.open(userUuid, schemaHash, workspaceSlug)
   } catch (e) {
     logger.warn('IndexedDB unavailable; degrading sync engine to memory-only', { error: e })
     state.memoryOnly = true
@@ -175,7 +177,7 @@ export async function hydrate(
     const oldName = state.handle.name
     state.handle.db.close()
     await idb.wipe(oldName)
-    state.handle = await idb.open(userUuid, schemaHash)
+    state.handle = await idb.open(userUuid, schemaHash, workspaceSlug)
     queue.setIdbHandle(state.handle)
 
     // The collaborative-document caches (separate y-indexeddb
@@ -236,11 +238,17 @@ export async function hydrate(
  * off (the axios client owns redirect-to-login for a dead session).
  */
 async function syncFetch(url: string): Promise<Response> {
-  const res = await fetch(url, { credentials: 'include' })
+  // The sync engine uses raw fetch (streaming JSONL), so the axios interceptor's
+  // selection header doesn't apply here; add it explicitly. Null in host mode,
+  // where the backend resolves the workspace from the Host.
+  const headers: Record<string, string> = {}
+  const slug = activeWorkspaceSlug()
+  if (slug) headers['X-Nosdesk-Workspace'] = slug
+  const res = await fetch(url, { credentials: 'include', headers })
   if (res.status !== 401) return res
   const refreshed = await refreshAccessToken()
   if (!refreshed) return res
-  return fetch(url, { credentials: 'include' })
+  return fetch(url, { credentials: 'include', headers })
 }
 
 export async function fetchServerIdentity(): Promise<{

--- a/frontend/src/sync/queue.ts
+++ b/frontend/src/sync/queue.ts
@@ -14,7 +14,7 @@
  */
 import { logger } from '@/utils/logger'
 import { getCsrfToken } from '@/utils/csrf'
-import { activeWorkspaceSlug } from '@/services/activeWorkspace'
+import { workspaceHeaders } from '@/services/activeWorkspace'
 import * as pool from './pool'
 import * as idb from './idb'
 import type { PushResponse, PushTransaction, SyncAggregate } from './types'
@@ -173,12 +173,13 @@ export async function flush(): Promise<void> {
         // middleware still requires the double-submit header on this
         // POST, so echo the token the same way apiClient does. The
         // selection header is added here too (the interceptor doesn't see
-        // this fetch); null in host mode, where the Host resolves it.
-        const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+        // this fetch); empty in host mode, where the Host resolves it.
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+          ...workspaceHeaders(),
+        }
         const csrfToken = getCsrfToken()
         if (csrfToken) headers['X-CSRF-Token'] = csrfToken
-        const workspaceSlug = activeWorkspaceSlug()
-        if (workspaceSlug) headers['X-Nosdesk-Workspace'] = workspaceSlug
         const res = await fetch('/api/sync/push', {
           method: 'POST',
           headers,

--- a/frontend/src/sync/queue.ts
+++ b/frontend/src/sync/queue.ts
@@ -14,6 +14,7 @@
  */
 import { logger } from '@/utils/logger'
 import { getCsrfToken } from '@/utils/csrf'
+import { activeWorkspaceSlug } from '@/services/activeWorkspace'
 import * as pool from './pool'
 import * as idb from './idb'
 import type { PushResponse, PushTransaction, SyncAggregate } from './types'
@@ -170,10 +171,14 @@ export async function flush(): Promise<void> {
       try {
         // Raw fetch (not apiClient) by design, but the global CSRF
         // middleware still requires the double-submit header on this
-        // POST, so echo the token the same way apiClient does.
+        // POST, so echo the token the same way apiClient does. The
+        // selection header is added here too (the interceptor doesn't see
+        // this fetch); null in host mode, where the Host resolves it.
         const headers: Record<string, string> = { 'Content-Type': 'application/json' }
         const csrfToken = getCsrfToken()
         if (csrfToken) headers['X-CSRF-Token'] = csrfToken
+        const workspaceSlug = activeWorkspaceSlug()
+        if (workspaceSlug) headers['X-Nosdesk-Workspace'] = workspaceSlug
         const res = await fetch('/api/sync/push', {
           method: 'POST',
           headers,

--- a/frontend/src/utils/shareUrl.ts
+++ b/frontend/src/utils/shareUrl.ts
@@ -1,0 +1,25 @@
+/**
+ * Build a full, shareable URL for a named app route.
+ *
+ * In path mode the workspace slug is folded in (so a copied link opens the right
+ * tenant for whoever receives it); in host mode the origin already carries the
+ * tenant (subdomain) so no slug is added. Built via `router.resolve` so the URL
+ * inherits the route table rather than re-deriving the path shape in a second
+ * place.
+ */
+import router from '@/router';
+import { activeWorkspaceSlug } from '@/services/activeWorkspace';
+import { getWorkspaceRouting } from '@/services/instanceConfig';
+
+export function shareableRouteUrl(
+  name: string,
+  params: Record<string, string>,
+): string {
+  const workspace =
+    getWorkspaceRouting() === 'path' ? activeWorkspaceSlug() : null;
+  const { href } = router.resolve({
+    name,
+    params: workspace ? { ...params, workspace } : params,
+  });
+  return `${window.location.origin}${href}`;
+}

--- a/frontend/src/views/AdminLayout.vue
+++ b/frontend/src/views/AdminLayout.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router';
 import { useFluent } from 'fluent-vue';
 import AdminSidebar from '@/components/admin/AdminSidebar.vue';
 import { allAdminNavItems, isAdminRouteActive } from '@/components/admin/adminNavData';
+import { effectiveRouteName } from '@/router/workspaceRouting';
 
 const route = useRoute();
 const fluent = useFluent();
@@ -11,8 +12,9 @@ const fluent = useFluent();
 // Index-page check via the named route, not a string compare.
 // The router resolves trailing slashes, query strings, hashes, and
 // future path renames into the same `route.name`, so a name check
-// is more robust than `route.path === '/admin'`.
-const isIndexPage = computed(() => route.name === 'admin-index');
+// is more robust than `route.path === '/admin'`. `effectiveRouteName`
+// keeps it working under the anonymous `/:workspace` nested copies.
+const isIndexPage = computed(() => effectiveRouteName(route) === 'admin-index');
 
 // Current active nav item for the mobile breadcrumb
 const activeItem = computed(() => {

--- a/frontend/src/views/AdminLayout.vue
+++ b/frontend/src/views/AdminLayout.vue
@@ -4,7 +4,6 @@ import { useRoute } from 'vue-router';
 import { useFluent } from 'fluent-vue';
 import AdminSidebar from '@/components/admin/AdminSidebar.vue';
 import { allAdminNavItems, isAdminRouteActive } from '@/components/admin/adminNavData';
-import { effectiveRouteName } from '@/router/workspaceRouting';
 
 const route = useRoute();
 const fluent = useFluent();
@@ -12,9 +11,8 @@ const fluent = useFluent();
 // Index-page check via the named route, not a string compare.
 // The router resolves trailing slashes, query strings, hashes, and
 // future path renames into the same `route.name`, so a name check
-// is more robust than `route.path === '/admin'`. `effectiveRouteName`
-// keeps it working under the anonymous `/:workspace` nested copies.
-const isIndexPage = computed(() => effectiveRouteName(route) === 'admin-index');
+// is more robust than `route.path === '/admin'`.
+const isIndexPage = computed(() => route.name === 'admin-index');
 
 // Current active nav item for the mobile breadcrumb
 const activeItem = computed(() => {

--- a/frontend/src/views/DocumentView.vue
+++ b/frontend/src/views/DocumentView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { shareableRouteUrl } from '@/utils/shareUrl'
 import { useFluent } from 'fluent-vue'
 import { formatDate } from '@/utils/dateUtils'
 import { docUrl, slugify } from '@/utils/docUrl'
@@ -125,7 +126,9 @@ const isDocumentPage = computed(() => !!document.value && !isTicketNote.value)
 
 const handleCopyLink = () => {
   const slug = document.value?.slug || document.value?.id
-  const url = `${window.location.origin}/documentation/${slug}`
+  if (slug == null) return
+  // Workspace-scoped in path mode so a shared link opens the right tenant.
+  const url = shareableRouteUrl('documentation-page', { path: String(slug) })
   copyToClipboard(url)
 }
 

--- a/frontend/src/views/NoWorkspaceAccessView.vue
+++ b/frontend/src/views/NoWorkspaceAccessView.vue
@@ -1,0 +1,54 @@
+<!-- NoWorkspaceAccessView.vue
+     Landing for an authenticated agent who belongs to no workspace yet.
+     Under Model C the workspace is a post-login selection, so a user whose
+     seat hasn't been provisioned (or was just revoked) has nothing to land
+     on. The router sends them here instead of falling through to a 404. -->
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useAuthStore } from '@/stores/auth';
+import AuthLayout from '@/components/auth/AuthLayout.vue';
+import Button from '@/components/common/Button.vue';
+
+const auth = useAuthStore();
+
+const refreshing = ref(false);
+const signingOut = ref(false);
+
+// Full reload so the post-login landing guard re-runs against a fresh
+// membership list and routes into a workspace if one was just granted.
+function refresh() {
+  refreshing.value = true;
+  window.location.assign('/');
+}
+
+async function signOut() {
+  signingOut.value = true;
+  try {
+    await auth.logout();
+  } finally {
+    signingOut.value = false;
+  }
+}
+</script>
+
+<template>
+  <AuthLayout>
+    <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-2">
+        <h1 class="text-2xl sm:text-3xl font-semibold tracking-tight text-primary">
+          {{ $t('no-workspace-access-title') }}
+        </h1>
+        <p class="text-base text-secondary">{{ $t('no-workspace-access-message') }}</p>
+      </div>
+      <p class="text-sm text-tertiary">{{ $t('no-workspace-access-description') }}</p>
+      <div class="flex gap-3">
+        <Button variant="primary" :loading="refreshing" @click="refresh">
+          {{ $t('no-workspace-access-refresh') }}
+        </Button>
+        <Button variant="secondary" :loading="signingOut" @click="signOut">
+          {{ $t('no-workspace-access-sign-out') }}
+        </Button>
+      </div>
+    </div>
+  </AuthLayout>
+</template>

--- a/frontend/src/views/RuleEditView.vue
+++ b/frontend/src/views/RuleEditView.vue
@@ -15,7 +15,6 @@
  */
 import { computed, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { effectiveRouteName } from '@/router/workspaceRouting';
 import { useFluent } from 'fluent-vue';
 import { useQueryCache } from '@pinia/colada';
 
@@ -44,7 +43,7 @@ const router = useRouter();
 const toast = useToastStore();
 const queryCache = useQueryCache();
 
-const isNew = computed(() => effectiveRouteName(route) === 'admin-rules-new');
+const isNew = computed(() => route.name === 'admin-rules-new');
 const ruleId = computed<number | null>(() =>
   isNew.value ? null : Number(route.params.id) || null,
 );

--- a/frontend/src/views/RuleEditView.vue
+++ b/frontend/src/views/RuleEditView.vue
@@ -15,6 +15,7 @@
  */
 import { computed, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
+import { effectiveRouteName } from '@/router/workspaceRouting';
 import { useFluent } from 'fluent-vue';
 import { useQueryCache } from '@pinia/colada';
 
@@ -43,7 +44,7 @@ const router = useRouter();
 const toast = useToastStore();
 const queryCache = useQueryCache();
 
-const isNew = computed(() => route.name === 'admin-rules-new');
+const isNew = computed(() => effectiveRouteName(route) === 'admin-rules-new');
 const ruleId = computed<number | null>(() =>
   isNew.value ? null : Number(route.params.id) || null,
 );

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -85,6 +85,14 @@ export default defineConfig({
         }
       : null,
     rolldownOptions: {
+      // Two SPA entries sharing one build: the agent app (index.html) and the
+      // customer portal (portal.html). The backend serves index.html on the
+      // agent origin and portal.html on a per-tenant portal origin; chunks are
+      // shared between them.
+      input: {
+        main: fileURLToPath(new URL("./index.html", import.meta.url)),
+        portal: fileURLToPath(new URL("./portal.html", import.meta.url)),
+      },
       output: {
         // Rolldown's group-based vendor splitting. Replaces the
         // deprecated `output.manualChunks` function form. Each

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -3004,6 +3004,14 @@ error-page-debug-glitch-frequency = Glitch Frequency
 error-page-debug-glitch-intensity = Glitch Intensity
 error-page-debug-cursor-influence = Cursor Influence
 
+# No workspace access (NoWorkspaceAccessView)
+no-workspace-access-title = No workspace access
+no-workspace-access-message = Your account isn't a member of any workspace yet.
+no-workspace-access-description = Ask your administrator to add you to a workspace, then refresh. If you were just added, a refresh should pick it up.
+no-workspace-access-refresh = Refresh
+no-workspace-access-sign-out = Sign out
+route-title-no-workspace-access = No workspace access
+
 # PDF viewer (PDFViewerView)
 pdf-viewer-default-filename = Document
 pdf-viewer-back = Back

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -85,6 +85,29 @@ invitation-body-text =
 
     -- { $app }
 
+# Customer-portal passwordless sign-in email. Same HTML/plaintext
+# split as the invitation: HTML keys carry inline <strong> emphasis,
+# variables are HTML-escaped at the Rust boundary.
+portal-magic-link-subject = Sign in to { $app } support
+portal-magic-link-title = Sign in to { $app }
+portal-magic-link-greeting = Hello <strong>{ $name }</strong>,
+portal-magic-link-intro = Use the button below to sign in to the <strong>{ $app }</strong> support portal and view your tickets.
+portal-magic-link-cta-label = Sign in
+portal-magic-link-notice-expiry = This sign-in link expires in <strong>20 minutes</strong> and can be used once
+portal-magic-link-notice-unexpected = If you didn't request this, you can safely ignore this email
+portal-magic-link-body-text =
+    Hello { $name },
+
+    Use this link to sign in to the { $app } support portal and view your tickets:
+
+    { $link }
+
+    A few things to know:
+      - This sign-in link expires in 20 minutes and can be used once.
+      - If you didn't request this, you can safely ignore this email.
+
+    -- { $app }
+
 # Notification email subjects. Each stamps the workspace name in
 # brackets so inbox grouping by sender + subject prefix still
 # works. $title is the entity (ticket title / doc page title);

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -2909,6 +2909,13 @@ error-page-default-message = Page introuvable
 error-page-description = La page que vous cherchez n'existe pas ou vous n'y avez peut-être pas accès.
 error-page-go-back = Retour
 error-page-go-home = Aller au tableau de bord
+# No workspace access (machine, à relire par un locuteur natif).
+no-workspace-access-title = Aucun accès à un espace de travail
+no-workspace-access-message = Votre compte n'est encore membre d'aucun espace de travail.
+no-workspace-access-description = Demandez à votre administrateur de vous ajouter à un espace de travail, puis actualisez. Si vous venez d'être ajouté, une actualisation devrait suffire.
+no-workspace-access-refresh = Actualiser
+no-workspace-access-sign-out = Se déconnecter
+route-title-no-workspace-access = Aucun accès à un espace de travail
 error-page-debug-title = Contrôles de débogage (appuyez sur « d » pour basculer)
 error-page-debug-master-toggle = Activation générale des effets
 error-page-debug-global-intensity = Intensité globale

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -49,6 +49,27 @@ invitation-body-text =
 
     -- { $app }
 
+# Connexion sans mot de passe au portail client (traduction automatique, en attente de relecture).
+portal-magic-link-subject = Connectez-vous à l'assistance { $app }
+portal-magic-link-title = Connectez-vous à { $app }
+portal-magic-link-greeting = Bonjour <strong>{ $name }</strong>,
+portal-magic-link-intro = Utilisez le bouton ci-dessous pour vous connecter au portail d'assistance <strong>{ $app }</strong> et consulter vos tickets.
+portal-magic-link-cta-label = Se connecter
+portal-magic-link-notice-expiry = Ce lien de connexion expire dans <strong>20 minutes</strong> et ne peut être utilisé qu'une seule fois
+portal-magic-link-notice-unexpected = Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail
+portal-magic-link-body-text =
+    Bonjour { $name },
+
+    Utilisez ce lien pour vous connecter au portail d'assistance { $app } et consulter vos tickets :
+
+    { $link }
+
+    À savoir :
+      - Ce lien de connexion expire dans 20 minutes et ne peut être utilisé qu'une seule fois.
+      - Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail.
+
+    -- { $app }
+
 # Notification email subjects.
 notif-ticket-assigned = [{ $app }] Ticket assigné : { $title }
 notif-ticket-status-changed = [{ $app }] Statut modifié : { $title }

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -2900,6 +2900,13 @@ error-page-default-message = Pagina niet gevonden
 error-page-description = De pagina die je zoekt bestaat niet, of je hebt er mogelijk geen toegang toe.
 error-page-go-back = Terug
 error-page-go-home = Naar dashboard
+# No workspace access (machine, te controleren door een moedertaalspreker).
+no-workspace-access-title = Geen toegang tot een werkruimte
+no-workspace-access-message = Je account is nog geen lid van een werkruimte.
+no-workspace-access-description = Vraag je beheerder om je aan een werkruimte toe te voegen en vernieuw daarna. Als je net bent toegevoegd, zou vernieuwen genoeg moeten zijn.
+no-workspace-access-refresh = Vernieuwen
+no-workspace-access-sign-out = Afmelden
+route-title-no-workspace-access = Geen toegang tot een werkruimte
 error-page-debug-title = Debug-instellingen (druk op 'd' om te wisselen)
 error-page-debug-master-toggle = Hoofdschakelaar effecten
 error-page-debug-global-intensity = Algemene intensiteit

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -46,6 +46,27 @@ invitation-body-text =
 
     -- { $app }
 
+# Wachtwoordloze aanmelding bij het klantenportaal (automatische vertaling, in afwachting van revisie).
+portal-magic-link-subject = Meld u aan bij { $app }-ondersteuning
+portal-magic-link-title = Meld u aan bij { $app }
+portal-magic-link-greeting = Hallo <strong>{ $name }</strong>,
+portal-magic-link-intro = Gebruik de knop hieronder om u aan te melden bij het <strong>{ $app }</strong>-ondersteuningsportaal en uw tickets te bekijken.
+portal-magic-link-cta-label = Aanmelden
+portal-magic-link-notice-expiry = Deze aanmeldlink verloopt over <strong>20 minuten</strong> en kan eenmaal worden gebruikt
+portal-magic-link-notice-unexpected = Als u dit niet hebt aangevraagd, kunt u deze e-mail negeren
+portal-magic-link-body-text =
+    Hallo { $name },
+
+    Gebruik deze link om u aan te melden bij het { $app }-ondersteuningsportaal en uw tickets te bekijken:
+
+    { $link }
+
+    Goed om te weten:
+      - Deze aanmeldlink verloopt over 20 minuten en kan eenmaal worden gebruikt.
+      - Als u dit niet hebt aangevraagd, kunt u deze e-mail negeren.
+
+    -- { $app }
+
 # Notification email subjects.
 notif-ticket-assigned = [{ $app }] Ticket toegewezen: { $title }
 notif-ticket-status-changed = [{ $app }] Status gewijzigd: { $title }


### PR DESCRIPTION
The cloud-hosted (Model C) v1.1 workstream. ~47 commits; deployed to staging via the dev image, validated incrementally.

## Highlights

**Model C (single-origin agent app)**
- Workspace resolution by request origin (not a global flag): agent origin -> selection (slug-in-path / X-Nosdesk-Workspace), tenant/portal origin -> host-derived, self-host -> bootstrap. Membership gate is origin-authoritative (a header can't override the origin's tenant).
- Central session: workspace-agnostic OIDC login at the central origin, RFC 9700 callback hardening (state->UA binding, iss, nonce, PKCE S256, id_token sig), verified-email account-linking gate.
- Federation retirement: removed the Model B per-tenant OIDC machinery (workspace-in-state binding, callback_workspace_decision, etc.). Self-host -> bootstrap; hosted-without-selection fails closed.

**Customer portal (new surface, nosdesk.app)**
- Magic-link sign-in for baseline members; portal-scope, workspace-bound session on isolated cookies; portal tokens walled out of the agent surface; portal CSRF realm.
- Ownership-scoped API (list/view/create/reply), RLS-pinned + forced requester-only visibility (a staff user is still confined to their own tickets through the portal).
- A second Vite SPA entry (portal.html) consuming /api/portal; origin-aware serving (portal.html on per-tenant origins, index.html on the agent origin / self-host).

**Email (Phase 1)**
- Per-workspace verified sending domains + BYODKIM, Return-Path/VERP + bounce decode, one-click List-Unsubscribe, Reply-To, SMTP validation, inbound quote-split + signature stripping, live DNS panel, notification-vs-transactional mail-class.

## Verification
Every backend invariant is covered by tests (resolution-by-origin, the membership/binding gates, single-use magic-links, ownership confinement, CSRF cookie selection, SPA shell selection). The portal SPA is type-check + build + lint clean; visual review pending.

## Not in this PR
Launch-time infra (DNS/cert for app./manage./*.nosdesk.app, Hydra redirect-URI registration), and the v1.1.0 tag — both follow staging validation of the merged dev image.