### PR TITLE
feat(auth): bearer-token session auth for native clients

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -151,7 +151,7 @@ pub(crate) fn complete_login(
     conn: &mut DbConnection,
 ) -> HttpResponse {
     match establish_login_session(user, request, conn) {
-        Ok((response, tokens)) => build_auth_cookie_response(response, &tokens),
+        Ok((response, tokens)) => build_auth_response(request, response, &tokens),
         Err(error_response) => error_response,
     }
 }
@@ -261,27 +261,62 @@ fn complete_mfa_login(
         &family_id,
         conn,
     ) {
-        Ok((response, tokens)) => build_auth_cookie_response(response, &tokens),
+        Ok((response, tokens)) => build_auth_response(request, response, &tokens),
         Err(error_response) => error_response,
     }
 }
 
-/// Attach auth cookies to an HTTP response.
-pub(crate) fn build_auth_cookie_response(
+/// Finish a login response, delivering the session tokens the way the client
+/// asked for (see `utils::auth_mode`).
+///
+/// - Cookie mode (web, the default): set the three httpOnly auth cookies and
+///   return `body` unchanged. Byte-identical to the historical behaviour.
+/// - Bearer mode (native, `X-Auth-Mode: bearer`): set NO cookies and inject the
+///   `access_token` + `refresh_token` into the JSON body, marked `no-store`.
+///
+/// The body is injected as a `serde_json::Value` rather than via typed fields so
+/// the same helper serves both the `LoginResponse` callers and the passkey
+/// finishers, which pass an ad-hoc `json!` value.
+pub(crate) fn build_auth_response(
+    request: &HttpRequest,
     body: impl serde::Serialize,
     tokens: &jwt_helpers::LoginTokens,
 ) -> HttpResponse {
-    HttpResponse::Ok()
-        .cookie(crate::utils::cookies::create_access_token_cookie(
-            &tokens.access_token,
-        ))
-        .cookie(crate::utils::cookies::create_refresh_token_cookie(
-            &tokens.refresh_token,
-        ))
-        .cookie(crate::utils::cookies::create_csrf_token_cookie(
-            &tokens.csrf_token,
-        ))
-        .json(body)
+    use crate::utils::auth_mode::{auth_mode_from_request, AuthMode};
+
+    match auth_mode_from_request(request) {
+        AuthMode::Cookie => HttpResponse::Ok()
+            .cookie(crate::utils::cookies::create_access_token_cookie(
+                &tokens.access_token,
+            ))
+            .cookie(crate::utils::cookies::create_refresh_token_cookie(
+                &tokens.refresh_token,
+            ))
+            .cookie(crate::utils::cookies::create_csrf_token_cookie(
+                &tokens.csrf_token,
+            ))
+            .json(body),
+        AuthMode::Bearer => {
+            // Native clients can't use the cookie jar, so hand them the tokens
+            // in the body and set no cookies. Inject into the serialized value
+            // so both LoginResponse and the passkey json! bodies pick them up.
+            let mut value = match serde_json::to_value(&body) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!("Failed to serialize bearer login body: {}", e);
+                    return errors::internal("Failed to build authentication response");
+                }
+            };
+            if let Some(obj) = value.as_object_mut() {
+                obj.insert("access_token".to_string(), json!(tokens.access_token));
+                obj.insert("refresh_token".to_string(), json!(tokens.refresh_token));
+            }
+            HttpResponse::Ok()
+                // The body now carries session secrets; keep them out of caches.
+                .insert_header(("Cache-Control", "no-store"))
+                .json(value)
+        }
+    }
 }
 
 /// Set the auth cookies and redirect (302) to `location`. The browser
@@ -2006,7 +2041,7 @@ pub async fn mfa_enable_login(
                     // the source allocation still gets wiped via
                     // the wrapper's Drop on handler exit.
                     response.backup_codes = Some((*backup_codes_plaintext).clone());
-                    build_auth_cookie_response(response, &tokens)
+                    build_auth_response(&http_request, response, &tokens)
                 }
                 Err(error_response) => error_response,
             }
@@ -2259,22 +2294,39 @@ pub async fn revoke_all_other_sessions(
 /// Refresh access token using refresh token (with reuse detection + grace period)
 pub async fn refresh_token(
     db_pool: web::Data<crate::db::Pool>,
+    // Optional so web clients, which POST an empty body and carry the refresh
+    // token in the httpOnly cookie, still bind.
+    body: Option<web::Json<crate::models::RefreshRequest>>,
     request: HttpRequest,
 ) -> impl Responder {
+    use crate::utils::auth_mode::{auth_mode_from_request, AuthMode};
+
     let mut conn = match helpers::db_conn(&db_pool) {
         Ok(c) => c,
         Err(e) => return e,
     };
 
-    // 1. Read refresh cookie → hash → lookup
-    let refresh_cookie = match request.cookie(crate::utils::cookies::REFRESH_TOKEN_COOKIE) {
-        Some(cookie) => cookie.value().to_string(),
+    // 1. Source the refresh token: native clients send it in the body, web
+    //    clients in the httpOnly cookie. Reply in body-token (bearer) mode when
+    //    the token came from the body or the client asked via X-Auth-Mode, so a
+    //    native caller never gets Set-Cookie back.
+    let from_body = body
+        .as_ref()
+        .and_then(|b| b.refresh_token.clone())
+        .filter(|t| !t.is_empty());
+    let bearer_mode = from_body.is_some() || auth_mode_from_request(&request) == AuthMode::Bearer;
+    let refresh_raw = match from_body.or_else(|| {
+        request
+            .cookie(crate::utils::cookies::REFRESH_TOKEN_COOKIE)
+            .map(|c| c.value().to_string())
+    }) {
+        Some(token) => token,
         None => {
             return errors::unauthorized("Refresh token not found");
         }
     };
 
-    let token_hash = JwtUtils::hash_refresh_token(&refresh_cookie);
+    let token_hash = JwtUtils::hash_refresh_token(&refresh_raw);
 
     let old_token = match crate::repository::refresh_tokens::get_refresh_token_by_hash(
         &mut conn,
@@ -2397,12 +2449,28 @@ pub async fn refresh_token(
         tracing::warn!("Failed to update session activity: {}", e);
     }
 
-    // 11. Return new tokens
+    // 11. Return new tokens, the way the client asked for them.
     let new_csrf_token = crate::utils::csrf::generate_csrf_token();
 
+    if bearer_mode {
+        // Native: rotated tokens in the body, no cookies, kept out of caches.
+        let response = crate::models::RefreshTokenResponse {
+            success: true,
+            csrf_token: new_csrf_token,
+            access_token: Some(new_access_token),
+            refresh_token: Some(new_refresh_raw),
+        };
+        return HttpResponse::Ok()
+            .insert_header(("Cache-Control", "no-store"))
+            .json(response);
+    }
+
+    // Web: rotated tokens in httpOnly cookies, only CSRF in the body (unchanged).
     let response = crate::models::RefreshTokenResponse {
         success: true,
         csrf_token: new_csrf_token.clone(),
+        access_token: None,
+        refresh_token: None,
     };
 
     HttpResponse::Ok()
@@ -2550,5 +2618,77 @@ mod tests {
             Some(user_uuid.to_string().as_str())
         );
         assert_eq!(json.get("name").and_then(|v| v.as_str()), Some("authuser"));
+    }
+}
+
+/// Serde invariants for bearer-mode tokens. Kept in a separate module so the
+/// standard `#[test]` attribute isn't shadowed by the `actix_web::test` import
+/// in the main `tests` module above. No DB needed.
+#[cfg(test)]
+mod bearer_serde_tests {
+    /// Web (cookie) flow leaves the token fields `None`; they must then be
+    /// omitted from the JSON entirely so the response is byte-identical to
+    /// before bearer support. A regression here leaks session tokens into the
+    /// web body, defeating the httpOnly cookies.
+    #[test]
+    fn login_response_omits_token_fields_when_none() {
+        let response = crate::models::LoginResponse {
+            success: true,
+            mfa_required: Some(false),
+            mfa_setup_required: Some(false),
+            passkey_mfa_required: None,
+            user_uuid: Some("u".into()),
+            csrf_token: Some("csrf".into()),
+            user: None,
+            message: None,
+            mfa_backup_code_used: None,
+            requires_backup_code_regeneration: None,
+            backup_codes: None,
+            access_token: None,
+            refresh_token: None,
+        };
+        let json = serde_json::to_value(&response).unwrap();
+        assert!(
+            json.get("access_token").is_none(),
+            "web login leaked access_token"
+        );
+        assert!(
+            json.get("refresh_token").is_none(),
+            "web login leaked refresh_token"
+        );
+        assert_eq!(
+            json.get("csrf_token").and_then(|v| v.as_str()),
+            Some("csrf")
+        );
+    }
+
+    /// Bearer mode surfaces both rotated tokens in the refresh body.
+    #[test]
+    fn refresh_response_includes_tokens_in_bearer_mode() {
+        let web = crate::models::RefreshTokenResponse {
+            success: true,
+            csrf_token: "csrf".into(),
+            access_token: None,
+            refresh_token: None,
+        };
+        let web_json = serde_json::to_value(&web).unwrap();
+        assert!(web_json.get("access_token").is_none());
+        assert!(web_json.get("refresh_token").is_none());
+
+        let native = crate::models::RefreshTokenResponse {
+            success: true,
+            csrf_token: "csrf".into(),
+            access_token: Some("at".into()),
+            refresh_token: Some("rt".into()),
+        };
+        let native_json = serde_json::to_value(&native).unwrap();
+        assert_eq!(
+            native_json.get("access_token").and_then(|v| v.as_str()),
+            Some("at")
+        );
+        assert_eq!(
+            native_json.get("refresh_token").and_then(|v| v.as_str()),
+            Some("rt")
+        );
     }
 }

--- a/backend/src/handlers/passkeys.rs
+++ b/backend/src/handlers/passkeys.rs
@@ -682,7 +682,8 @@ pub async fn finish_passkey_login(
     match jwt_helpers::create_login_response(user, &session.session_id, &family_id, &mut conn) {
         Ok((response, tokens)) => {
             info!("Passkey login successful for user {}", user_uuid);
-            super::auth::build_auth_cookie_response(
+            super::auth::build_auth_response(
+                &req,
                 json!({
                     "success": true,
                     "csrf_token": response.csrf_token,
@@ -1349,7 +1350,7 @@ pub async fn finish_passkey_setup_login(
                 response_json["backup_codes"] = json!(&*plaintext_codes);
             }
 
-            super::auth::build_auth_cookie_response(response_json, &tokens)
+            super::auth::build_auth_response(&req, response_json, &tokens)
         }
         Err(error_response) => error_response,
     }

--- a/backend/src/middleware/api_token.rs
+++ b/backend/src/middleware/api_token.rs
@@ -3,9 +3,26 @@
 //! Provides Bearer token authentication for programmatic API access.
 //! Works alongside cookie-based authentication.
 
-use actix_web::{dev::ServiceRequest, web, Error, HttpMessage};
+use actix_web::{dev::ServiceRequest, web, Error, HttpMessage, HttpResponse};
 use std::net::IpAddr;
 use tracing::{debug, error, info, warn};
+
+/// Build an RFC 6750 `401` carrying a `WWW-Authenticate: Bearer` challenge.
+///
+/// Per §3, include `error="invalid_token"` only when a credential was presented
+/// and failed; send a bare `Bearer` challenge when none was presented (so a
+/// client isn't told *why* auth is needed when it offered nothing).
+fn bearer_unauthorized(invalid_token: bool, message: &'static str) -> Error {
+    let challenge = if invalid_token {
+        "Bearer error=\"invalid_token\""
+    } else {
+        "Bearer"
+    };
+    let response = HttpResponse::Unauthorized()
+        .insert_header(("WWW-Authenticate", challenge))
+        .body(message);
+    actix_web::error::InternalError::from_response(message, response).into()
+}
 
 use crate::db::Pool;
 use crate::middleware::request_context;
@@ -182,33 +199,61 @@ pub async fn dual_auth_middleware(
         .ok_or_else(|| actix_web::error::ErrorInternalServerError("Database pool not found"))?
         .clone();
 
-    // Try Bearer token authentication first
-    match try_bearer_auth(&req, &pool)? {
-        Some(claims) => {
-            // Item U: workspace membership 403 gate. Bearer-token
-            // requests go through the same check as cookie-auth so an
-            // API token issued in workspace A can't be used to probe
-            // workspace B's subdomain. (The control-plane provisioning
-            // surface is no longer an api_token, so there's no
-            // cross-workspace token kind to exempt here.)
+    use crate::utils::jwt::JwtUtils;
+
+    // A Bearer credential can be either a personal API token (`nsk_…`, looked up
+    // in the DB) or a session JWT (native/mobile clients, who can't use the
+    // cookie jar). Branch on the unambiguous prefix; a JWT never starts `nsk_`.
+    if let Some(raw) = extract_bearer_token(&req) {
+        if raw.starts_with("nsk_") {
+            // Personal API token — unchanged behaviour.
+            let claims = try_bearer_auth(&req, &pool)?
+                .ok_or_else(|| bearer_unauthorized(true, "Invalid API token"))?;
             let mut conn = pool.get().map_err(|_| {
                 actix_web::error::ErrorInternalServerError("Database connection failed")
             })?;
+            // Item U: workspace membership 403 gate. Bearer-token requests go
+            // through the same check as cookie-auth so a token issued in
+            // workspace A can't be used to probe workspace B's subdomain.
             crate::middleware::cookie_auth::enforce_workspace_membership(&req, &mut conn, &claims)?;
-            // Release before the handler — see the cookie-fallback path below.
             drop(conn);
             request_context::populate(&req, &claims);
             req.extensions_mut().insert(claims);
             return next.call(req).await;
         }
-        None => {
-            // No Bearer token, fall through to cookie auth.
+
+        // Session-JWT bearer (native/mobile). Validate via the SAME path the
+        // cookie flow uses, so the active_sessions session check applies and
+        // logout / reuse-detection revoke mobile access too.
+        let mut conn = pool.get().map_err(|_| {
+            actix_web::error::ErrorInternalServerError("Database connection failed")
+        })?;
+        let (claims, _user) = JwtUtils::authenticate_with_token(&raw, &mut conn)
+            .await
+            .map_err(|err| {
+                error!(error = ?err, "Bearer JWT auth: token validation failed");
+                bearer_unauthorized(true, "Invalid or expired token")
+            })?;
+
+        // Scope guard (MANDATORY): only genuine agent sessions carry scope
+        // "full". SSE tokens ("sse") skip the session check and portal tokens
+        // ("portal") belong to the customer surface; either replayed as a
+        // bearer could over-authorize on routes the scope middleware classes
+        // `Any`. The cookie path can't receive these tokens (they're never in
+        // the access_token cookie); the bearer path must reject them here.
+        if claims.scope != "full" {
+            warn!(path = %req.path(), scope = %claims.scope, "Rejected non-session JWT on bearer path");
+            return Err(bearer_unauthorized(true, "Token not valid for this API"));
         }
+
+        crate::middleware::cookie_auth::enforce_workspace_membership(&req, &mut conn, &claims)?;
+        drop(conn);
+        request_context::populate(&req, &claims);
+        req.extensions_mut().insert(claims);
+        return next.call(req).await;
     }
 
-    // Fall back to cookie-based authentication.
-    use crate::utils::jwt::JwtUtils;
-
+    // No Bearer token — fall back to cookie-based authentication.
     let mut conn = pool
         .get()
         .map_err(|_| actix_web::error::ErrorInternalServerError("Database connection failed"))?;
@@ -217,14 +262,14 @@ pub async fn dual_auth_middleware(
         .cookie(crate::utils::cookies::ACCESS_TOKEN_COOKIE)
         .ok_or_else(|| {
             warn!(path = %req.path(), "No access_token cookie and no Bearer token");
-            actix_web::error::ErrorUnauthorized("Authentication required")
+            bearer_unauthorized(false, "Authentication required")
         })?;
 
     let (claims, _user) = JwtUtils::authenticate_with_token(token.value(), &mut conn)
         .await
         .map_err(|err| {
             error!(error = ?err, "Cookie auth: token validation failed");
-            actix_web::error::ErrorUnauthorized("Invalid or expired token")
+            bearer_unauthorized(true, "Invalid or expired token")
         })?;
 
     info!(user = %claims.sub, "Cookie auth: user authenticated successfully");

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -3052,6 +3052,13 @@ pub struct LoginResponse {
     pub mfa_backup_code_used: Option<bool>,
     pub requires_backup_code_regeneration: Option<bool>,
     pub backup_codes: Option<Vec<String>>, // Present when MFA is enabled during login setup
+    // Native/bearer clients (X-Auth-Mode: bearer) receive the session tokens in
+    // the body instead of httpOnly cookies. Omitted entirely for web clients, so
+    // the cookie-flow JSON is byte-identical.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
 }
 
 /// Request for MFA verification during login
@@ -3093,11 +3100,24 @@ pub struct MfaEnableLoginRequest {
 }
 
 /// Response for token refresh
-/// Note: tokens are now in httpOnly cookies, only CSRF token is in response
+/// Web clients get rotated tokens in httpOnly cookies (only CSRF is in the body).
+/// Native/bearer clients get the rotated session tokens in the body instead.
 #[derive(Debug, Serialize)]
 pub struct RefreshTokenResponse {
     pub success: bool,
     pub csrf_token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+}
+
+/// Optional body for `POST /api/auth/refresh`. Native/bearer clients send the
+/// rotating refresh token here (web clients send it in the httpOnly cookie).
+#[derive(Debug, Deserialize, Default)]
+pub struct RefreshRequest {
+    #[serde(default)]
+    pub refresh_token: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/backend/src/utils/auth_mode.rs
+++ b/backend/src/utils/auth_mode.rs
@@ -1,0 +1,66 @@
+//! How a client wants its session credentials delivered.
+//!
+//! Web clients use httpOnly cookies (the default). Native/mobile clients can't
+//! rely on a cookie jar on a `tauri://` origin, so they opt into bearer mode by
+//! sending the `X-Auth-Mode: bearer` request header; the auth endpoints then
+//! return the session tokens in the response body (and set no cookies), and the
+//! validator accepts the access token as `Authorization: Bearer`.
+//!
+//! Absent or any other header value means cookie mode, i.e. exactly the
+//! existing web behaviour.
+
+use actix_web::dev::ServiceRequest;
+use actix_web::HttpRequest;
+
+/// Request header a native client sets to opt into token-in-body auth.
+pub const AUTH_MODE_HEADER: &str = "X-Auth-Mode";
+const BEARER_VALUE: &str = "bearer";
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AuthMode {
+    /// httpOnly cookies (web). The default.
+    Cookie,
+    /// Session tokens in the response body, `Authorization: Bearer` on requests.
+    Bearer,
+}
+
+fn mode_from_header_value(value: Option<&str>) -> AuthMode {
+    match value {
+        Some(v) if v.trim().eq_ignore_ascii_case(BEARER_VALUE) => AuthMode::Bearer,
+        _ => AuthMode::Cookie,
+    }
+}
+
+/// Resolve the auth mode from a handler's `HttpRequest`.
+pub fn auth_mode_from_request(req: &HttpRequest) -> AuthMode {
+    mode_from_header_value(
+        req.headers()
+            .get(AUTH_MODE_HEADER)
+            .and_then(|h| h.to_str().ok()),
+    )
+}
+
+/// Resolve the auth mode from middleware's `ServiceRequest`.
+pub fn auth_mode_from_service_request(req: &ServiceRequest) -> AuthMode {
+    mode_from_header_value(
+        req.headers()
+            .get(AUTH_MODE_HEADER)
+            .and_then(|h| h.to_str().ok()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_value_parsing() {
+        assert_eq!(mode_from_header_value(Some("bearer")), AuthMode::Bearer);
+        assert_eq!(mode_from_header_value(Some("Bearer")), AuthMode::Bearer);
+        assert_eq!(mode_from_header_value(Some("  bearer ")), AuthMode::Bearer);
+        assert_eq!(mode_from_header_value(None), AuthMode::Cookie);
+        assert_eq!(mode_from_header_value(Some("")), AuthMode::Cookie);
+        assert_eq!(mode_from_header_value(Some("cookie")), AuthMode::Cookie);
+        assert_eq!(mode_from_header_value(Some("token")), AuthMode::Cookie);
+    }
+}

--- a/backend/src/utils/jwt.rs
+++ b/backend/src/utils/jwt.rs
@@ -567,6 +567,8 @@ pub mod helpers {
             mfa_backup_code_used: None,
             requires_backup_code_regeneration: None,
             backup_codes: None,
+            access_token: None,
+            refresh_token: None,
         };
 
         Ok((response, tokens))
@@ -586,6 +588,8 @@ pub mod helpers {
             mfa_backup_code_used: None,
             requires_backup_code_regeneration: None,
             backup_codes: None,
+            access_token: None,
+            refresh_token: None,
         }
     }
 
@@ -607,6 +611,8 @@ pub mod helpers {
             mfa_backup_code_used: None,
             requires_backup_code_regeneration: None,
             backup_codes: None,
+            access_token: None,
+            refresh_token: None,
         }
     }
 
@@ -626,6 +632,8 @@ pub mod helpers {
             mfa_backup_code_used: None,
             requires_backup_code_regeneration: None,
             backup_codes: None,
+            access_token: None,
+            refresh_token: None,
         }
     }
 
@@ -661,6 +669,8 @@ pub mod helpers {
             mfa_backup_code_used: Some(backup_code_used),
             requires_backup_code_regeneration: Some(requires_regeneration),
             backup_codes: None,
+            access_token: None,
+            refresh_token: None,
         };
 
         Ok((response, tokens))

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod analytics_cache;
 pub mod auth;
+pub mod auth_mode;
 pub mod bootstrap_token;
 pub mod client_ip;
 pub mod content;

--- a/backend/tests/bearer_auth.rs
+++ b/backend/tests/bearer_auth.rs
@@ -1,0 +1,211 @@
+//! Bearer-token (native/mobile) auth on the dual-auth `/api` surface.
+//!
+//! The mobile app authenticates with a session JWT in `Authorization: Bearer`
+//! instead of the httpOnly `access_token` cookie. These prove the additive
+//! bearer path holds the security invariants:
+//!  - a genuine agent session JWT (scope "full") authenticates,
+//!  - revoking the session revokes bearer access (the session check applies),
+//!  - an SSE-scope JWT (which skips the session check) is rejected — it must
+//!    not over-authorize on the agent API,
+//!  - a missing credential yields a bare `WWW-Authenticate: Bearer` (RFC 6750),
+//!    an invalid one yields `error="invalid_token"`,
+//!  - `nsk_` personal API tokens still work (regression guard).
+//!
+//! The membership gate self-skips when no workspace context is resolved
+//! (`enforce_workspace_membership` returns Ok with no Host/selection workspace),
+//! so these exercise the auth path without tenant fixturing.
+
+#![allow(clippy::expect_used)]
+
+use actix_web::middleware::from_fn;
+use actix_web::{test, web, App, HttpResponse};
+use backend::middleware::api_token::dual_auth_middleware;
+use backend::models::NewActiveSession;
+use backend::utils::jwt::JwtUtils;
+
+mod common;
+
+async fn ping() -> HttpResponse {
+    HttpResponse::Ok().json(serde_json::json!({ "ok": true }))
+}
+
+/// App with a single protected `/api/ping` behind the real dual-auth middleware.
+macro_rules! protected_app {
+    ($pool:expr) => {
+        test::init_service(
+            App::new().app_data(web::Data::new($pool.clone())).service(
+                web::scope("/api")
+                    .wrap(from_fn(dual_auth_middleware))
+                    .route("/ping", web::get().to(ping)),
+            ),
+        )
+        .await
+    };
+}
+
+/// Create an active session for `user` and mint the matching session JWT.
+fn session_jwt(pool: &backend::db::Pool, user: &backend::models::User) -> (uuid::Uuid, String) {
+    let session = backend::repository::active_sessions::create_session(
+        &mut pool.get().expect("conn"),
+        NewActiveSession {
+            user_uuid: user.uuid,
+            device_name: Some("bearer-test".into()),
+            ip_address: None,
+            user_agent: Some("nosdesk-mobile-test".into()),
+            location: None,
+            expires_at: (chrono::Utc::now() + chrono::Duration::hours(1)).naive_utc(),
+            is_current: true,
+        },
+    )
+    .expect("create active session");
+    let token = JwtUtils::create_token(user, &session.session_id).expect("mint JWT");
+    (session.session_id, token)
+}
+
+#[actix_web::test]
+async fn session_jwt_authenticates_as_bearer() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let pool = db.pool_with_size(2);
+    let user = common::insert_user(&mut pool.get().expect("conn"), "Bearer Alice");
+    let (_sid, token) = session_jwt(&pool, &user);
+
+    let app = protected_app!(pool);
+    let req = test::TestRequest::get()
+        .uri("/api/ping")
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        200,
+        "valid session JWT bearer should authenticate"
+    );
+}
+
+#[actix_web::test]
+async fn revoked_session_rejects_bearer() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let pool = db.pool_with_size(2);
+    let user = common::insert_user(&mut pool.get().expect("conn"), "Bearer Bob");
+    let (sid, token) = session_jwt(&pool, &user);
+
+    // Revoke the session — as logout / reuse-detection would.
+    backend::repository::active_sessions::revoke_session_by_uuid(
+        &mut pool.get().expect("conn"),
+        &sid,
+    )
+    .expect("revoke session");
+
+    let app = protected_app!(pool);
+    let req = test::TestRequest::get()
+        .uri("/api/ping")
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .to_request();
+    // The middleware rejects with an Error (rendered to a 401 at the edge).
+    let err = test::try_call_service(&app, req)
+        .await
+        .err()
+        .expect("revoked session must reject the bearer token");
+    let resp = err.error_response();
+    assert_eq!(resp.status(), 401);
+    assert_eq!(
+        resp.headers()
+            .get("WWW-Authenticate")
+            .and_then(|v| v.to_str().ok()),
+        Some("Bearer error=\"invalid_token\""),
+    );
+}
+
+#[actix_web::test]
+async fn sse_scope_jwt_rejected_on_bearer() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let pool = db.pool_with_size(2);
+    let user = common::insert_user(&mut pool.get().expect("conn"), "Bearer Carol");
+    // An SSE token (scope "sse") skips the session check; it must not ride the
+    // agent API as a bearer.
+    let sse = JwtUtils::create_sse_token(&user.uuid.to_string(), &user.platform_role, None)
+        .expect("mint sse token");
+
+    let app = protected_app!(pool);
+    let req = test::TestRequest::get()
+        .uri("/api/ping")
+        .insert_header(("Authorization", format!("Bearer {sse}")))
+        .to_request();
+    let err = test::try_call_service(&app, req)
+        .await
+        .err()
+        .expect("SSE-scope JWT must be rejected on the agent bearer path");
+    assert_eq!(err.error_response().status(), 401);
+}
+
+#[actix_web::test]
+async fn missing_credential_returns_bare_challenge() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let pool = db.pool_with_size(2);
+
+    let app = protected_app!(pool);
+    let req = test::TestRequest::get().uri("/api/ping").to_request();
+    let err = test::try_call_service(&app, req)
+        .await
+        .err()
+        .expect("missing credential must be rejected");
+    let resp = err.error_response();
+    assert_eq!(resp.status(), 401);
+    assert_eq!(
+        resp.headers()
+            .get("WWW-Authenticate")
+            .and_then(|v| v.to_str().ok()),
+        Some("Bearer"),
+        "no credential should get a bare Bearer challenge (no error code)",
+    );
+}
+
+#[actix_web::test]
+async fn invalid_jwt_bearer_returns_invalid_token() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let pool = db.pool_with_size(2);
+
+    let app = protected_app!(pool);
+    let req = test::TestRequest::get()
+        .uri("/api/ping")
+        .insert_header(("Authorization", "Bearer not-a-real-jwt"))
+        .to_request();
+    let err = test::try_call_service(&app, req)
+        .await
+        .err()
+        .expect("invalid JWT must be rejected");
+    let resp = err.error_response();
+    assert_eq!(resp.status(), 401);
+    assert_eq!(
+        resp.headers()
+            .get("WWW-Authenticate")
+            .and_then(|v| v.to_str().ok()),
+        Some("Bearer error=\"invalid_token\""),
+    );
+}
+
+#[actix_web::test]
+async fn nsk_api_token_still_authenticates() {
+    common::ensure_test_keyring();
+    let db = common::TestDb::new();
+    let pool = db.pool_with_size(2);
+    let user = common::insert_user(&mut pool.get().expect("conn"), "Bearer Dave");
+    let api_token = common::mint_api_token(&mut pool.get().expect("conn"), &user, "regression");
+
+    let app = protected_app!(pool);
+    let req = test::TestRequest::get()
+        .uri("/api/ping")
+        .insert_header(("Authorization", format!("Bearer {api_token}")))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        200,
+        "nsk_ API tokens must keep working unchanged"
+    );
+}


### PR DESCRIPTION
Additive bearer-token auth alongside the existing web cookie flow, so a native/mobile client (which can't use a cookie jar on a `tauri://` origin) can authenticate. **The web cookie flow is byte-for-byte unchanged.**

A client opts in with `X-Auth-Mode: bearer`; login / MFA / passkey-finish / refresh then return the session tokens in the body (no cookies), and the validator accepts the session JWT as `Authorization: Bearer`.

## Changes
- `build_auth_response` seam: all five login finishers return body tokens (no `Set-Cookie`) in bearer mode, cookies otherwise.
- `dual_auth_middleware` accepts a session JWT on the bearer path, validated via the same `authenticate_with_token` as cookies, so the `active_sessions` check applies (mobile sessions are revocable by logout / reuse-detection). A **mandatory scope guard** rejects SSE/portal tokens so they can't ride the agent API. `nsk_` API tokens are unchanged.
- `refresh_token` reads the refresh token from the body (native) or cookie (web); rotation / reuse-detection logic is untouched.
- RFC 6750 `WWW-Authenticate` on validator 401s.
- `LoginResponse` / `RefreshTokenResponse` gain optional token fields (`skip_serializing_if`), so web JSON stays identical.

## Spec
RFC 6750 (bearer usage + challenges), RFC 9700 (15m/7d lifetimes, already compliant), and native-app guidance (tokens in body + secure storage; web keeps httpOnly + CSRF).

## Tests
6 integration (bearer path, session revocation, scope rejection, `WWW-Authenticate`) plus serde/header unit tests. Existing cookie-path auth, membership-gate, and portal-session tests are unregressed.

## Follow-ups (out of scope)
SSE / collab-WS native token (EventSource can't send `Authorization`), native OIDC deep-link, DPoP sender-constraining.
