### PR TITLE
feat(mobile): self-host server picker

### DIFF
--- a/frontend/src/platform/index.ts
+++ b/frontend/src/platform/index.ts
@@ -21,13 +21,9 @@ async function setupWebPlatform(): Promise<void> {
 
 async function setupTauriPlatform(): Promise<void> {
   const { bootstrapMobile, memorySecureStore } = await import('@nosdesk/mobile')
+  // The server (cloud or self-hosted) comes from the persisted choice / the
+  // connect screen, not a build constant. bootstrapMobile resolves it.
   await bootstrapMobile({
-    // Tauri talks to the absolute hosted API; the web build uses relative `/api`.
-    apiBaseUrl:
-      (import.meta.env.VITE_TAURI_API_URL as string | undefined) ?? 'https://app.nosdesk.com/api',
-    collabWsBaseUrl:
-      (import.meta.env.VITE_TAURI_WS_URL as string | undefined) ??
-      'wss://app.nosdesk.com/api/collaboration/ws',
     // TODO(tauri): swap memorySecureStore for a keychain-backed SecureStore once
     // chosen on-device (see mobile/src/secureStore.ts). memory = login each cold start.
     secureStore: memorySecureStore(),

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -19,6 +19,9 @@ UI; `@nosdesk/core` is what lets the one UI run in both hosts.
   - `tauriHttpAdapter.ts` — axios adapter over `@tauri-apps/plugin-http` (the
     `tauri://` origin can't reach the API cross-origin from the webview).
   - `storageSetup.ts` / `loggerSetup.ts` — the general-KV + logger seams.
+  - `serverConfig.ts` — the server picker: persist the chosen origin (cloud or
+    self-hosted), derive the base URLs, and `validateServer()` (HTTPS + probes
+    `/api/auth/setup/status` to confirm it's a Nosdesk instance).
   - `secureStore.ts` — the keychain `SecureStore` contract + an in-memory impl.
 
 The frontend chooses the host at startup in `frontend/src/platform/index.ts`
@@ -40,11 +43,16 @@ branch is a lazy chunk, so the web bundle stays Tauri-free.
 - **Keychain `SecureStore`** (`secureStore.ts`): only `memorySecureStore` ships
   (no cold-start persistence). Pick a non-biometric-gated keychain plugin
   on-device, NOT Stronghold (deprecated) or the plaintext store plugin.
-- **Tune** the placeholder API host (`com.nosdesk.app` identifier, the CSP
-  `connect-src` and the `http` capability `allow` URL all point at
-  `app.nosdesk.com`) and confirm SSE (EventSource) + collab WS against the real
-  deployment, the backend must allowlist the Tauri origin for those (the http
-  plugin handles REST natively, but SSE/WS go through the webview).
+- **Connect screen (Vue UI)** — the plumbing is here (`validateServer` /
+  `setServer` / `getStoredServer` / `DEFAULT_SERVER`); the actual first-run
+  "choose your Nosdesk server" screen + a settings entry to switch servers is
+  frontend work. Cloud is the default until then. To support arbitrary
+  self-hosted servers the `http` capability allows any `https://**` and the CSP
+  `connect-src` allows `https:`/`wss:` (still HTTPS-only, only the server the
+  user picks).
+- **Backend** must allowlist the Tauri origin for SSE (EventSource) + collab WS
+  per server (the http plugin handles REST natively, but SSE/WS go through the
+  webview).
 - App icons (placeholders), signing, store metadata; native enhancements (push,
   biometric unlock, deep links, native passkeys); on-device smoke test
   (login → `/me` → ticket list).

--- a/mobile/src-tauri/capabilities/default.json
+++ b/mobile/src-tauri/capabilities/default.json
@@ -9,8 +9,9 @@
     "core:default",
     {
       "identifier": "http:default",
+      "comment": "Any HTTPS host: the user picks their Nosdesk server (cloud or self-hosted). Still HTTPS-only and only ever the server the user configured.",
       "allow": [
-        { "url": "https://app.nosdesk.com/*" }
+        { "url": "https://**" }
       ]
     }
   ]

--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://app.nosdesk.com wss://app.nosdesk.com"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https: wss:"
     }
   },
   "bundle": {

--- a/mobile/src/bootstrap.ts
+++ b/mobile/src/bootstrap.ts
@@ -1,17 +1,23 @@
 /**
  * Single entry point that wires `@nosdesk/core` for the Tauri host. Call once
- * at app start, before any request or store access.
+ * at app start, before anything uses a seam.
  *
- * Order matters: logger + storage are synchronous; transport loads the
- * persisted refresh token from the keychain (async) and registers the seam;
- * the api-client interceptors then read that seam per request.
+ * Order: logger + storage are synchronous; the api-client interceptors +
+ * native HTTP adapter are installed; then the transport is pointed at the
+ * persisted server (or the default cloud) so a returning user lands on login.
+ * A first-run user with no stored server gets the default; the connect /
+ * settings screen calls `setServer()` to override (see serverConfig + transport).
  */
 import { setupLogger, type MobileLoggerOptions } from './loggerSetup'
 import { setupStorage } from './storageSetup'
-import { setupTransport, type MobileTransportOptions } from './transport'
+import { configureServer, setSecureStore } from './transport'
 import { setupApiClient } from './apiClient'
+import { DEFAULT_SERVER, getStoredServer } from './serverConfig'
+import type { SecureStore } from './secureStore'
 
-export interface MobileBootstrapOptions extends MobileTransportOptions {
+export interface MobileBootstrapOptions {
+  /** Keychain-backed store for the refresh token. */
+  secureStore: SecureStore
   /** Logger config; defaults to dev (DEBUG level, no user id). */
   logger?: MobileLoggerOptions
 }
@@ -19,6 +25,9 @@ export interface MobileBootstrapOptions extends MobileTransportOptions {
 export async function bootstrapMobile(opts: MobileBootstrapOptions): Promise<void> {
   setupLogger(opts.logger ?? { isProd: false })
   setupStorage()
-  await setupTransport(opts)
+  setSecureStore(opts.secureStore)
   setupApiClient()
+  // Use the persisted server, else the default cloud. The connect/settings
+  // screen can later override via setServer().
+  await configureServer(getStoredServer() ?? DEFAULT_SERVER)
 }

--- a/mobile/src/index.ts
+++ b/mobile/src/index.ts
@@ -1,12 +1,21 @@
 /**
  * Public surface of the mobile host layer.
  *
- * `bootstrapMobile` wires the @nosdesk/core seams at app start; `setSession` /
- * `clearSession` are called by the login and sign-out flows; `SecureStore` is
- * the keychain contract the native shell implements (with `memorySecureStore`
- * available for dev/tests).
+ * `bootstrapMobile` wires the @nosdesk/core seams at app start. The server
+ * picker (`validateServer` / `setServer` / `getStoredServer` / `DEFAULT_SERVER`)
+ * backs the connect screen so a self-hoster can point the app at their own
+ * instance. `setSession` / `clearSession` are called by the login and sign-out
+ * flows. `SecureStore` is the keychain contract the native shell implements
+ * (`memorySecureStore` for dev/tests).
  */
 export { bootstrapMobile, type MobileBootstrapOptions } from './bootstrap'
-export { setSession, clearSession, type MobileTransportOptions } from './transport'
+export { setSession, clearSession, setServer } from './transport'
+export {
+  getStoredServer,
+  clearStoredServer,
+  validateServer,
+  DEFAULT_SERVER,
+  type ServerValidation,
+} from './serverConfig'
 export { memorySecureStore, type SecureStore } from './secureStore'
 export type { MobileLoggerOptions } from './loggerSetup'

--- a/mobile/src/serverConfig.ts
+++ b/mobile/src/serverConfig.ts
@@ -1,0 +1,80 @@
+/**
+ * Which Nosdesk server the app talks to.
+ *
+ * Nosdesk is self-hostable, so the app isn't pinned to one host: the user picks
+ * a server (the official cloud by default, or their own instance) and it's
+ * persisted. The chosen origin feeds the transport seam's base URLs.
+ *
+ * The origin is not a secret, so it lives in the general KV store (the refresh
+ * token, which IS a secret, lives in the keychain, see secureStore.ts).
+ */
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import { storage } from '@nosdesk/core/storage'
+
+const SERVER_KEY = 'nosdesk:server-origin'
+
+/** Pre-filled in the connect screen; the official cloud. */
+export const DEFAULT_SERVER = 'https://app.nosdesk.com'
+
+/** The persisted server origin (e.g. `https://help.acme.com`), or null. */
+export function getStoredServer(): string | null {
+  return storage().getItem(SERVER_KEY)
+}
+
+export function storeServer(origin: string): void {
+  storage().setItem(SERVER_KEY, origin)
+}
+
+export function clearStoredServer(): void {
+  storage().removeItem(SERVER_KEY)
+}
+
+/** REST base for a server origin, e.g. `https://help.acme.com/api`. */
+export function apiBaseUrlFor(origin: string): string {
+  return `${origin.replace(/\/$/, '')}/api`
+}
+
+/** Collab y-websocket base for a server origin (provider appends `/${docId}`). */
+export function collabWsBaseUrlFor(origin: string): string {
+  const ws = origin.replace(/^http:/i, 'ws:').replace(/^https:/i, 'wss:')
+  return `${ws.replace(/\/$/, '')}/api/collaboration/ws`
+}
+
+export interface ServerValidation {
+  ok: boolean
+  /** The normalized origin (scheme + host[:port]) on success. */
+  origin?: string
+  error?: string
+}
+
+/**
+ * Normalize + validate a user-entered server URL: it must be HTTPS and actually
+ * be a Nosdesk instance (its public setup-status endpoint answers with the
+ * expected shape). Uses the native HTTP client so it isn't blocked by the
+ * webview's CORS/CSP. Call this from the connect screen before `setServer`.
+ */
+export async function validateServer(input: string): Promise<ServerValidation> {
+  let origin: string
+  try {
+    const withScheme = /^https?:\/\//i.test(input) ? input : `https://${input.trim()}`
+    const url = new URL(withScheme)
+    if (url.protocol !== 'https:') {
+      return { ok: false, error: 'The server URL must use https://' }
+    }
+    origin = url.origin
+  } catch {
+    return { ok: false, error: 'Enter a valid server URL' }
+  }
+
+  try {
+    const res = await tauriFetch(`${apiBaseUrlFor(origin)}/auth/setup/status`, { method: 'GET' })
+    if (!res.ok) return { ok: false, error: `The server responded ${res.status}` }
+    const body = (await res.json().catch(() => null)) as { requires_setup?: unknown } | null
+    if (!body || typeof body.requires_setup === 'undefined') {
+      return { ok: false, error: "That doesn't look like a Nosdesk server" }
+    }
+    return { ok: true, origin }
+  } catch {
+    return { ok: false, error: 'Could not reach that server' }
+  }
+}

--- a/mobile/src/transport.ts
+++ b/mobile/src/transport.ts
@@ -1,28 +1,32 @@
 /**
- * Bearer-token transport wiring for the Tauri app, the mobile twin of the
- * web's `frontend/src/services/transport.ts`.
+ * Bearer-token transport wiring for the Tauri app, the mobile twin of the web's
+ * `frontend/src/services/transport.ts`.
  *
  * The app authenticates with a session JWT in `Authorization: Bearer` plus
- * `X-Auth-Mode: bearer` (so the backend returns tokens in the body instead of
- * setting cookies). The short-lived access token lives in memory so
- * `authHeaders()` can read it synchronously per request; the long-lived refresh
- * token is mirrored in memory for `hasSession()` and persisted to the keychain
- * (see SecureStore) so a cold start can re-establish the session.
+ * `X-Auth-Mode: bearer` (so the backend returns tokens in the body, not
+ * cookies). The short-lived access token lives in memory so `authHeaders()` can
+ * read it synchronously per request; the long-lived refresh token is mirrored
+ * in memory for `hasSession()` and persisted to the keychain (SecureStore) for
+ * cold starts. The base URL comes from the selected server (see serverConfig).
  */
-import axios from 'axios'
-import { configureTransport, type AuthStrategy } from '@nosdesk/core/transport'
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import { apiBaseUrl, configureTransport, type AuthStrategy } from '@nosdesk/core/transport'
+import { apiBaseUrlFor, collabWsBaseUrlFor, storeServer } from './serverConfig'
 import type { SecureStore } from './secureStore'
 
 // In-memory session state (see module doc for why access stays in memory).
 let accessToken: string | null = null
 let refreshToken: string | null = null
-
-let baseUrl = ''
 let store: SecureStore | null = null
 
 interface BearerTokens {
   access_token?: string
   refresh_token?: string
+}
+
+/** Register the keychain store. Called once at bootstrap, before configureServer. */
+export function setSecureStore(secureStore: SecureStore): void {
+  store = secureStore
 }
 
 /**
@@ -35,7 +39,7 @@ export async function setSession(access: string, refresh: string): Promise<void>
   await store?.save(refresh)
 }
 
-/** Clear the session locally (sign-out). */
+/** Clear the session locally (sign-out, or before switching servers). */
 export async function clearSession(): Promise<void> {
   accessToken = null
   refreshToken = null
@@ -53,17 +57,18 @@ const bearerAuthStrategy: AuthStrategy = {
   async refresh() {
     if (!refreshToken) return false
     try {
-      const res = await axios.post<BearerTokens>(
-        `${baseUrl}/auth/refresh`,
-        { refresh_token: refreshToken },
-        { headers: { 'X-Auth-Mode': 'bearer' }, withCredentials: false },
-      )
-      const access = res.data.access_token
-      const refresh = res.data.refresh_token
-      if (!access || !refresh) return false
-      accessToken = access
-      refreshToken = refresh
-      await store?.save(refresh)
+      // Native fetch (off the webview / off the axios interceptor stack).
+      const res = await tauriFetch(`${apiBaseUrl()}/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Auth-Mode': 'bearer' },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      })
+      if (!res.ok) return false
+      const data = (await res.json()) as BearerTokens
+      if (!data.access_token || !data.refresh_token) return false
+      accessToken = data.access_token
+      refreshToken = data.refresh_token
+      await store?.save(data.refresh_token)
       return true
     } catch {
       return false
@@ -80,27 +85,30 @@ const bearerAuthStrategy: AuthStrategy = {
   },
 }
 
-export interface MobileTransportOptions {
-  /** Absolute REST base, e.g. `https://app.nosdesk.com/api`. */
-  apiBaseUrl: string
-  /** Absolute collab y-websocket base, including the `/collaboration/ws` suffix. */
-  collabWsBaseUrl: string
-  /** Keychain-backed store for the refresh token. */
-  secureStore: SecureStore
+/**
+ * Point the transport at a server origin. Loads that server's persisted refresh
+ * token so a returning user can transparently refresh into an access token.
+ * Does NOT persist the choice (bootstrap uses the stored/default server;
+ * `setServer` is the explicit, persisted user choice).
+ */
+export async function configureServer(origin: string): Promise<void> {
+  accessToken = null
+  refreshToken = (await store?.load()) ?? null
+  configureTransport({
+    baseUrl: apiBaseUrlFor(origin),
+    collabWsBaseUrl: collabWsBaseUrlFor(origin),
+    auth: bearerAuthStrategy,
+  })
 }
 
 /**
- * Register the bearer transport with `@nosdesk/core`. Loads any persisted
- * refresh token from the keychain first, so a returning user's first
- * authenticated request can transparently refresh into an access token.
+ * The explicit "connect to this server" action for the connect / settings
+ * screen: drop any existing session (a different server needs a fresh login),
+ * persist the choice, and point the transport at it. Validate the origin with
+ * `validateServer` first.
  */
-export async function setupTransport(opts: MobileTransportOptions): Promise<void> {
-  baseUrl = opts.apiBaseUrl
-  store = opts.secureStore
-  refreshToken = await store.load()
-  configureTransport({
-    baseUrl: opts.apiBaseUrl,
-    collabWsBaseUrl: opts.collabWsBaseUrl,
-    auth: bearerAuthStrategy,
-  })
+export async function setServer(origin: string): Promise<void> {
+  await clearSession()
+  storeServer(origin)
+  await configureServer(origin)
 }


### PR DESCRIPTION
Nosdesk is self-hostable, so the Tauri app shouldn't be pinned to the cloud. This makes the server a user choice (cloud by default, or their own instance), persisted across launches, the universal pattern for self-hostable apps (Bitwarden, Element, NextCloud, Immich…).

## Plumbing (this PR)
- **`serverConfig.ts`** — persist the chosen origin (general KV; not a secret), derive the `/api` + collab-ws base URLs, and **`validateServer()`**: require HTTPS and probe `/api/auth/setup/status` via the native HTTP client to confirm it's actually a Nosdesk instance before saving.
- **`transport.ts`** — server-aware. `configureServer(origin)` points the seam at a server; `setServer(origin)` is the explicit "connect here" action (drops the session, persists, reconfigures). Token refresh goes through the native HTTP client.
- **`bootstrap.ts`** — resolves the server from the persisted choice, falling back to `DEFAULT_SERVER` (cloud), so it works out of the box and self-host is an override.
- **`index.ts`** — exports the connect-screen API.

## Scoping trade-off
The cloud-only scaffold pinned the `http` capability `allow` and the CSP `connect-src` to `app.nosdesk.com`. Supporting arbitrary self-hosted servers means relaxing those to `https://**` / `https:`+`wss:`. Still **HTTPS-only, and only ever the one server the user configures** — the same trade-off every self-hostable app makes.

## Remaining (frontend Vue UI, not this PR)
The connect screen itself, a first-run "choose your Nosdesk server" view (cloud default + a self-hosted URL field calling `validateServer` → `setServer`) and a settings entry to switch servers. All the plumbing it needs is exported here.

## Verified
`@nosdesk/mobile` + `frontend` type-check, `frontend` build, and `cargo check` on the Rust shell (validates the relaxed capability/CSP config). Web path unchanged (the Tauri branch is a lazy chunk).
