### PR TITLE
Hosted email: correctness fixes + admin consolidation

### DIFF
--- a/backend/src/handlers/app_config.rs
+++ b/backend/src/handlers/app_config.rs
@@ -14,6 +14,11 @@ use serde_json::json;
 /// `"host"` for the subdomain / self-hosted model. Derived from the same
 /// selection-resolution switch the backend auth gate reads, so the client's
 /// routing and the server's workspace resolution never disagree.
+///
+/// `deployment_mode` (`"hosted"` | `"self_hosted"`) lets the SPA render
+/// deployment-aware admin UI, e.g. hiding the platform SMTP relay panel on
+/// hosted (it's Nosdesk-managed infra, not a tenant concern). Not sensitive:
+/// hosted vs self-host is observable from the surface anyway.
 pub async fn get_public_config() -> impl Responder {
     let workspace_routing = if crate::middleware::workspace_context::selection_resolution_enabled()
     {
@@ -21,5 +26,12 @@ pub async fn get_public_config() -> impl Responder {
     } else {
         "host"
     };
-    HttpResponse::Ok().json(json!({ "workspace_routing": workspace_routing }))
+    let deployment_mode = match crate::middleware::DeploymentMode::current() {
+        crate::middleware::DeploymentMode::Hosted => "hosted",
+        crate::middleware::DeploymentMode::SelfHosted => "self_hosted",
+    };
+    HttpResponse::Ok().json(json!({
+        "workspace_routing": workspace_routing,
+        "deployment_mode": deployment_mode,
+    }))
 }

--- a/backend/src/handlers/email.rs
+++ b/backend/src/handlers/email.rs
@@ -29,9 +29,29 @@ pub async fn get_email_config(_tc: TenantConn, req: HttpRequest) -> impl Respond
     // active transport.
     match EmailService::from_env() {
         Ok(service) => {
-            // Return configuration (without secrets).
             let config = service.config();
+            // Hosted: outbound is delivered by Nosdesk-managed infra. The
+            // platform SMTP relay (host + username) is operator/infra config, and
+            // the username is an SES IAM credential, so it must not surface in the
+            // product admin UI. Return only the managed status + the From identity.
+            let managed = crate::middleware::DeploymentMode::current()
+                == crate::middleware::DeploymentMode::Hosted;
+            if managed {
+                return HttpResponse::Ok().json(json!({
+                    "managed": true,
+                    "provider": service.provider_name(),
+                    "from_name": config.from_name,
+                    "from_email": config.from_email,
+                    "enabled": config.enabled,
+                    "is_configured": service.is_configured(),
+                }));
+            }
+            // Self-host: the operator configured this relay; show what it points
+            // at (host/port/from) so they can verify it. Never echo `smtp_username`
+            // back, it's a credential identifier and adds no value over the
+            // configured/host fields.
             HttpResponse::Ok().json(json!({
+                "managed": false,
                 "provider": service.provider_name(),
                 "from_name": config.from_name,
                 "from_email": config.from_email,
@@ -39,7 +59,6 @@ pub async fn get_email_config(_tc: TenantConn, req: HttpRequest) -> impl Respond
                 "is_configured": service.is_configured(),
                 "smtp_host": config.smtp_host,
                 "smtp_port": config.smtp_port,
-                "smtp_username": config.smtp_username,
                 "smtp_password_configured": !config.smtp_password.is_empty(),
             }))
         }

--- a/backend/src/services/dkim_verification.rs
+++ b/backend/src/services/dkim_verification.rs
@@ -65,25 +65,38 @@ pub fn published_record_has_key(published: &[String], expected_public_b64: &str)
         .any(|p| p == expected)
 }
 
-/// Resolve the TXT records at `name`. NXDOMAIN / no-records yields an empty
-/// list (the record isn't published yet), not an error. Shared with the
-/// DNS-diagnostics panel ([`crate::services::dns_diagnostics`]).
-pub(crate) async fn txt_lookup(name: &str) -> Result<Vec<String>, VerifyError> {
-    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-    use hickory_resolver::net::{runtime::TokioRuntimeProvider, DnsError, NetError};
-    use hickory_resolver::proto::rr::RData;
+/// Single source of truth for the email-auth DNS resolver, shared by the DKIM
+/// verifier (`txt_lookup`) and the diagnostics panel (`dns_diagnostics::mx_lookup`).
+///
+/// Builds from the host's system configuration (`/etc/resolv.conf`) rather than a
+/// hardcoded public resolver. Hardcoding `8.8.8.8` was the anti-pattern: it
+/// ignores the host's DNS config and assumes public UDP reachability, which the
+/// hosted (Fly) environment doesn't provide (DNS is reachable only via the
+/// internal resolver), so every lookup failed there with "no connections
+/// available". The host resolver is correct in every environment, hosted recurses
+/// public records via the internal resolver, self-host uses the operator's.
+pub(crate) fn email_auth_resolver() -> Result<hickory_resolver::TokioResolver, String> {
+    use hickory_resolver::config::ResolverOpts;
     use hickory_resolver::TokioResolver;
 
     let mut opts = ResolverOpts::default();
     opts.timeout = Duration::from_secs(5);
     opts.attempts = 2;
-    let resolver = TokioResolver::builder_with_config(
-        ResolverConfig::default(),
-        TokioRuntimeProvider::default(),
-    )
-    .with_options(opts)
-    .build()
-    .map_err(|e| VerifyError::Dns(format!("resolver build: {e}")))?;
+    TokioResolver::builder_tokio()
+        .map_err(|e| format!("resolver build (system conf): {e}"))?
+        .with_options(opts)
+        .build()
+        .map_err(|e| format!("resolver build: {e}"))
+}
+
+/// Resolve the TXT records at `name`. NXDOMAIN / no-records yields an empty
+/// list (the record isn't published yet), not an error. Shared with the
+/// DNS-diagnostics panel ([`crate::services::dns_diagnostics`]).
+pub(crate) async fn txt_lookup(name: &str) -> Result<Vec<String>, VerifyError> {
+    use hickory_resolver::net::{DnsError, NetError};
+    use hickory_resolver::proto::rr::RData;
+
+    let resolver = email_auth_resolver().map_err(VerifyError::Dns)?;
 
     match resolver.txt_lookup(name).await {
         // `TXT`'s Display concatenates its <=255-char segments into the full

--- a/backend/src/services/dns_diagnostics.rs
+++ b/backend/src/services/dns_diagnostics.rs
@@ -184,22 +184,12 @@ fn dmarc_policy(record: &str) -> Option<String> {
 /// Resolve MX hostnames at `name`, sorted by preference. NXDOMAIN / no-records
 /// yields an empty list, mirroring `txt_lookup`.
 async fn mx_lookup(name: &str) -> Result<Vec<String>, String> {
-    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-    use hickory_resolver::net::{runtime::TokioRuntimeProvider, DnsError, NetError};
+    use hickory_resolver::net::{DnsError, NetError};
     use hickory_resolver::proto::rr::RData;
-    use hickory_resolver::TokioResolver;
-    use std::time::Duration;
 
-    let mut opts = ResolverOpts::default();
-    opts.timeout = Duration::from_secs(5);
-    opts.attempts = 2;
-    let resolver = TokioResolver::builder_with_config(
-        ResolverConfig::default(),
-        TokioRuntimeProvider::default(),
-    )
-    .with_options(opts)
-    .build()
-    .map_err(|e| format!("resolver build: {e}"))?;
+    // One shared resolver for the whole email-auth DNS surface (see
+    // `dkim_verification::email_auth_resolver` for why it's the host resolver).
+    let resolver = crate::services::dkim_verification::email_auth_resolver()?;
 
     match resolver.mx_lookup(name).await {
         Ok(lookup) => {

--- a/backend/src/services/outbound_email.rs
+++ b/backend/src/services/outbound_email.rs
@@ -50,6 +50,14 @@ pub struct OutboundEmailResolver {
     /// The env-configured service, used when a workspace has no identity of
     /// its own. `None` when no env SMTP is configured at all.
     fallback: Option<Arc<EmailService>>,
+    /// Whether WORKSPACE mail may fall back to the env identity. True only on
+    /// self-host, where the env relay IS the single operator's own identity; on
+    /// hosted the env identity is the SHARED PLATFORM identity, so tenant mail
+    /// must never fall back to it (it would leave on the platform domain). The
+    /// bulk queue path ([`resolve_batch`](Self::resolve_batch)) honours this; the
+    /// direct-send path ([`from_row`](Self::from_row)) always falls back (a
+    /// pre-existing asymmetry, see its note).
+    workspace_fallback_allowed: bool,
 }
 
 #[derive(Debug)]
@@ -78,7 +86,41 @@ impl std::error::Error for ResolveError {}
 
 impl OutboundEmailResolver {
     pub fn new(pool: Pool, fallback: Option<Arc<EmailService>>) -> Self {
-        Self { pool, fallback }
+        // Self-host: the env identity is the operator's own, so WORKSPACE mail
+        // may fall back to it. Hosted: it's shared platform infra, never.
+        let workspace_fallback_allowed = crate::middleware::DeploymentMode::current()
+            == crate::middleware::DeploymentMode::SelfHosted;
+        Self {
+            pool,
+            fallback,
+            workspace_fallback_allowed,
+        }
+    }
+
+    /// Test constructor that sets the workspace-fallback policy explicitly, since
+    /// `DeploymentMode::current()` is process-cached and can't be flipped per test.
+    #[cfg(test)]
+    fn with_policy(
+        pool: Pool,
+        fallback: Option<Arc<EmailService>>,
+        workspace_fallback_allowed: bool,
+    ) -> Self {
+        Self {
+            pool,
+            fallback,
+            workspace_fallback_allowed,
+        }
+    }
+
+    /// The env identity, but only when it's safe to send WORKSPACE mail from it
+    /// (self-host). On hosted this is always `None`: tenant mail must never fall
+    /// back to the shared platform identity. Used by [`resolve_batch`](Self::resolve_batch).
+    fn workspace_safe_fallback(&self) -> Option<Arc<EmailService>> {
+        if self.workspace_fallback_allowed {
+            self.fallback.clone()
+        } else {
+            None
+        }
     }
 
     /// Resolve on a connection the caller already holds. The caller is
@@ -110,14 +152,17 @@ impl OutboundEmailResolver {
     /// (the worker resolves PLATFORM rows via [`platform`](Self::platform)).
     ///
     /// A workspace with its own usable identity (a verified sending domain or
-    /// an smtp_relay) maps to that service. A workspace WITHOUT one is omitted
-    /// — it does NOT fall back to the platform identity. Tenant mail carries
-    /// tenant-controlled content (workspace name, customer names, ticket
-    /// text); sending it from the platform domain would lend the platform's
-    /// reputation to phishing and risk the platform's deliverability. So the
+    /// an smtp_relay) maps to that service. A workspace WITHOUT one is, on
+    /// HOSTED, omitted — it does NOT fall back to the SHARED platform identity.
+    /// Tenant mail carries tenant-controlled content (workspace name, customer
+    /// names, ticket text); sending it from the platform domain would lend the
+    /// platform's reputation to phishing and risk its deliverability. So the
     /// caller reads a missing entry as "unconfigured" and defers the row until
-    /// the workspace verifies a sending domain. (A row whose stored password
-    /// won't decrypt is likewise omitted, deferring rather than mis-sending.)
+    /// the workspace verifies a sending domain. On SELF-HOST the env identity is
+    /// the single operator's own, so an unconfigured workspace falls back to it
+    /// (matching the direct-send path) rather than stranding the operator's
+    /// notification mail. (A row whose stored password won't decrypt is omitted
+    /// on both modes, deferring rather than mis-sending.)
     pub fn resolve_batch(
         &self,
         conn: &mut DbConnection,
@@ -137,12 +182,19 @@ impl OutboundEmailResolver {
             let svc = match by_ws.get(&ws) {
                 Some(r) => match self.build_for_row(r) {
                     Ok(Some(svc)) => svc,
-                    // No usable workspace identity: omit, do NOT fall back to
-                    // the platform. Tenant content must never leave on the
-                    // platform domain; the row defers until a sending domain
-                    // is verified.
-                    Ok(None) => continue,
+                    // No usable workspace identity. On HOSTED, omit: tenant
+                    // content must never leave on the SHARED platform domain, so
+                    // the row defers until a sending domain is verified. On
+                    // self-host the env identity is the operator's own, so it's
+                    // safe to fall back (matching the direct-send path).
+                    Ok(None) => match self.workspace_safe_fallback() {
+                        Some(fb) => fb,
+                        None => continue,
+                    },
                     Err(e) => {
+                        // A configured-but-broken identity (e.g. a key that won't
+                        // decrypt): defer rather than mis-send from the env
+                        // identity, on both modes.
                         tracing::warn!(
                             workspace_id = ws,
                             error = %e,
@@ -151,8 +203,12 @@ impl OutboundEmailResolver {
                         continue;
                     }
                 },
-                // No settings row at all: same policy, no platform fallback.
-                None => continue,
+                // No settings row at all: same policy (self-host falls back,
+                // hosted defers).
+                None => match self.workspace_safe_fallback() {
+                    Some(fb) => fb,
+                    None => continue,
+                },
             };
             out.insert(ws, svc);
         }
@@ -313,12 +369,20 @@ mod tests {
         }))
     }
 
+    // Self-host policy (WORKSPACE mail may fall back to the env identity), set
+    // explicitly so tests don't depend on the process-cached DeploymentMode.
     fn resolver_with_fallback() -> OutboundEmailResolver {
-        OutboundEmailResolver::new(setup_test_pool(), Some(fallback_service()))
+        OutboundEmailResolver::with_policy(setup_test_pool(), Some(fallback_service()), true)
     }
 
     fn resolver_no_fallback() -> OutboundEmailResolver {
-        OutboundEmailResolver::new(setup_test_pool(), None)
+        OutboundEmailResolver::with_policy(setup_test_pool(), None, true)
+    }
+
+    // Hosted policy: WORKSPACE mail must never fall back to the shared platform
+    // identity, an unconfigured workspace is omitted (defers).
+    fn resolver_hosted_with_fallback() -> OutboundEmailResolver {
+        OutboundEmailResolver::with_policy(setup_test_pool(), Some(fallback_service()), false)
     }
 
     fn enabled_fields() -> UpsertWorkspaceEmailSettings {
@@ -419,15 +483,15 @@ mod tests {
     }
 
     #[test]
-    fn resolve_batch_maps_own_identity_and_omits_unconfigured() {
+    fn resolve_batch_maps_own_identity_and_omits_unconfigured_on_hosted() {
         let mut conn = setup_test_connection();
         repo::upsert(&mut conn, enabled_fields()).unwrap();
 
-        // Workspace 1 has its own identity; 424242 reads as "no row"
+        // HOSTED: workspace 1 has its own identity; 424242 reads as "no row"
         // (unconfigured). Even WITH a platform fallback present, the
         // unconfigured workspace is OMITTED — tenant mail must not send from
-        // the platform identity — so the worker defers it.
-        let map = resolver_with_fallback()
+        // the SHARED platform identity — so the worker defers it.
+        let map = resolver_hosted_with_fallback()
             .resolve_batch(&mut conn, &[1, 424242])
             .unwrap();
         assert_eq!(
@@ -436,7 +500,28 @@ mod tests {
         );
         assert!(
             map.get(&424242).is_none(),
-            "an unconfigured workspace must not fall back to the platform identity"
+            "on hosted an unconfigured workspace must not fall back to the platform identity"
+        );
+    }
+
+    #[test]
+    fn resolve_batch_falls_back_for_unconfigured_on_self_host() {
+        let mut conn = setup_test_connection();
+        repo::upsert(&mut conn, enabled_fields()).unwrap();
+
+        // SELF-HOST: the env identity is the operator's own, so an unconfigured
+        // workspace falls back to it rather than stranding its notification mail.
+        let map = resolver_with_fallback()
+            .resolve_batch(&mut conn, &[1, 424242])
+            .unwrap();
+        assert_eq!(
+            map.get(&1).unwrap().config().from_email,
+            "support@acme.test"
+        );
+        assert_eq!(
+            map.get(&424242).unwrap().config().from_email,
+            "platform@fallback.test",
+            "on self-host an unconfigured workspace falls back to the env identity"
         );
     }
 

--- a/frontend/src/components/admin/adminNavData.ts
+++ b/frontend/src/components/admin/adminNavData.ts
@@ -72,6 +72,25 @@ export const adminNavGroups: AdminNavGroup[] = [
     ]
   },
   {
+    labelKey: 'admin-nav-group-communication',
+    items: [
+      {
+        titleKey: 'admin-nav-channels-email-title',
+        descriptionKey: 'admin-nav-channels-email-description',
+        icon: 'email',
+        route: '/admin/channels/email',
+        keywords: ['email', 'imap', 'ingestion', 'inbox', 'mailbox', 'channel', 'channels', 'pipeline', 'tickets']
+      },
+      {
+        titleKey: 'admin-nav-email-delivery-title',
+        descriptionKey: 'admin-nav-email-delivery-description',
+        icon: 'email',
+        route: '/admin/email',
+        keywords: ['email', 'delivery', 'sending', 'smtp', 'domain', 'dkim', 'spf', 'dmarc', 'queue', 'suppressions', 'bounce', 'unsubscribe', 'outbound', 'from']
+      }
+    ]
+  },
+  {
     labelKey: 'admin-nav-group-integrations',
     items: [
       {
@@ -102,27 +121,6 @@ export const adminNavGroups: AdminNavGroup[] = [
         route: '/admin/data-import',
         keywords: ['import', 'data', 'intune', 'csv', 'microsoft', 'graph', 'migration']
       },
-      {
-        titleKey: 'admin-nav-channels-email-title',
-        descriptionKey: 'admin-nav-channels-email-description',
-        icon: 'email',
-        route: '/admin/channels/email',
-        keywords: ['email', 'imap', 'ingestion', 'inbox', 'mailbox', 'channel', 'pipeline', 'tickets']
-      },
-      {
-        titleKey: 'admin-nav-email-queue-title',
-        descriptionKey: 'admin-nav-email-queue-description',
-        icon: 'email',
-        route: '/admin/email-queue',
-        keywords: ['email', 'outbound', 'queue', 'smtp', 'send', 'retry', 'bounce', 'delivery', 'spool']
-      },
-      {
-        titleKey: 'admin-nav-email-suppressions-title',
-        descriptionKey: 'admin-nav-email-suppressions-description',
-        icon: 'email',
-        route: '/admin/email-suppressions',
-        keywords: ['email', 'suppressions', 'block', 'bounce', 'blocklist', 'unsubscribe', 'complaint']
-      }
     ]
   },
   {
@@ -148,20 +146,6 @@ export const adminNavGroups: AdminNavGroup[] = [
         route: '/admin/settings/branding',
         keywords: ['branding', 'logo', 'theme', 'appearance', 'colors', 'customization']
       },
-      {
-        titleKey: 'admin-nav-email-settings-title',
-        descriptionKey: 'admin-nav-email-settings-description',
-        icon: 'email',
-        route: '/admin/email-settings',
-        keywords: ['email', 'smtp', 'mail', 'notifications', 'configuration']
-      },
-      {
-        titleKey: 'admin-nav-email-sending-domain-title',
-        descriptionKey: 'admin-nav-email-sending-domain-description',
-        icon: 'email',
-        route: '/admin/email/sending-domain',
-        keywords: ['email', 'domain', 'sending', 'dkim', 'spf', 'dmarc', 'verified', 'from']
-      }
     ]
   },
   {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -782,16 +782,23 @@ const router = createRouter({
           redirect: { name: 'admin-audit' }
         },
         {
+          // Consolidated outbound-email admin: Setup + Activity sub-tabs.
+          path: 'email',
+          name: 'admin-email-delivery',
+          component: () => import('../views/EmailDeliveryView.vue'),
+          meta: { titleKey: 'route-title-admin-email-delivery', requiresAuth: true, adminRequired: true }
+        },
+        // The standalone outbound-email routes now live as sub-sections of
+        // Email delivery; redirect old links/bookmarks to the right tab.
+        {
           path: 'email-queue',
           name: 'admin-email-queue',
-          component: () => import('../views/admin/EmailQueueView.vue'),
-          meta: { titleKey: 'route-title-admin-email-queue' }
+          redirect: { name: 'admin-email-delivery', query: { tab: 'activity' } }
         },
         {
           path: 'email-suppressions',
           name: 'admin-email-suppressions',
-          component: () => import('../views/admin/EmailSuppressionsView.vue'),
-          meta: { titleKey: 'route-title-admin-email-suppressions' }
+          redirect: { name: 'admin-email-delivery', query: { tab: 'activity' } }
         },
         {
           path: 'guest-access',
@@ -802,14 +809,12 @@ const router = createRouter({
         {
           path: 'email-settings',
           name: 'admin-email-settings',
-          component: () => import('../views/EmailSettingsView.vue'),
-          meta: { titleKey: 'route-title-admin-email-settings' }
+          redirect: { name: 'admin-email-delivery' }
         },
         {
           path: 'email/sending-domain',
           name: 'admin-email-sending-domain',
-          component: () => import('../views/EmailSendingDomainView.vue'),
-          meta: { titleKey: 'route-title-admin-email-sending-domain' }
+          redirect: { name: 'admin-email-delivery' }
         },
         {
           path: 'channels/email',

--- a/frontend/src/services/instanceConfig.ts
+++ b/frontend/src/services/instanceConfig.ts
@@ -11,14 +11,24 @@ import { logger } from '@/utils/logger';
 /** Where the selected workspace lives in the URL. */
 export type WorkspaceRouting = 'host' | 'path';
 
+/** Whether this instance is the managed hosted SaaS or a self-hosted install. */
+export type DeploymentMode = 'hosted' | 'self_hosted';
+
 interface InstanceConfig {
   workspace_routing: WorkspaceRouting;
+  deployment_mode: DeploymentMode;
 }
 
 // Default 'host': the subdomain / self-hosted model every current deployment
 // runs. A pending or failed fetch keeps today's behaviour and never activates
 // the single-origin slug-in-path routing.
 let workspaceRouting: WorkspaceRouting = 'host';
+
+// Default 'self_hosted': the conservative, backward-compatible default. Hosted-
+// aware UI that hides infrastructure must still rely on backend enforcement (the
+// API redacts platform secrets regardless of this client hint), so a config blip
+// can never leak.
+let deploymentMode: DeploymentMode = 'self_hosted';
 
 // Memoised so bootstrap and the router guard share one fetch. The guard awaits
 // this before reading the routing mode, so a cold load (hard refresh, deep link)
@@ -40,6 +50,9 @@ export function fetchInstanceConfig(): Promise<void> {
         if (data?.workspace_routing === 'path' || data?.workspace_routing === 'host') {
           workspaceRouting = data.workspace_routing;
         }
+        if (data?.deployment_mode === 'hosted' || data?.deployment_mode === 'self_hosted') {
+          deploymentMode = data.deployment_mode;
+        }
       } catch (e) {
         logger.error('Failed to fetch instance config; defaulting workspace_routing=host', e);
       }
@@ -51,4 +64,14 @@ export function fetchInstanceConfig(): Promise<void> {
 /** Where the workspace lives in the URL. 'host' until the config resolves. */
 export function getWorkspaceRouting(): WorkspaceRouting {
   return workspaceRouting;
+}
+
+/** The instance's deployment mode. 'self_hosted' until the config resolves. */
+export function getDeploymentMode(): DeploymentMode {
+  return deploymentMode;
+}
+
+/** True on the managed hosted SaaS. Use to hide operator/infra-only admin UI. */
+export function isHostedDeployment(): boolean {
+  return deploymentMode === 'hosted';
 }

--- a/frontend/src/views/EmailDeliveryView.vue
+++ b/frontend/src/views/EmailDeliveryView.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+/**
+ * Email delivery — the consolidated outbound-email admin page.
+ *
+ * One page, two sub-tabs:
+ *   - Setup: sending identity (hosted-aware) + sending domain (DKIM/DNS) + test.
+ *   - Activity: the outbound queue + suppression list.
+ *
+ * The sub-sections are the existing standalone views rendered with `embedded`
+ * (header/page-chrome suppressed) so they compose under one header. The
+ * standalone routes are retired in favour of this page + `?tab=`.
+ */
+import { computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useFluent } from 'fluent-vue';
+
+import EmailSettingsView from './EmailSettingsView.vue';
+import EmailSendingDomainView from './EmailSendingDomainView.vue';
+import EmailQueueView from './admin/EmailQueueView.vue';
+import EmailSuppressionsView from './admin/EmailSuppressionsView.vue';
+
+const fluent = useFluent();
+const t = (key: string) => fluent.$t(key);
+
+const route = useRoute();
+const router = useRouter();
+
+type Tab = 'setup' | 'activity';
+const tab = computed<Tab>(() => (route.query.tab === 'activity' ? 'activity' : 'setup'));
+
+function selectTab(next: Tab) {
+  if (next === tab.value) return;
+  // 'setup' is the default, so drop the query param for a clean URL.
+  router.replace({ query: { ...route.query, tab: next === 'setup' ? undefined : next } });
+}
+
+const tabs: { id: Tab; labelKey: string }[] = [
+  { id: 'setup', labelKey: 'admin-email-delivery-tab-setup' },
+  { id: 'activity', labelKey: 'admin-email-delivery-tab-activity' },
+];
+</script>
+
+<template>
+  <div class="flex-1">
+    <div class="flex flex-col gap-6 px-4 sm:px-6 py-4 mx-auto w-full max-w-8xl">
+      <header class="flex flex-col gap-1">
+        <h1 class="text-xl sm:text-2xl font-bold text-primary">{{ t('admin-email-delivery-title') }}</h1>
+        <p class="text-secondary">{{ t('admin-email-delivery-description') }}</p>
+      </header>
+
+      <nav class="flex gap-1 border-b border-default" role="tablist">
+        <button
+          v-for="tb in tabs"
+          :key="tb.id"
+          type="button"
+          role="tab"
+          :aria-selected="tab === tb.id"
+          class="px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors"
+          :class="tab === tb.id ? 'border-accent text-primary' : 'border-transparent text-secondary hover:text-primary'"
+          @click="selectTab(tb.id)"
+        >
+          {{ t(tb.labelKey) }}
+        </button>
+      </nav>
+
+      <div v-if="tab === 'setup'" class="flex flex-col gap-6">
+        <EmailSettingsView embedded />
+        <EmailSendingDomainView embedded />
+      </div>
+      <div v-else class="flex flex-col gap-6">
+        <EmailQueueView embedded />
+        <EmailSuppressionsView embedded />
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/views/EmailSendingDomainView.vue
+++ b/frontend/src/views/EmailSendingDomainView.vue
@@ -16,6 +16,10 @@ import workspaceEmailService, {
 import { extractErrorMessage } from '@/utils/errors';
 import { useToastStore } from '@/stores/toast';
 
+// `embedded`: render as a section inside the consolidated Email delivery page
+// (no page header / outer padding), vs. the standalone admin route.
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false });
+
 const toast = useToastStore();
 const fluent = useFluent();
 const t = (key: string) => fluent.$t(key);
@@ -175,8 +179,8 @@ async function copy(text: string) {
 </script>
 
 <template>
-  <div class="max-w-2xl mx-auto p-6 flex flex-col gap-6">
-    <header class="flex flex-col gap-1">
+  <div :class="props.embedded ? 'flex flex-col gap-6' : 'max-w-2xl mx-auto p-6 flex flex-col gap-6'">
+    <header v-if="!props.embedded" class="flex flex-col gap-1">
       <h1 class="text-xl font-semibold text-primary">{{ t('email-domain-title') }}</h1>
       <p class="text-sm text-tertiary">{{ t('email-domain-description') }}</p>
     </header>

--- a/frontend/src/views/EmailSettingsView.vue
+++ b/frontend/src/views/EmailSettingsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
-import axios from 'axios';
+import apiClient from '@/services/apiConfig';
 import { useFluent } from 'fluent-vue';
 import { useQuery, useQueryCache } from '@pinia/colada';
 
@@ -43,7 +43,7 @@ const EMAIL_CONFIG_KEY = ['email-config'] as const;
 const emailConfigQuery = useQuery({
   key: EMAIL_CONFIG_KEY,
   query: async () => {
-    const response = await axios.get('/api/admin/email/config');
+    const response = await apiClient.get('/admin/email/config');
     return response.data as EmailConfig;
   },
 });
@@ -80,7 +80,7 @@ const sendTestEmail = async () => {
   errorMessage.value = '';
 
   try {
-    const response = await axios.post('/api/admin/email/test', {
+    const response = await apiClient.post('/admin/email/test', {
       to: testEmailAddress.value
     });
 

--- a/frontend/src/views/EmailSettingsView.vue
+++ b/frontend/src/views/EmailSettingsView.vue
@@ -25,10 +25,15 @@ const t = (key: string) => fluent.$t(key);
 interface EmailConfig {
   /** Active transport. Always 'smtp'; older backends omit it. */
   provider?: 'smtp';
-  smtp_host: string;
-  smtp_port: number;
-  smtp_username: string;
-  smtp_password_configured: boolean;
+  /**
+   * Hosted: outbound is Nosdesk-managed, so the platform relay details
+   * (host/username) are withheld and only the managed status + From are sent.
+   * The SES SMTP username is a credential and is never returned.
+   */
+  managed?: boolean;
+  smtp_host?: string;
+  smtp_port?: number;
+  smtp_password_configured?: boolean;
   from_name: string;
   from_email: string;
   enabled: boolean;
@@ -249,17 +254,26 @@ const getRequiredEnvVars = () => [
               </div>
             </div>
 
-            <!-- Current Configuration -->
-            <div v-if="emailConfig?.is_configured" class="flex flex-col md:flex-row gap-4 text-sm">
-              <!-- Left: Server, Username, From details -->
+            <!-- Hosted: outbound is Nosdesk-managed infra. Don't expose the
+                 platform relay; point the admin at their sending domain. -->
+            <div v-if="emailConfig?.managed" class="flex flex-col gap-2 text-sm bg-surface-alt rounded-lg p-3">
+              <p class="text-secondary">{{ $t('admin-email-settings-managed-note') }}</p>
+              <RouterLink
+                :to="{ name: 'admin-email-sending-domain' }"
+                class="text-accent hover:underline font-medium w-fit"
+              >
+                {{ $t('admin-email-settings-managed-domain-link') }}
+              </RouterLink>
+            </div>
+
+            <!-- Self-host: the operator's own relay. The username is never
+                 echoed back (it's a credential identifier, no display value). -->
+            <div v-else-if="emailConfig?.is_configured" class="flex flex-col md:flex-row gap-4 text-sm">
+              <!-- Left: Server, From details -->
               <div class="flex-1 flex flex-col gap-2">
                 <div class="flex flex-col gap-0.5">
                   <span class="text-tertiary text-xs">{{ $t('admin-email-settings-server') }}</span>
                   <span class="text-primary font-mono text-xs bg-surface-alt px-2 py-1.5 rounded select-all">{{ emailConfig.smtp_host }}:{{ emailConfig.smtp_port }}</span>
-                </div>
-                <div class="flex flex-col gap-0.5">
-                  <span class="text-tertiary text-xs">{{ $t('admin-email-settings-username') }}</span>
-                  <span class="text-primary font-mono text-xs bg-surface-alt px-2 py-1.5 rounded select-all break-all">{{ emailConfig.smtp_username }}</span>
                 </div>
                 <div class="flex flex-col gap-0.5">
                   <span class="text-tertiary text-xs">{{ $t('admin-email-settings-from-address') }}</span>
@@ -283,8 +297,9 @@ const getRequiredEnvVars = () => [
               {{ emailConfig.error }}
             </div>
 
-            <!-- Required environment variables -->
-            <div class="flex items-center gap-2 text-xs">
+            <!-- Required environment variables (self-host only; hosted relay
+                 is operator infra, not configured from the product UI). -->
+            <div v-if="!emailConfig?.managed" class="flex items-center gap-2 text-xs">
               <span class="text-tertiary">{{ $t('admin-email-settings-env-vars-label') }}</span>
               <div class="flex flex-wrap gap-1">
                 <code

--- a/frontend/src/views/EmailSettingsView.vue
+++ b/frontend/src/views/EmailSettingsView.vue
@@ -17,6 +17,10 @@ import brandingService, { type BrandingConfig } from '@/services/brandingService
 import { extractErrorMessage } from '@/utils/errors';
 import { useToastStore } from '@/stores/toast';
 
+// `embedded`: render as a section inside the consolidated Email delivery page
+// (no page header / outer padding), vs. the standalone admin route.
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false });
+
 const toast = useToastStore();
 const fluent = useFluent();
 const t = (key: string) => fluent.$t(key);
@@ -175,17 +179,18 @@ const getRequiredEnvVars = () => [
 </script>
 
 <template>
-  <div class="flex-1">
-    <div class="flex flex-col gap-4 px-4 sm:px-6 py-4 mx-auto w-full max-w-8xl">
-      <div class="mb-6">
+  <div :class="props.embedded ? '' : 'flex-1'">
+    <div :class="props.embedded ? 'flex flex-col gap-4' : 'flex flex-col gap-4 px-4 sm:px-6 py-4 mx-auto w-full max-w-8xl'">
+      <div v-if="!props.embedded" class="mb-6">
         <h1 class="text-xl sm:text-2xl font-bold text-primary">{{ $t('admin-email-settings-title') }}</h1>
         <p class="text-secondary mt-2">
           {{ $t('admin-email-settings-description') }}
         </p>
       </div>
 
-      <!-- Configuration Notice -->
-      <EnvConfigNotice>
+      <!-- Configuration Notice (self-host: the relay is set via .env; hidden on
+           hosted, where outbound is Nosdesk-managed). -->
+      <EnvConfigNotice v-if="!emailConfig?.managed">
         {{ $t('admin-email-settings-env-notice-prefix') }}
         <code class="bg-surface px-1 rounded text-primary">.env</code>
         {{ $t('admin-email-settings-env-notice-suffix') }}

--- a/frontend/src/views/admin/EmailQueueView.vue
+++ b/frontend/src/views/admin/EmailQueueView.vue
@@ -17,6 +17,9 @@ import {
   type OutboundEmailStatus,
 } from '@/services/emailQueueService';
 
+// `embedded`: render as the Activity tab inside the Email delivery page.
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false });
+
 const fluent = useFluent();
 const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
 
@@ -203,8 +206,8 @@ const deadTotal = computed(
 </script>
 
 <template>
-  <div class="flex flex-col gap-6 p-6">
-    <header class="flex flex-col gap-2">
+  <div :class="props.embedded ? 'flex flex-col gap-6' : 'flex flex-col gap-6 p-6'">
+    <header v-if="!props.embedded" class="flex flex-col gap-2">
       <h1 class="text-2xl font-semibold">{{ $t('admin-email-queue-title') }}</h1>
       <p class="text-sm text-secondary">
         {{ $t('admin-email-queue-description') }}

--- a/frontend/src/views/admin/EmailSuppressionsView.vue
+++ b/frontend/src/views/admin/EmailSuppressionsView.vue
@@ -27,6 +27,9 @@ import {
   type EmailSuppression,
 } from '@/services/emailSuppressionsService';
 
+// `embedded`: render as part of the Activity tab inside the Email delivery page.
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false });
+
 const fluent = useFluent();
 const t = (key: string, args?: Record<string, string | number>) => fluent.$t(key, args);
 
@@ -135,8 +138,8 @@ function formatDateTime(iso: string): string {
 </script>
 
 <template>
-    <div class="flex flex-col gap-6 p-6">
-        <header class="flex flex-col gap-2">
+    <div :class="props.embedded ? 'flex flex-col gap-6' : 'flex flex-col gap-6 p-6'">
+        <header v-if="!props.embedded" class="flex flex-col gap-2">
             <h1 class="text-2xl font-semibold">{{ $t('admin-suppressions-title') }}</h1>
             <p class="text-sm text-secondary">
                 {{ $t('admin-suppressions-description') }}

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -1198,6 +1198,9 @@ admin-email-settings-from-address = From Address
 admin-email-settings-password = Password
 admin-email-settings-password-not-set = Not Set
 admin-email-settings-env-vars-label = Env:
+# Hosted only: shown instead of the platform SMTP relay (Nosdesk-managed infra).
+admin-email-settings-managed-note = Outbound email is delivered by Nosdesk. To send from your own address, set up a sending domain.
+admin-email-settings-managed-domain-link = Configure sending domain
 admin-email-settings-test-send = Send test:
 admin-email-settings-test-placeholder = recipient@example.com
 admin-email-settings-test-send-button = Send

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -1201,6 +1201,15 @@ admin-email-settings-env-vars-label = Env:
 # Hosted only: shown instead of the platform SMTP relay (Nosdesk-managed infra).
 admin-email-settings-managed-note = Outbound email is delivered by Nosdesk. To send from your own address, set up a sending domain.
 admin-email-settings-managed-domain-link = Configure sending domain
+# Email delivery: the consolidated outbound-email admin page + its nav group.
+admin-nav-group-communication = Communication
+admin-nav-email-delivery-title = Email delivery
+admin-nav-email-delivery-description = Sending identity, domain, and delivery activity
+route-title-admin-email-delivery = Email delivery
+admin-email-delivery-title = Email delivery
+admin-email-delivery-description = How this workspace sends email, and how delivery is going.
+admin-email-delivery-tab-setup = Setup
+admin-email-delivery-tab-activity = Activity
 admin-email-settings-test-send = Send test:
 admin-email-settings-test-placeholder = recipient@example.com
 admin-email-settings-test-send-button = Send

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -1113,6 +1113,15 @@ admin-email-settings-env-vars-label = Env :
 # (machine, à relire par un locuteur natif).
 admin-email-settings-managed-note = Les e-mails sortants sont distribués par Nosdesk. Pour envoyer depuis votre propre adresse, configurez un domaine d'envoi.
 admin-email-settings-managed-domain-link = Configurer le domaine d'envoi
+# (machine, à relire par un locuteur natif).
+admin-nav-group-communication = Communication
+admin-nav-email-delivery-title = Distribution des e-mails
+admin-nav-email-delivery-description = Identité d'expéditeur, domaine et activité de distribution
+route-title-admin-email-delivery = Distribution des e-mails
+admin-email-delivery-title = Distribution des e-mails
+admin-email-delivery-description = Comment cet espace de travail envoie ses e-mails et comment se déroule la distribution.
+admin-email-delivery-tab-setup = Configuration
+admin-email-delivery-tab-activity = Activité
 admin-email-settings-test-send = Envoyer un test :
 admin-email-settings-test-placeholder = destinataire@exemple.com
 admin-email-settings-test-send-button = Envoyer

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -1110,6 +1110,9 @@ admin-email-settings-from-address = Adresse d'expéditeur
 admin-email-settings-password = Mot de passe
 admin-email-settings-password-not-set = Non défini
 admin-email-settings-env-vars-label = Env :
+# (machine, à relire par un locuteur natif).
+admin-email-settings-managed-note = Les e-mails sortants sont distribués par Nosdesk. Pour envoyer depuis votre propre adresse, configurez un domaine d'envoi.
+admin-email-settings-managed-domain-link = Configurer le domaine d'envoi
 admin-email-settings-test-send = Envoyer un test :
 admin-email-settings-test-placeholder = destinataire@exemple.com
 admin-email-settings-test-send-button = Envoyer

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -1107,6 +1107,9 @@ admin-email-settings-from-address = Afzender
 admin-email-settings-password = Wachtwoord
 admin-email-settings-password-not-set = Niet ingesteld
 admin-email-settings-env-vars-label = Env:
+# (machine, na te kijken door moedertaalspreker).
+admin-email-settings-managed-note = Uitgaande e-mail wordt bezorgd door Nosdesk. Stel een verzenddomein in om vanaf je eigen adres te verzenden.
+admin-email-settings-managed-domain-link = Verzenddomein instellen
 admin-email-settings-test-send = Test verzenden:
 admin-email-settings-test-placeholder = ontvanger@voorbeeld.com
 admin-email-settings-test-send-button = Verzenden

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -1110,6 +1110,15 @@ admin-email-settings-env-vars-label = Env:
 # (machine, na te kijken door moedertaalspreker).
 admin-email-settings-managed-note = Uitgaande e-mail wordt bezorgd door Nosdesk. Stel een verzenddomein in om vanaf je eigen adres te verzenden.
 admin-email-settings-managed-domain-link = Verzenddomein instellen
+# (machine, na te kijken door moedertaalspreker).
+admin-nav-group-communication = Communicatie
+admin-nav-email-delivery-title = E-mailbezorging
+admin-nav-email-delivery-description = Afzenderidentiteit, domein en bezorgactiviteit
+route-title-admin-email-delivery = E-mailbezorging
+admin-email-delivery-title = E-mailbezorging
+admin-email-delivery-description = Hoe deze werkruimte e-mail verzendt en hoe de bezorging verloopt.
+admin-email-delivery-tab-setup = Instellen
+admin-email-delivery-tab-activity = Activiteit
 admin-email-settings-test-send = Test verzenden:
 admin-email-settings-test-placeholder = ontvanger@voorbeeld.com
 admin-email-settings-test-send-button = Verzenden


### PR DESCRIPTION
Five coherent commits, all verified on the staging dev image.

## Bug fixes
- **CSRF on admin email calls** — `EmailSettingsView` used bare `axios`, so the test-send/config calls carried no `X-CSRF-Token` and were rejected. Route them through the shared `apiClient`.
- **Email-auth DNS resolver** — the DKIM verifier + DNS panel hardcoded `8.8.8.8` over UDP, unreachable on Fly ("no connections available"), which also broke the periodic re-verify job. Use the host's system resolver, and DRY the two duplicated builders into one shared `email_auth_resolver()`.
- **Self-host fallback** — the queue's `resolve_batch` never fell back to the env identity (correct on hosted, anti-phishing), but on self-host it stranded the operator's notification mail. Inject deployment mode and gate the fallback: self-host falls back to its own env identity, hosted still defers. New test covers it.

## Hosted-awareness
- **Redact platform SMTP** — `get_email_config` returned `smtp_username` (the SES IAM key on hosted). Drop it entirely; on hosted return only the managed status + From. Expose `deployment_mode` on `GET /api/config`. The email view shows an "outbound delivered by Nosdesk" managed note on hosted, the operator's relay (no username) on self-host.

## Admin consolidation
- Replace the five scattered email surfaces (across Integrations + Appearance) with a single **Communication** group: **Channels** (inbound) and **Email delivery** (outbound). Email delivery is one page with **Setup** + **Activity** sub-tabs, composing the existing views via an `embedded` prop; old routes redirect.

## Verification
`cargo check`/`--tests` + the email-module tests pass; `vue-tsc` clean. Deployed and exercised on staging (`app.nosdesk.dev`): DKIM domain verified end-to-end, hosted SMTP username gone, consolidated page works.

Follow-up (separate): Section A (Channels list + add-channel scaffold).