### PR TITLE
feat(mobile): @nosdesk/mobile host bootstrap layer

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,40 @@
+# @nosdesk/mobile
+
+Host layer for the Tauri app: wires the headless `@nosdesk/core` seams to the
+native platform. The mobile twin of the web setup files
+(`frontend/src/services/transport.ts`, `frontend/src/utils/{storageSetup,loggerSetup}.ts`,
+`frontend/src/services/apiConfig.ts`).
+
+## What it wires
+
+`bootstrapMobile({ apiBaseUrl, collabWsBaseUrl, secureStore, logger? })` (call
+once at app start) configures, in order:
+
+- **logger** (`loggerSetup`): min level + user-id resolver.
+- **storage** (`storageSetup`): the general KV seam over the webview's
+  `localStorage` (drafts, recent items, prefs). Not for secrets.
+- **transport** (`transport`): the `bearerAuthStrategy`, `Authorization: Bearer`
+  + `X-Auth-Mode: bearer`, `useCredentials: false`, refresh via the rotating
+  refresh token. Access token in memory; refresh token in the keychain.
+- **api client** (`apiClient`): the transport interceptors on core's shared
+  axios instance (base URL, credential mode, auth headers, 401 -> refresh ->
+  retry).
+
+The login / sign-out flows call `setSession(access, refresh)` / `clearSession()`.
+
+## Targets the bearer backend
+
+Depends on the additive bearer auth in the backend: login/refresh return tokens
+in the body for `X-Auth-Mode: bearer`, and the validator accepts a session JWT
+as a bearer credential.
+
+## Stubbed / next steps
+
+- **`SecureStore` keychain impl** (`secureStore.ts`): only `memorySecureStore`
+  (dev, non-persistent) ships today. The production `tauriSecureStore` over the
+  OS keychain is sketched in a comment, fill it in once the native shell and the
+  keychain plugin are chosen.
+- **Native Tauri scaffold** (`src-tauri`, `tauri.conf.json`, mobile targets) and
+  the **UI layer** are separate, larger pieces, not part of this bootstrap.
+- No runtime tests yet (no test runner wired); the modules are type-checked
+  against `@nosdesk/core`.

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@nosdesk/mobile",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@nosdesk/core": "workspace:*",
+    "axios": "^1.6.2"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.0"
+  }
+}

--- a/mobile/src/apiClient.ts
+++ b/mobile/src/apiClient.ts
@@ -1,0 +1,53 @@
+/**
+ * Registers the transport interceptors on `@nosdesk/core`'s shared axios
+ * instance, the mobile counterpart of the web's `apiConfig`.
+ *
+ * Scope is deliberately the transport concerns only: base URL, credential mode,
+ * auth headers (from the seam), and the 401 -> refresh -> retry path. The web
+ * `apiConfig` also registers correlation-id / diagnostics / SSE-client-id /
+ * workspace-selection headers and richer error handling; those are app-level
+ * concerns layered on later, not part of the bootstrap.
+ */
+import apiClient from '@nosdesk/core/apiClient'
+import { apiBaseUrl, transport } from '@nosdesk/core/transport'
+import type { AxiosError, InternalAxiosRequestConfig } from 'axios'
+
+type RetryConfig = InternalAxiosRequestConfig & { _retry?: boolean }
+
+let registered = false
+// Single in-flight refresh shared across concurrent 401s, so a burst of
+// requests triggers exactly one token rotation.
+let refreshing: Promise<boolean> | null = null
+
+export function setupApiClient(): void {
+  if (registered) return
+  registered = true
+
+  apiClient.interceptors.request.use((config) => {
+    config.baseURL = apiBaseUrl()
+    config.withCredentials = transport().auth.useCredentials
+    Object.assign(config.headers, transport().auth.authHeaders())
+    return config
+  })
+
+  apiClient.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+      const original = error.config as RetryConfig | undefined
+      if (error.response?.status !== 401 || !original || original._retry) {
+        return Promise.reject(error)
+      }
+      original._retry = true
+      refreshing ??= transport()
+        .auth.refresh()
+        .finally(() => {
+          refreshing = null
+        })
+      const refreshed = await refreshing
+      if (refreshed) return apiClient(original)
+      // Session can't be renewed: clear local state and surface the 401.
+      transport().auth.onSessionLost()
+      return Promise.reject(error)
+    },
+  )
+}

--- a/mobile/src/bootstrap.ts
+++ b/mobile/src/bootstrap.ts
@@ -1,0 +1,24 @@
+/**
+ * Single entry point that wires `@nosdesk/core` for the Tauri host. Call once
+ * at app start, before any request or store access.
+ *
+ * Order matters: logger + storage are synchronous; transport loads the
+ * persisted refresh token from the keychain (async) and registers the seam;
+ * the api-client interceptors then read that seam per request.
+ */
+import { setupLogger, type MobileLoggerOptions } from './loggerSetup'
+import { setupStorage } from './storageSetup'
+import { setupTransport, type MobileTransportOptions } from './transport'
+import { setupApiClient } from './apiClient'
+
+export interface MobileBootstrapOptions extends MobileTransportOptions {
+  /** Logger config; defaults to dev (DEBUG level, no user id). */
+  logger?: MobileLoggerOptions
+}
+
+export async function bootstrapMobile(opts: MobileBootstrapOptions): Promise<void> {
+  setupLogger(opts.logger ?? { isProd: false })
+  setupStorage()
+  await setupTransport(opts)
+  setupApiClient()
+}

--- a/mobile/src/index.ts
+++ b/mobile/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Public surface of the mobile host layer.
+ *
+ * `bootstrapMobile` wires the @nosdesk/core seams at app start; `setSession` /
+ * `clearSession` are called by the login and sign-out flows; `SecureStore` is
+ * the keychain contract the native shell implements (with `memorySecureStore`
+ * available for dev/tests).
+ */
+export { bootstrapMobile, type MobileBootstrapOptions } from './bootstrap'
+export { setSession, clearSession, type MobileTransportOptions } from './transport'
+export { memorySecureStore, type SecureStore } from './secureStore'
+export type { MobileLoggerOptions } from './loggerSetup'

--- a/mobile/src/loggerSetup.ts
+++ b/mobile/src/loggerSetup.ts
@@ -1,0 +1,21 @@
+/**
+ * Logger wiring, the mobile twin of the web's
+ * `frontend/src/utils/loggerSetup.ts`. Injects the two platform bits the
+ * headless logger can't resolve itself: the minimum level and the current
+ * user id.
+ */
+import { configureLogger, LogLevel } from '@nosdesk/core/utils/logger'
+
+export interface MobileLoggerOptions {
+  /** INFO in production, DEBUG otherwise. */
+  isProd: boolean
+  /** Resolve the current user id, to tag log entries. */
+  getUserId?: () => string | undefined
+}
+
+export function setupLogger(opts: MobileLoggerOptions): void {
+  configureLogger({
+    minLevel: opts.isProd ? LogLevel.INFO : LogLevel.DEBUG,
+    getUserId: opts.getUserId,
+  })
+}

--- a/mobile/src/secureStore.ts
+++ b/mobile/src/secureStore.ts
@@ -1,0 +1,42 @@
+/**
+ * Secure, persistent storage for the long-lived refresh token.
+ *
+ * Unlike the general key/value seam (drafts, recent items, which the webview's
+ * `localStorage` backs), the refresh token is a credential and must live in the
+ * OS keychain (iOS Keychain / Android Keystore), never in `localStorage`. The
+ * interface is async because native keychain access is.
+ */
+export interface SecureStore {
+  /** Read the persisted refresh token, or null if none. */
+  load(): Promise<string | null>
+  /** Persist (overwrite) the refresh token. */
+  save(token: string): Promise<void>
+  /** Remove the refresh token (sign-out / unrecoverable 401). */
+  clear(): Promise<void>
+}
+
+/**
+ * In-memory implementation for dev / tests. Tokens do NOT survive an app
+ * restart, so a cold start always lands on the login screen.
+ */
+export function memorySecureStore(): SecureStore {
+  let token: string | null = null
+  return {
+    load: async () => token,
+    save: async (t) => {
+      token = t
+    },
+    clear: async () => {
+      token = null
+    },
+  }
+}
+
+// Production keychain implementation (to fill in once the Tauri shell exists):
+//
+//   export function tauriSecureStore(): SecureStore {
+//     // Back with the OS keychain via a Tauri plugin (e.g. a keyring/stronghold
+//     // plugin), invoked over `@tauri-apps/api`. Kept out of this module for now
+//     // so the bootstrap layer carries no Tauri dependency before the native
+//     // scaffold and plugin choice are settled.
+//   }

--- a/mobile/src/storageSetup.ts
+++ b/mobile/src/storageSetup.ts
@@ -1,0 +1,38 @@
+/**
+ * General key/value storage wiring, the mobile twin of the web's
+ * `frontend/src/utils/storageSetup.ts`.
+ *
+ * The Tauri webview provides a persistent `localStorage`, so the general KV
+ * seam (drafts, recent items, UI prefs) uses the same guarded adapter as web.
+ * Credentials do NOT go here: the refresh token lives in the OS keychain (see
+ * `secureStore.ts`).
+ */
+import { configureStorage, type KeyValueStore } from '@nosdesk/core/storage'
+
+const localStorageAdapter: KeyValueStore = {
+  getItem(key) {
+    try {
+      return localStorage.getItem(key)
+    } catch {
+      return null
+    }
+  },
+  setItem(key, value) {
+    try {
+      localStorage.setItem(key, value)
+    } catch {
+      // ignore quota / unavailable
+    }
+  },
+  removeItem(key) {
+    try {
+      localStorage.removeItem(key)
+    } catch {
+      // ignore unavailable
+    }
+  },
+}
+
+export function setupStorage(): void {
+  configureStorage(localStorageAdapter)
+}

--- a/mobile/src/transport.ts
+++ b/mobile/src/transport.ts
@@ -1,0 +1,106 @@
+/**
+ * Bearer-token transport wiring for the Tauri app, the mobile twin of the
+ * web's `frontend/src/services/transport.ts`.
+ *
+ * The app authenticates with a session JWT in `Authorization: Bearer` plus
+ * `X-Auth-Mode: bearer` (so the backend returns tokens in the body instead of
+ * setting cookies). The short-lived access token lives in memory so
+ * `authHeaders()` can read it synchronously per request; the long-lived refresh
+ * token is mirrored in memory for `hasSession()` and persisted to the keychain
+ * (see SecureStore) so a cold start can re-establish the session.
+ */
+import axios from 'axios'
+import { configureTransport, type AuthStrategy } from '@nosdesk/core/transport'
+import type { SecureStore } from './secureStore'
+
+// In-memory session state (see module doc for why access stays in memory).
+let accessToken: string | null = null
+let refreshToken: string | null = null
+
+let baseUrl = ''
+let store: SecureStore | null = null
+
+interface BearerTokens {
+  access_token?: string
+  refresh_token?: string
+}
+
+/**
+ * Seed the session after a successful login / MFA / passkey finish. The login
+ * response (bearer mode) carries `access_token` + `refresh_token` in its body.
+ */
+export async function setSession(access: string, refresh: string): Promise<void> {
+  accessToken = access
+  refreshToken = refresh
+  await store?.save(refresh)
+}
+
+/** Clear the session locally (sign-out). */
+export async function clearSession(): Promise<void> {
+  accessToken = null
+  refreshToken = null
+  await store?.clear()
+}
+
+const bearerAuthStrategy: AuthStrategy = {
+  authHeaders() {
+    const headers: Record<string, string> = { 'X-Auth-Mode': 'bearer' }
+    if (accessToken) headers.Authorization = `Bearer ${accessToken}`
+    return headers
+  },
+  // No cookie jar on a tauri:// origin.
+  useCredentials: false,
+  async refresh() {
+    if (!refreshToken) return false
+    try {
+      const res = await axios.post<BearerTokens>(
+        `${baseUrl}/auth/refresh`,
+        { refresh_token: refreshToken },
+        { headers: { 'X-Auth-Mode': 'bearer' }, withCredentials: false },
+      )
+      const access = res.data.access_token
+      const refresh = res.data.refresh_token
+      if (!access || !refresh) return false
+      accessToken = access
+      refreshToken = refresh
+      await store?.save(refresh)
+      return true
+    } catch {
+      return false
+    }
+  },
+  hasSession() {
+    return accessToken !== null || refreshToken !== null
+  },
+  onSessionLost() {
+    accessToken = null
+    refreshToken = null
+    // Fire-and-forget: the interface is synchronous, keychain clear is async.
+    void store?.clear()
+  },
+}
+
+export interface MobileTransportOptions {
+  /** Absolute REST base, e.g. `https://app.nosdesk.com/api`. */
+  apiBaseUrl: string
+  /** Absolute collab y-websocket base, including the `/collaboration/ws` suffix. */
+  collabWsBaseUrl: string
+  /** Keychain-backed store for the refresh token. */
+  secureStore: SecureStore
+}
+
+/**
+ * Register the bearer transport with `@nosdesk/core`. Loads any persisted
+ * refresh token from the keychain first, so a returning user's first
+ * authenticated request can transparently refresh into an access token.
+ */
+export async function setupTransport(opts: MobileTransportOptions): Promise<void> {
+  baseUrl = opts.apiBaseUrl
+  store = opts.secureStore
+  refreshToken = await store.load()
+  configureTransport({
+    baseUrl: opts.apiBaseUrl,
+    collabWsBaseUrl: opts.collabWsBaseUrl,
+    auth: bearerAuthStrategy,
+  })
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,19 @@ importers:
         specifier: ^3.2.0
         version: 3.3.5(typescript@6.0.3)
 
+  mobile:
+    dependencies:
+      '@nosdesk/core':
+        specifier: workspace:*
+        version: link:../packages/core
+      axios:
+        specifier: ^1.6.2
+        version: 1.18.1
+    devDependencies:
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+
   packages/core:
     dependencies:
       '@pinia/colada':


### PR DESCRIPTION
Adds the `mobile/` workspace package (`@nosdesk/mobile`): the host layer that wires the headless `@nosdesk/core` seams to the Tauri app. The mobile twin of the web setup files.

## Modules
- **transport** — `bearerAuthStrategy`: `Authorization: Bearer` + `X-Auth-Mode: bearer`, `useCredentials: false`, refresh via the rotating refresh token. Access token in memory (so `authHeaders()` stays synchronous, matching the core interface); refresh token in the OS keychain. `setSession` / `clearSession` for the login / sign-out flows.
- **storageSetup** — the general KV seam over the webview's `localStorage` (drafts, recent items, prefs). Not for secrets.
- **loggerSetup** — `configureLogger` (min level + user-id resolver).
- **apiClient** — the transport interceptors on core's shared axios instance (base URL, credential mode, auth headers, 401 -> refresh -> retry).
- **secureStore** — the keychain `SecureStore` contract + an in-memory dev impl.
- **bootstrap / index** — one `bootstrapMobile()` entry + the public surface.

## Notes
- Targets the additive bearer-token backend auth (already on main): login/refresh return body tokens for `X-Auth-Mode: bearer`, and the validator accepts a session JWT as a bearer credential.
- Type-checks against `@nosdesk/core` (`tsc`, strict + `verbatimModuleSyntax`).
- Self-contained: a new isolated package, no changes to `frontend` or `backend`.

## Follow-ups (out of scope)
Production `tauriSecureStore` keychain impl, the native Tauri shell (`src-tauri`, mobile targets), the UI layer, a CI type-check job for this package, and runtime tests.
