### PR TITLE
Promote ticket notes to documents (transclude back), retire the full-page-note hack

### DIFF
--- a/backend/src/handlers/documentation.rs
+++ b/backend/src/handlers/documentation.rs
@@ -505,6 +505,7 @@ pub async fn get_documentation_page_content_by_uuid(
 
         Ok::<_, diesel::result::Error>(PageContentOutcome::Ok(json!({
             "uuid": page.uuid,
+            "slug": page.slug,
             "title": page.title,
             "icon": page.icon,
             "status": page.status,

--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -116,10 +116,10 @@ setTicketNavigationHandler((ticketId: number) => {
     router.push(`/tickets/${ticketId}`);
 });
 
-setDocumentNavigationHandler((uuid: string) => {
-    // Navigate to doc page by searching for it via the API
-    // For now, use the uuid directly - the router will handle lookup
-    router.push(`/documentation/${uuid}`);
+setDocumentNavigationHandler((slug: string) => {
+    // The documentation page route resolves by slug, so navigate by the
+    // doc's slug (resolved from its uuid by the embed before calling).
+    router.push(`/documentation/${slug}`);
 });
 
 // Document picker state

--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -125,25 +125,45 @@ setDocumentNavigationHandler((uuid: string) => {
 // Document picker state
 const showDocumentPicker = ref(false);
 
+// Build an `embedded_document` node from a doc reference. Shared by the
+// picker-driven insert and the promote-to-document replace so the node
+// shape stays in one place.
+const buildEmbeddedDocNode = (doc: { uuid: string; title: string }) => {
+    if (!editorView) return null;
+    const type = editorView.state.schema.nodes.embedded_document;
+    if (!type) return null;
+    return type.create({ documentUuid: doc.uuid, documentTitle: doc.title });
+};
+
 const insertEmbeddedDocument = (doc: { uuid: string; title: string }) => {
     showDocumentPicker.value = false;
     if (!editorView) return;
 
-    const view = editorView;
-    const { state } = view;
-    const embeddedDocType = state.schema.nodes.embedded_document;
-    if (!embeddedDocType) return;
+    const node = buildEmbeddedDocNode(doc);
+    if (!node) return;
 
-    const node = embeddedDocType.create({
-        documentUuid: doc.uuid,
-        documentTitle: doc.title,
-    });
-
-    const tr = state.tr.replaceSelectionWith(node);
-    view.dispatch(tr);
-    view.focus();
+    const tr = editorView.state.tr.replaceSelectionWith(node);
+    editorView.dispatch(tr);
+    editorView.focus();
 
     // Sync embeddings after inserting
+    syncEmbeddings();
+};
+
+// Replace the entire document body with a single embedded-document node.
+// Used when promoting a ticket note into a standalone document: the
+// note's content is cloned into the new doc server-side, then the note
+// body becomes a transclusion of that doc (one source of truth).
+const replaceAllWithEmbeddedDocument = (doc: { uuid: string; title: string }) => {
+    if (!editorView) return;
+
+    const node = buildEmbeddedDocNode(doc);
+    if (!node) return;
+
+    const { state } = editorView;
+    const tr = state.tr.replaceWith(0, state.doc.content.size, node);
+    editorView.dispatch(tr);
+
     syncEmbeddings();
 };
 
@@ -1941,6 +1961,7 @@ defineExpose({
     isViewingRevision,
     currentRevisionNumber,
     getTextContent,
+    replaceAllWithEmbeddedDocument,
 });
 </script>
 

--- a/frontend/src/components/common/icons.ts
+++ b/frontend/src/components/common/icons.ts
@@ -78,6 +78,12 @@ export const ICON_REGISTRY = {
   bell: {
     d: 'M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0',
   },
+  /** Open book — the "documentation / knowledge base" concept,
+   * app-wide. Matches the Documentation nav section so converting a
+   * ticket note into a doc page reads as "send this to the docs". */
+  book: {
+    d: 'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253',
+  },
   /** Calendar grid with day-tick marks. Used wherever a surface
    * places tickets onto specific days (the Calendar built-in view,
    * due-date picker headers). Distinct from `clock` (a generic

--- a/frontend/src/components/editor/embeddedDocumentPlugin.ts
+++ b/frontend/src/components/editor/embeddedDocumentPlugin.ts
@@ -11,23 +11,34 @@ import * as Y from 'yjs'
 export const embeddedDocumentPluginKey = new PluginKey('embeddedDocument')
 
 // Cache for embedded document content
-const contentCache = new Map<string, { html: string; title: string; icon: string; loading: boolean; error: boolean }>()
+interface EmbeddedDocContent {
+  html: string
+  title: string
+  icon: string
+  // Canonical slug for navigation. Docs are routed by slug, not uuid,
+  // so the open affordance needs this to reach the page.
+  slug: string | null
+  loading: boolean
+  error: boolean
+}
+const contentCache = new Map<string, EmbeddedDocContent>()
 
-// Navigation callback
-let navigateToDocument: ((uuid: string) => void) | null = null
+// Navigation callback. Receives the doc's slug (the routable path), not
+// the uuid — the documentation route resolves by slug.
+let navigateToDocument: ((slug: string) => void) | null = null
 
-export function setDocumentNavigationHandler(handler: (uuid: string) => void) {
+export function setDocumentNavigationHandler(handler: (slug: string) => void) {
   navigateToDocument = handler
 }
 
 // Fetch document content for embedding
-async function fetchDocumentContent(uuid: string): Promise<{ html: string; title: string; icon: string }> {
+async function fetchDocumentContent(uuid: string): Promise<EmbeddedDocContent> {
   const cached = contentCache.get(uuid)
   if (cached && !cached.loading && !cached.error) {
     return cached
   }
 
-  contentCache.set(uuid, { html: '', title: translate('editor-loading', undefined, 'Loading...'), icon: '📄', loading: true, error: false })
+  contentCache.set(uuid, { html: '', title: translate('editor-loading', undefined, 'Loading...'), icon: '📄', slug: null, loading: true, error: false })
 
   try {
     const response = await apiClient.get(`/documentation/pages/uuid/${uuid}/content`)
@@ -50,10 +61,11 @@ async function fetchDocumentContent(uuid: string): Promise<{ html: string; title
       html = `<p class="text-tertiary text-sm italic">${translate('editor-embed-empty-document', undefined, 'Empty document')}</p>`
     }
 
-    const result = {
+    const result: EmbeddedDocContent = {
       html,
       title: data.title || translate('docs-untitled-page', undefined, 'Untitled'),
       icon: data.icon || '📄',
+      slug: data.slug ?? null,
       loading: false,
       error: false,
     }
@@ -62,10 +74,11 @@ async function fetchDocumentContent(uuid: string): Promise<{ html: string; title
   } catch (err) {
     console.error(`Failed to fetch embedded document ${uuid}:`, err)
     const loadFailedMsg = translate('editor-embed-load-failed', undefined, "Couldn't load document")
-    const errorResult = {
+    const errorResult: EmbeddedDocContent = {
       html: `<p class="text-tertiary text-sm italic">${loadFailedMsg}</p>`,
       title: loadFailedMsg,
       icon: '⚠️',
+      slug: null,
       loading: false,
       error: true,
     }
@@ -140,6 +153,7 @@ class EmbeddedDocumentView implements NodeView {
   dom: HTMLElement
   private uuid: string
   private title: string
+  private slug: string | null = null
 
   constructor(node: ProseMirrorNode, _view: EditorView, _getPos: () => number | undefined) {
     this.uuid = node.attrs.documentUuid
@@ -168,7 +182,18 @@ class EmbeddedDocumentView implements NodeView {
   private async loadContent() {
     const data = await fetchDocumentContent(this.uuid)
     this.title = data.title
+    this.slug = data.slug
     this.render(data)
+  }
+
+  // Navigate to the embedded doc. Docs route by slug, so resolve it
+  // (cached after the content fetch) before navigating; without a slug
+  // there's nothing to open.
+  private async openDocument() {
+    if (!this.slug) {
+      this.slug = (await fetchDocumentContent(this.uuid)).slug
+    }
+    if (this.slug && navigateToDocument) navigateToDocument(this.slug)
   }
 
   private render(data: { html: string; title: string; icon: string }) {
@@ -206,17 +231,21 @@ class EmbeddedDocumentView implements NodeView {
           '<polyline points="15,3 21,3 21,9" />' +
           '<line x1="10" y1="14" x2="21" y2="3" />' +
         '</svg>'
+      // Real link so cmd/ctrl/middle-click opens the doc in a new tab;
+      // a plain click is intercepted for SPA navigation.
+      if (this.slug) openEl.setAttribute('href', `/documentation/${this.slug}`)
       openEl.addEventListener('click', (e) => {
-        e.preventDefault()
         e.stopPropagation()
-        if (navigateToDocument) navigateToDocument(this.uuid)
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
+        e.preventDefault()
+        this.openDocument()
       })
       header.appendChild(openEl)
     }
 
     header.addEventListener('click', (e) => {
       if ((e.target as HTMLElement).closest('.embedded-doc-open')) return
-      if (navigateToDocument) navigateToDocument(this.uuid)
+      this.openDocument()
     })
 
     return header

--- a/frontend/src/components/ticketComponents/CollaborativeTicketArticle.vue
+++ b/frontend/src/components/ticketComponents/CollaborativeTicketArticle.vue
@@ -1,12 +1,13 @@
 <!-- CollaborativeTicketArticle.vue -->
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, nextTick } from 'vue';
 import { useRouter } from 'vue-router';
 import { useFluent } from 'fluent-vue';
 import CollaborativeEditor from '@/components/CollaborativeEditor.vue';
 import RevisionList from '@/components/editor/RevisionList.vue';
 import SectionCard from '@/components/common/SectionCard.vue';
 import Icon from '@/components/common/Icon.vue';
+import ConfirmModal from '@/components/common/ConfirmModal.vue';
 import apiClient from '@/services/apiConfig';
 import { docUrl } from '@/utils/docUrl';
 import { useCollabDocId } from '@/composables/useCollabDocId';
@@ -60,14 +61,6 @@ onMounted(() => {
   }
 });
 
-// Handle expand to full page editor
-const handleExpand = () => {
-  router.push({ 
-    path: '/documentation', 
-    query: { ticketId: String(props.ticketId) } 
-  });
-};
-
 // No need to save via HTTP POST - backend automatically saves via WebSocket sync protocol
 // Just update local state for any watchers
 const handleContentChange = (newValue: string) => {
@@ -113,22 +106,41 @@ const toggleRevisionHistory = () => {
   showRevisionHistory.value = !showRevisionHistory.value;
 };
 
-// Handle convert to documentation
-const handleConvertToDocumentation = async () => {
+// Promote this ticket note into a standalone document, then transclude
+// the new doc back into the note. The note's content is cloned into the
+// doc server-side; we then replace the note body with an embed of that
+// doc so the content lives in one place and the ticket shows it inline.
+// Confirmed first, since it rewrites the note body.
+const showPromoteConfirm = ref(false);
+const promoting = ref(false);
+
+const confirmPromote = async () => {
+  promoting.value = true;
   try {
-    // Backend handles both cases: returns existing page or creates new one
+    // Idempotent: returns the existing linked page or creates a new
+    // draft, cloning the note's content and filing it under the
+    // system "Tickets" collection.
     const response = await apiClient.post(`/tickets/${props.ticketId}/documentation/create`, {
       title: t('tickets-collaborative-article-doc-title', { id: props.ticketId }),
       icon: '📋',
-      parent_id: null
+      parent_id: null,
     });
 
-    if (response.data && response.data.id) {
-      // Navigate to the documentation page (existing or newly created)
-      router.push(docUrl(response.data));
+    const doc = response.data;
+    if (doc?.uuid) {
+      // Replace the note body with a transclusion of the new doc, then
+      // let the editor commit it to the collab doc before we navigate
+      // away and unmount it. No content is lost: the doc already holds
+      // the cloned content server-side.
+      editorRef.value?.replaceAllWithEmbeddedDocument({ uuid: doc.uuid, title: doc.title });
+      await nextTick();
+      showPromoteConfirm.value = false;
+      router.push(docUrl(doc));
     }
   } catch (error) {
-    console.error('Failed to convert to documentation:', error);
+    console.error('Failed to promote note to documentation:', error);
+  } finally {
+    promoting.value = false;
   }
 };
 </script>
@@ -146,18 +158,11 @@ const handleConvertToDocumentation = async () => {
         <Icon name="clock" />
       </button>
       <button
-        @click="handleConvertToDocumentation"
+        @click="showPromoteConfirm = true"
         class="p-1 text-tertiary hover:text-primary hover:bg-surface-hover rounded transition-colors"
         :title="t('tickets-collaborative-article-convert-doc')"
       >
-        <Icon name="documentEdit" />
-      </button>
-      <button
-        @click="handleExpand"
-        class="p-1 text-tertiary hover:text-primary hover:bg-surface-hover rounded transition-colors"
-        :title="t('tickets-collaborative-article-open-full')"
-      >
-        <Icon name="openExternal" />
+        <Icon name="book" />
       </button>
     </template>
 
@@ -191,6 +196,18 @@ const handleConvertToDocumentation = async () => {
         />
       </aside>
     </div>
+
+    <ConfirmModal
+      :show="showPromoteConfirm"
+      variant="info"
+      :title="t('tickets-collaborative-article-promote-confirm-title')"
+      :message="t('tickets-collaborative-article-promote-confirm-message')"
+      :confirm-label="t('tickets-collaborative-article-promote-confirm-label')"
+      :cancel-label="t('common-cancel')"
+      :loading="promoting"
+      @confirm="confirmPromote"
+      @close="showPromoteConfirm = false"
+    />
   </SectionCard>
 </template>
 

--- a/frontend/src/components/ticketComponents/CollaborativeTicketArticle.vue
+++ b/frontend/src/components/ticketComponents/CollaborativeTicketArticle.vue
@@ -10,6 +10,7 @@ import Icon from '@/components/common/Icon.vue';
 import ConfirmModal from '@/components/common/ConfirmModal.vue';
 import apiClient from '@/services/apiConfig';
 import { docUrl } from '@/utils/docUrl';
+import { listDocsForTicket, createPageFromTicket, type TicketDocLink } from '@/services/documentationService';
 import { useCollabDocId } from '@/composables/useCollabDocId';
 import { useSyncTicketsStore } from '@/sync/stores/tickets';
 
@@ -50,15 +51,23 @@ const docId = useCollabDocId('ticket', () => ticketsStore.byId(props.ticketId).v
 const showRevisionHistory = ref(false);
 const editorRef = ref<InstanceType<typeof CollaborativeEditor> | null>(null);
 
+// The document this note was promoted into, if any (the 'resolves'
+// link). Drives whether the header action promotes or just opens the
+// existing document, and keeps promote idempotent (no double embed).
+const promotedDoc = ref<TicketDocLink | null>(null);
+
+async function refreshPromotedDoc() {
+  const links = await listDocsForTicket(props.ticketId);
+  promotedDoc.value = links.find((l) => l.link_type === 'resolves') ?? null;
+}
+
 // No need to load content via HTTP - the CollaborativeEditor handles everything via WebSocket
 // The editor will sync with the backend's in-memory Yjs document automatically
 onMounted(() => {
   // Just mark as loaded immediately - editor handles content sync via WebSocket
   isLoading.value = false;
   emit('initialization-complete');
-  if (import.meta.env.DEV) {
-    console.log('CollaborativeTicketArticle mounted for ticket', props.ticketId, '- editor will sync via WebSocket');
-  }
+  refreshPromotedDoc();
 });
 
 // No need to save via HTTP POST - backend automatically saves via WebSocket sync protocol
@@ -114,25 +123,35 @@ const toggleRevisionHistory = () => {
 const showPromoteConfirm = ref(false);
 const promoting = ref(false);
 
+// Header action: open the document if the note was already promoted,
+// otherwise ask to promote.
+const onPromoteOrOpen = () => {
+  if (promotedDoc.value) {
+    router.push(docUrl({ slug: promotedDoc.value.page_slug, id: promotedDoc.value.page_id }));
+    return;
+  }
+  showPromoteConfirm.value = true;
+};
+
 const confirmPromote = async () => {
   promoting.value = true;
   try {
     // Idempotent: returns the existing linked page or creates a new
     // draft, cloning the note's content and filing it under the
     // system "Tickets" collection.
-    const response = await apiClient.post(`/tickets/${props.ticketId}/documentation/create`, {
+    const doc = await createPageFromTicket(props.ticketId, {
       title: t('tickets-collaborative-article-doc-title', { id: props.ticketId }),
       icon: '📋',
       parent_id: null,
     });
 
-    const doc = response.data;
     if (doc?.uuid) {
       // Replace the note body with a transclusion of the new doc, then
       // let the editor commit it to the collab doc before we navigate
       // away and unmount it. No content is lost: the doc already holds
       // the cloned content server-side.
       editorRef.value?.replaceAllWithEmbeddedDocument({ uuid: doc.uuid, title: doc.title });
+      await refreshPromotedDoc();
       await nextTick();
       showPromoteConfirm.value = false;
       router.push(docUrl(doc));
@@ -158,9 +177,9 @@ const confirmPromote = async () => {
         <Icon name="clock" />
       </button>
       <button
-        @click="showPromoteConfirm = true"
+        @click="onPromoteOrOpen"
         class="p-1 text-tertiary hover:text-primary hover:bg-surface-hover rounded transition-colors"
-        :title="t('tickets-collaborative-article-convert-doc')"
+        :title="promotedDoc ? t('tickets-collaborative-article-open-doc') : t('tickets-collaborative-article-convert-doc')"
       >
         <Icon name="book" />
       </button>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -476,13 +476,6 @@ const router = createRouter({
         to.meta.titleKeyArgs = undefined;
         to.meta.preloadedDocument = undefined;
 
-        // Handle ticket notes, preloaded inside component (needs different data shape)
-        if (to.query.ticketId) {
-          to.meta.titleKey = 'route-title-ticket-notes';
-          to.meta.titleKeyArgs = { id: String(to.query.ticketId) };
-          return;
-        }
-
         // Preload document data so the view renders instantly
         const path = to.params.path?.toString();
         if (path) {

--- a/frontend/src/views/DocumentView.vue
+++ b/frontend/src/views/DocumentView.vue
@@ -13,7 +13,6 @@ import { useDocumentPanelState } from '@/composables/useDocumentPanelState'
 import { useMyWorkspacesStore } from '@/stores/myWorkspaces'
 import { buildCollabDocId } from '@/utils/collabDocId'
 import documentationService from '@/services/documentationService'
-import ticketService from '@/services/ticketService'
 import type { Page, Article } from '@/services/documentationService'
 import CollaborativeEditor from '@/components/CollaborativeEditor.vue'
 import BackButton from '@/components/common/BackButton.vue'
@@ -107,13 +106,6 @@ watch(showInsights, (open) => {
   if (open) refreshInsightsText()
 })
 
-// Ticket note mode
-const isTicketNote = ref(false)
-const ticketId = ref<string | null>(null)
-// The ticket's immutable UUID, used to key the collab doc so a recycled
-// integer id can't inherit a previous ticket's cached note.
-const ticketUuid = ref<string | null>(null)
-
 // Subscription state
 const isSubscribed = ref(false)
 
@@ -122,7 +114,7 @@ const isStarred = ref(false)
 
 // Computed helpers
 const currentPageId = computed(() => document.value?.id ?? null)
-const isDocumentPage = computed(() => !!document.value && !isTicketNote.value)
+const isDocumentPage = computed(() => !!document.value)
 
 const handleCopyLink = () => {
   const slug = document.value?.slug || document.value?.id
@@ -149,11 +141,9 @@ const documentObj = computed(() => {
   }
 })
 
-// Doc ID for CollaborativeEditor. Pages own their Yjs doc directly;
-// ticket notes share the room with the originating ticket. Both
-// share the workspace-namespaced docId format (see
-// utils/collabDocId.ts) so stale IDB caches across a database reset
-// can't repopulate the new doc.
+// Doc ID for CollaborativeEditor. Pages own their Yjs doc, keyed by the
+// page's immutable UUID (see utils/collabDocId.ts) so stale IDB caches
+// across a database reset can't repopulate the new doc.
 //
 // Returns `null` (rather than a fabricated default) until the
 // workspace UUID resolves. The editor render is gated below so the
@@ -164,13 +154,6 @@ const workspaces = useMyWorkspacesStore()
 const docId = computed(() => {
   const uuid = workspaces.activeWorkspace?.workspace_uuid
   if (!uuid) return null
-  // Collab docs are keyed by the resource's immutable UUID, never the
-  // recyclable integer id (see utils/collabDocId.ts). Return null until
-  // the UUID is known so the editor waits rather than connecting under
-  // a wrong/temporary key.
-  if (isTicketNote.value) {
-    return ticketUuid.value ? buildCollabDocId(uuid, 'ticket', ticketUuid.value) : null
-  }
   if (document.value && 'uuid' in document.value && document.value.uuid) {
     return buildCollabDocId(uuid, 'doc', document.value.uuid)
   }
@@ -181,19 +164,9 @@ const docId = computed(() => {
 })
 
 // Navigation helpers
-const fallbackRoute = computed(() => {
-  if (isTicketNote.value && ticketId.value) {
-    return `/tickets/${ticketId.value}`
-  }
-  return '/documentation'
-})
+const fallbackRoute = computed(() => '/documentation')
 
-const backButtonLabel = computed(() => {
-  if (isTicketNote.value) {
-    return t('doc-detail-back-to-ticket')
-  }
-  return t('doc-detail-back-to-documentation')
-})
+const backButtonLabel = computed(() => t('doc-detail-back-to-documentation'))
 
 // Content update handler
 const updateContent = (newContent: string) => {
@@ -411,44 +384,6 @@ const fetchContent = async () => {
   }
   isLoading.value = true
 
-  // Check for ticket note mode
-  if (route.query.ticketId) {
-    const ticketIdParam = route.query.ticketId as string
-
-    try {
-      const ticket = await ticketService.getTicketById(Number(ticketIdParam))
-
-      if (ticket) {
-        document.value = {
-          id: `ticket-note-${ticketIdParam}`,
-          title: t('doc-detail-ticket-note-title', { id: ticket.id }),
-          description: t('doc-detail-ticket-note-description', { title: ticket.title }),
-          content: ticket.article_content || '',
-          author: ticket.assignee || t('doc-detail-ticket-note-author-system'),
-          lastUpdated: ticket.modified,
-          status: 'published',
-          slug: '',
-          parent_id: null,
-          icon: null,
-          children: [],
-        }
-
-        isTicketNote.value = true
-        ticketId.value = ticketIdParam
-        ticketUuid.value = ticket.uuid ?? null
-        editContent.value = document.value.content || ''
-        editTitle.value = document.value.title
-        documentIcon.value = document.value.icon || 'mdi-text-box-outline'
-
-        emit('update:title', document.value.title)
-        isLoading.value = false
-        return
-      }
-    } catch (error) {
-      console.error(`Error loading ticket ${ticketIdParam}:`, error)
-    }
-  }
-
   // Load document by path
   const path = route.params.path as string
 
@@ -493,7 +428,7 @@ const fetchContent = async () => {
     isLoading.value = false
 
     // Fetch subscription and starred status for the loaded page
-    if (currentPageId.value && !isTicketNote.value) {
+    if (currentPageId.value) {
       documentationService.getPageSubscription(Number(currentPageId.value)).then(subscribed => {
         isSubscribed.value = subscribed
       })
@@ -662,7 +597,7 @@ watch(documentObj, (newDocument) => {
 
         <!-- Publish button for unpublished pages -->
         <button
-          v-if="document && !isTicketNote && document.status !== 'published'"
+          v-if="document && document.status !== 'published'"
           @click="handlePublishPage"
           class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-emerald-600 text-white hover:bg-emerald-700 transition-colors"
         >
@@ -739,7 +674,6 @@ watch(documentObj, (newDocument) => {
           <div class="w-full max-w-3xl px-4 sm:px-6 lg:px-8 py-6 sm:py-8 flex flex-col">
             <!-- Breadcrumb -->
             <DocumentationBreadcrumb
-              v-if="!isTicketNote"
               :page-id="document.id || ''"
               :parent-id="document.parent_id || null"
               class="mb-4"
@@ -780,7 +714,7 @@ watch(documentObj, (newDocument) => {
                     the author badge.
                   -->
                   <button
-                    v-if="!isTicketNote && document.created_by && document.requires_verification && !document.verified_at"
+                    v-if="document.created_by && document.requires_verification && !document.verified_at"
                     type="button"
                     class="text-[10px] px-1.5 py-0.5 rounded font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors flex items-center gap-1"
                     :title="$t('doc-detail-needs-verification-title')"
@@ -790,7 +724,7 @@ watch(documentObj, (newDocument) => {
                     {{ $t('doc-detail-needs-verification') }}
                   </button>
                   <button
-                    v-else-if="!isTicketNote && document.is_stale"
+                    v-else-if="document.is_stale"
                     type="button"
                     class="text-[10px] px-1.5 py-0.5 rounded font-medium bg-amber-500/15 text-amber-700 dark:text-amber-300 hover:bg-amber-500/25 transition-colors flex items-center gap-1 animate-pulse"
                     :title="$t('doc-detail-verification-stale-title')"
@@ -806,7 +740,7 @@ watch(documentObj, (newDocument) => {
                        picker. Two-way bind on `open` lets the
                        sibling status chip open the same popover. -->
                   <DocumentAuthorBadge
-                    v-if="!isTicketNote && document.created_by"
+                    v-if="document.created_by"
                     v-model:open="verificationOpen"
                     :page="document"
                     :can-verify="authStore.isTechnician || authStore.isAdmin"
@@ -862,7 +796,7 @@ watch(documentObj, (newDocument) => {
               />
 
               <PageTicketLinksPanel
-                v-if="!isTicketNote && document.id"
+                v-if="document.id"
                 :page-id="document.id"
                 :can-edit="authStore.isTechnician || authStore.isAdmin"
               />

--- a/i18n/locales/en-AU/main.ftl
+++ b/i18n/locales/en-AU/main.ftl
@@ -2371,7 +2371,6 @@ docs-gaps-resolve-action = Save as doc
 # Document view (DocumentView): full-page editor for a single doc
 # page (or a ticket note). Covers the header toolbar, metadata
 # strip, save indicators, verification chips, panels, and toasts.
-doc-detail-back-to-ticket = Back to Ticket
 doc-detail-back-to-documentation = Back to Documentation
 doc-detail-saving = Saving
 doc-detail-publish = Publish
@@ -2399,9 +2398,6 @@ doc-detail-toast-deleting = Deleting document
 doc-detail-toast-deleted = Document deleted
 doc-detail-toast-delete-error = Couldn't delete document
 doc-detail-duplicate-suffix = { $title } (copy)
-doc-detail-ticket-note-title = Notes for Ticket #{ $id }
-doc-detail-ticket-note-description = Documentation for ticket { $title }
-doc-detail-ticket-note-author-system = System
 
 # Asset planner (AssetPlannerView): rollout-planning kanban for
 # devices, grouped by OS family, warranty bucket, or compliance
@@ -4539,7 +4535,6 @@ tickets-collaborative-article-title = Ticket Notes
 tickets-collaborative-article-doc-title = Docs: Ticket #{ $id }
 tickets-collaborative-article-revision-history = Revision history
 tickets-collaborative-article-convert-doc = Turn into a docs page
-tickets-collaborative-article-open-full = Open full editor
 tickets-project-info-remove = Remove from project
 tickets-project-info-description = Description
 tickets-project-info-project-id = Project ID
@@ -4616,7 +4611,6 @@ route-title-dashboard = Dashboard
 route-title-inbox = Inbox
 route-title-tickets = Tickets
 route-title-ticket-view = View ticket
-route-title-ticket-notes = Ticket #{ $id } notes
 route-title-user-profile = User profile
 route-title-user-settings = User settings
 route-title-user-settings-profile = User profile settings

--- a/i18n/locales/en-GB/main.ftl
+++ b/i18n/locales/en-GB/main.ftl
@@ -2358,7 +2358,6 @@ docs-gaps-resolve-action = Save as doc
 # Document view (DocumentView): full-page editor for a single doc
 # page (or a ticket note). Covers the header toolbar, metadata
 # strip, save indicators, verification chips, panels, and toasts.
-doc-detail-back-to-ticket = Back to Ticket
 doc-detail-back-to-documentation = Back to Documentation
 doc-detail-saving = Saving
 doc-detail-publish = Publish
@@ -2386,9 +2385,6 @@ doc-detail-toast-deleting = Deleting document
 doc-detail-toast-deleted = Document deleted successfully
 doc-detail-toast-delete-error = Error deleting document
 doc-detail-duplicate-suffix = { $title } (copy)
-doc-detail-ticket-note-title = Notes for Ticket #{ $id }
-doc-detail-ticket-note-description = Documentation for ticket { $title }
-doc-detail-ticket-note-author-system = System
 
 # Asset planner (AssetPlannerView): rollout-planning kanban for
 # devices, grouped by OS family, warranty bucket, or compliance
@@ -4527,7 +4523,6 @@ tickets-collaborative-article-title = Ticket Notes
 tickets-collaborative-article-doc-title = Documentation: Ticket #{ $id }
 tickets-collaborative-article-revision-history = Revision history
 tickets-collaborative-article-convert-doc = Convert to documentation page
-tickets-collaborative-article-open-full = Open full editor
 tickets-project-info-remove = Remove from project
 tickets-project-info-description = Description
 tickets-project-info-project-id = Project ID
@@ -4604,7 +4599,6 @@ route-title-dashboard = Dashboard
 route-title-inbox = Inbox
 route-title-tickets = Tickets
 route-title-ticket-view = View ticket
-route-title-ticket-notes = Ticket #{ $id } notes
 route-title-user-profile = User profile
 route-title-user-settings = User settings
 route-title-user-settings-profile = User profile settings

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -2895,7 +2895,6 @@ docs-gaps-resolve-action = Save as doc
 # Document view (DocumentView): full-page editor for a single doc
 # page (or a ticket note). Covers the header toolbar, metadata
 # strip, save indicators, verification chips, panels, and toasts.
-doc-detail-back-to-ticket = Back to Ticket
 doc-detail-back-to-documentation = Back to Documentation
 doc-detail-saving = Saving
 doc-detail-publish = Publish
@@ -2923,9 +2922,6 @@ doc-detail-toast-deleting = Deleting document
 doc-detail-toast-deleted = Document deleted successfully
 doc-detail-toast-delete-error = Error deleting document
 doc-detail-duplicate-suffix = { $title } (copy)
-doc-detail-ticket-note-title = Notes for Ticket #{ $id }
-doc-detail-ticket-note-description = Documentation for ticket { $title }
-doc-detail-ticket-note-author-system = System
 
 # devices, grouped by OS family, warranty bucket, or compliance
 # state. Covers the header, sidebar filters, group columns, and
@@ -5321,7 +5317,9 @@ tickets-collaborative-article-title = Ticket Notes
 tickets-collaborative-article-doc-title = Documentation: Ticket #{ $id }
 tickets-collaborative-article-revision-history = Revision history
 tickets-collaborative-article-convert-doc = Convert to documentation page
-tickets-collaborative-article-open-full = Open full editor
+tickets-collaborative-article-promote-confirm-title = Promote note to a document?
+tickets-collaborative-article-promote-confirm-message = This moves the note's content into a new document and replaces the note with an embed of it. The document opens in full-page view, and the ticket keeps showing it inline.
+tickets-collaborative-article-promote-confirm-label = Promote
 tickets-project-info-remove = Remove from project
 tickets-project-info-description = Description
 tickets-project-info-project-id = Project ID
@@ -5398,7 +5396,6 @@ route-title-dashboard = Dashboard
 route-title-inbox = Inbox
 route-title-tickets = Tickets
 route-title-ticket-view = View ticket
-route-title-ticket-notes = Ticket #{ $id } notes
 route-title-user-profile = User profile
 route-title-user-settings = User settings
 route-title-user-settings-profile = User profile settings

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -5317,6 +5317,7 @@ tickets-collaborative-article-title = Ticket Notes
 tickets-collaborative-article-doc-title = Documentation: Ticket #{ $id }
 tickets-collaborative-article-revision-history = Revision history
 tickets-collaborative-article-convert-doc = Convert to documentation page
+tickets-collaborative-article-open-doc = Open linked document
 tickets-collaborative-article-promote-confirm-title = Promote note to a document?
 tickets-collaborative-article-promote-confirm-message = This moves the note's content into a new document and replaces the note with an embed of it. The document opens in full-page view, and the ticket keeps showing it inline.
 tickets-collaborative-article-promote-confirm-label = Promote

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -5208,6 +5208,8 @@ tickets-collaborative-article-doc-title = Documentation : Ticket n°{ $id }
 tickets-collaborative-article-revision-history = Historique des révisions
 tickets-collaborative-article-convert-doc = Convertir en page de documentation
 # Machine-translated, pending native review.
+tickets-collaborative-article-open-doc = Ouvrir le document lié
+# Machine-translated, pending native review.
 tickets-collaborative-article-promote-confirm-title = Promouvoir la note en document ?
 tickets-collaborative-article-promote-confirm-message = Le contenu de la note est déplacé dans un nouveau document, et la note est remplacée par une intégration de celui-ci. Le document s'ouvre en plein écran, et le ticket continue de l'afficher en ligne.
 tickets-collaborative-article-promote-confirm-label = Promouvoir

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -2840,7 +2840,6 @@ docs-gaps-resolve-action = Enregistrer comme document
 # Document view (DocumentView): full-page editor for a single doc
 # page (or a ticket note). Covers the header toolbar, metadata
 # strip, save indicators, verification chips, panels, and toasts.
-doc-detail-back-to-ticket = Retour au ticket
 doc-detail-back-to-documentation = Retour à la documentation
 doc-detail-saving = Enregistrement
 doc-detail-publish = Publier
@@ -2868,9 +2867,6 @@ doc-detail-toast-deleting = Suppression du document
 doc-detail-toast-deleted = Document supprimé avec succès
 doc-detail-toast-delete-error = Erreur lors de la suppression du document
 doc-detail-duplicate-suffix = { $title } (copie)
-doc-detail-ticket-note-title = Notes pour le ticket n°{ $id }
-doc-detail-ticket-note-description = Documentation pour le ticket { $title }
-doc-detail-ticket-note-author-system = Système
 
 # déploiements d'équipements, regroupés par famille d'OS, période
 # de garantie ou état de conformité. Couvre l'en-tête, les filtres
@@ -5211,7 +5207,10 @@ tickets-collaborative-article-title = Notes du ticket
 tickets-collaborative-article-doc-title = Documentation : Ticket n°{ $id }
 tickets-collaborative-article-revision-history = Historique des révisions
 tickets-collaborative-article-convert-doc = Convertir en page de documentation
-tickets-collaborative-article-open-full = Ouvrir l'éditeur complet
+# Machine-translated, pending native review.
+tickets-collaborative-article-promote-confirm-title = Promouvoir la note en document ?
+tickets-collaborative-article-promote-confirm-message = Le contenu de la note est déplacé dans un nouveau document, et la note est remplacée par une intégration de celui-ci. Le document s'ouvre en plein écran, et le ticket continue de l'afficher en ligne.
+tickets-collaborative-article-promote-confirm-label = Promouvoir
 tickets-project-info-remove = Retirer du projet
 tickets-project-info-description = Description
 tickets-project-info-project-id = ID projet
@@ -5288,7 +5287,6 @@ route-title-dashboard = Tableau de bord
 route-title-inbox = Boîte de réception
 route-title-tickets = Tickets
 route-title-ticket-view = Voir le ticket
-route-title-ticket-notes = Notes du ticket #{ $id }
 route-title-user-profile = Profil utilisateur
 route-title-user-settings = Paramètres utilisateur
 route-title-user-settings-profile = Paramètres du profil utilisateur

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -2831,7 +2831,6 @@ docs-gaps-resolve-action = Opslaan als document
 # Document view (DocumentView): full-page editor for a single doc
 # page (or a ticket note). Covers the header toolbar, metadata
 # strip, save indicators, verification chips, panels, and toasts.
-doc-detail-back-to-ticket = Terug naar ticket
 doc-detail-back-to-documentation = Terug naar documentatie
 doc-detail-saving = Bezig met opslaan
 doc-detail-publish = Publiceren
@@ -2859,9 +2858,6 @@ doc-detail-toast-deleting = Document verwijderen
 doc-detail-toast-deleted = Document succesvol verwijderd
 doc-detail-toast-delete-error = Fout bij verwijderen document
 doc-detail-duplicate-suffix = { $title } (kopie)
-doc-detail-ticket-note-title = Notities voor ticket #{ $id }
-doc-detail-ticket-note-description = Documentatie voor ticket { $title }
-doc-detail-ticket-note-author-system = Systeem
 
 # apparaat-uitrol, gegroepeerd op OS-familie, garantieperiode of
 # nalevingsstatus. Bevat de header, zijbalkfilters, groepkolommen
@@ -5202,7 +5198,10 @@ tickets-collaborative-article-title = Ticketnotities
 tickets-collaborative-article-doc-title = Documentatie: ticket #{ $id }
 tickets-collaborative-article-revision-history = Versiegeschiedenis
 tickets-collaborative-article-convert-doc = Omzetten naar documentatiepagina
-tickets-collaborative-article-open-full = Volledige editor openen
+# Machine-translated, pending native review.
+tickets-collaborative-article-promote-confirm-title = Notitie promoveren naar document?
+tickets-collaborative-article-promote-confirm-message = Hiermee wordt de inhoud van de notitie naar een nieuw document verplaatst en wordt de notitie vervangen door een insluiting ervan. Het document opent in volledig scherm en het ticket blijft het inline tonen.
+tickets-collaborative-article-promote-confirm-label = Promoveren
 tickets-project-info-remove = Uit project verwijderen
 tickets-project-info-description = Beschrijving
 tickets-project-info-project-id = Project-ID
@@ -5279,7 +5278,6 @@ route-title-dashboard = Dashboard
 route-title-inbox = Inbox
 route-title-tickets = Tickets
 route-title-ticket-view = Ticket bekijken
-route-title-ticket-notes = Notities ticket #{ $id }
 route-title-user-profile = Gebruikersprofiel
 route-title-user-settings = Gebruikersinstellingen
 route-title-user-settings-profile = Instellingen gebruikersprofiel

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -5199,6 +5199,8 @@ tickets-collaborative-article-doc-title = Documentatie: ticket #{ $id }
 tickets-collaborative-article-revision-history = Versiegeschiedenis
 tickets-collaborative-article-convert-doc = Omzetten naar documentatiepagina
 # Machine-translated, pending native review.
+tickets-collaborative-article-open-doc = Gekoppeld document openen
+# Machine-translated, pending native review.
 tickets-collaborative-article-promote-confirm-title = Notitie promoveren naar document?
 tickets-collaborative-article-promote-confirm-message = Hiermee wordt de inhoud van de notitie naar een nieuw document verplaatst en wordt de notitie vervangen door een insluiting ervan. Het document opent in volledig scherm en het ticket blijft het inline tonen.
 tickets-collaborative-article-promote-confirm-label = Promoveren


### PR DESCRIPTION
## Summary

Replaces the brittle "open ticket note full page" feature with a coherent **promote → transclude** model, and fixes embedded-document navigation along the way.

The old full-page view rendered a ticket note inside `DocumentView` via a `route.query.ticketId` special case. It was fragile (it broke), and it overlapped confusingly with "convert to documentation". Documents already have a real full-page editor and we already have transclusion, so:

- Ticket notes stay lightweight and ticket-scoped.
- When a note grows into something substantial, **promote** it: the existing endpoint creates the documentation page (draft, filed under the system "Tickets" collection, content cloned), the note body is replaced with an **embed of that doc**, and the doc opens in its own full-page editor. Content lives in one place; the ticket shows it inline.
- The full-page-note hack is deleted.

## Changes

**Promote flow**
- `CollaborativeEditor`: new `replaceAllWithEmbeddedDocument`, sharing the embed-node builder with `insertEmbeddedDocument` (DRY).
- `CollaborativeTicketArticle`: confirm-gated promote via the typed `createPageFromTicket`; the book action reflects state, "Promote to document" when none exists, "Open linked document" once promoted (loaded from `GET /tickets/{id}/documentation`), so it stays idempotent and never double-embeds.

**Delete the full-page-note hack**
- Remove the expand button + `handleExpand`.
- Strip ticket-note mode from `DocumentView.vue` (refs, `fetchContent` branch, `docId`/`fallbackRoute`/`backButtonLabel` branches, `!isTicketNote` template guards, `ticketService` import).
- Remove the router `beforeEnter` `ticketId` block and six dead i18n keys across all locales.

**Embedded-document navigation fix**
- The embed open affordance navigated to `/documentation/<uuid>`, but the route resolves `:path` by slug, so it 404'd to the index. The content-by-uuid endpoint now returns `slug`; the embed resolves it before navigating; the open link is a real `<a href>` so cmd/middle-click opens a new tab while a plain click does SPA navigation.

## Scope notes

- One backend line (add `slug` to the content-by-uuid JSON response). No migration, no new endpoint.
- Promoted docs are contained as `Draft` + `is_public=false` in the "Tickets" collection (no KB pollution); decided against a dedicated "unlisted" flag for now.
- Net change is roughly even, with `DocumentView` and the router getting noticeably smaller.

## Testing

- Frontend type-check + eslint clean; backend rustfmt clean and compiles.
- Manual smoke test recommended before merge: promote a note → confirm → note collapses to the embed → lands in the doc editor → reopen the ticket → button reads "Open linked document" and the embed title opens the doc (hard refresh first to clear the embed content cache).