### PR TITLE
feat(mobile): first-run connect screen

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,10 @@
 // App.vue
 <script setup lang="ts">
 import { RouterView, useRoute, useRouter } from 'vue-router'
-import { computed, ref, onMounted, watch, nextTick } from 'vue'
+import { computed, ref, onMounted, watch, nextTick, defineAsyncComponent } from 'vue'
+import { needsServerSelection } from '@/platform/serverGate'
+// Native first-run server picker; lazy so the web bundle doesn't carry it.
+const ConnectServerView = defineAsyncComponent(() => import('@/views/ConnectServerView.vue'))
 import { useFluent } from 'fluent-vue'
 import Navbar from './components/Navbar.vue'
 import PageHeader from './components/SiteHeader.vue'
@@ -191,8 +194,12 @@ onMounted(async () => {
 </script>
 
 <template>
+  <!-- Native app first run: choose a Nosdesk server before anything else.
+       Always false on the web. -->
+  <ConnectServerView v-if="needsServerSelection" />
+
   <!-- Blank layout for login -->
-  <RouterView v-if="isBlankLayout" />
+  <RouterView v-else-if="isBlankLayout" />
 
   <!-- Default layout with responsive navigation - Simple flexbox layout -->
   <div v-else v-twemoji class="flex w-full h-full bg-app overflow-hidden">

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,6 @@
 import './assets/main.css'
 import { configurePlatform } from './platform'
+import { initServerGate } from './platform/serverGate'
 
 import { interceptConsole } from './utils/remoteLogger'
 
@@ -21,6 +22,10 @@ async function bootstrap() {
   // Configure the @nosdesk/core seams for the current platform (web: cookies +
   // localStorage; Tauri: bearer + native HTTP) before anything uses them.
   await configurePlatform()
+
+  // Native app: decide whether the first-run "choose your server" screen is
+  // needed before the app renders (no-op on the web).
+  await initServerGate()
 
   // Remote logging for debugging (can be disabled via localStorage).
   interceptConsole()

--- a/frontend/src/platform/serverGate.ts
+++ b/frontend/src/platform/serverGate.ts
@@ -1,0 +1,40 @@
+/**
+ * First-run server gate for the native app.
+ *
+ * In Tauri, if no server has been chosen yet, the app shows the connect screen
+ * before anything else (App.vue reads `needsServerSelection`). On the web this
+ * is always false. All `@nosdesk/mobile` access is via dynamic import so the
+ * web bundle never pulls Tauri code.
+ */
+import { ref } from 'vue'
+import { isTauriRuntime } from './index'
+
+/** True when the connect screen must show first (Tauri + no server stored). */
+export const needsServerSelection = ref(false)
+
+/** Decide on boot whether the connect screen is needed. */
+export async function initServerGate(): Promise<void> {
+  if (!isTauriRuntime()) return
+  const { getStoredServer } = await import('@nosdesk/mobile')
+  needsServerSelection.value = getStoredServer() === null
+}
+
+/** Connect to the official cloud and dismiss the gate. */
+export async function selectCloud(): Promise<void> {
+  const { setServer, DEFAULT_SERVER } = await import('@nosdesk/mobile')
+  await setServer(DEFAULT_SERVER)
+  needsServerSelection.value = false
+}
+
+/**
+ * Validate a self-hosted server URL and, on success, connect to it and dismiss
+ * the gate. Returns the validation error otherwise (the screen displays it).
+ */
+export async function connectTo(input: string): Promise<{ ok: boolean; error?: string }> {
+  const { validateServer, setServer } = await import('@nosdesk/mobile')
+  const result = await validateServer(input)
+  if (!result.ok || !result.origin) return { ok: false, error: result.error }
+  await setServer(result.origin)
+  needsServerSelection.value = false
+  return { ok: true }
+}

--- a/frontend/src/views/ConnectServerView.vue
+++ b/frontend/src/views/ConnectServerView.vue
@@ -1,0 +1,109 @@
+<!--
+First-run "choose your Nosdesk server" screen for the native (Tauri) app.
+
+Nosdesk is self-hostable, so the app isn't pinned to the cloud: the user either
+taps "Nosdesk Cloud" or enters their own instance's URL. The choice is validated
+(HTTPS + confirmed to be a Nosdesk server) and persisted; the app then proceeds
+to the normal login. Shown only in Tauri when no server is stored yet (see
+platform/serverGate). On the web this never renders.
+-->
+<script setup lang="ts">
+import { ref } from 'vue';
+import AuthLayout from '@/components/auth/AuthLayout.vue';
+import Button from '@/components/common/Button.vue';
+import FormInput from '@/components/common/FormInput.vue';
+import { selectCloud, connectTo } from '@/platform/serverGate';
+
+const mode = ref<'choose' | 'self-hosted'>('choose');
+const serverUrl = ref('');
+const error = ref('');
+const busy = ref(false);
+
+async function chooseCloud() {
+  busy.value = true;
+  error.value = '';
+  try {
+    await selectCloud();
+  } catch {
+    error.value = 'Could not connect to Nosdesk Cloud';
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function connectSelfHosted() {
+  if (!serverUrl.value.trim()) return;
+  busy.value = true;
+  error.value = '';
+  try {
+    const result = await connectTo(serverUrl.value);
+    if (!result.ok) error.value = result.error ?? 'Could not connect';
+  } finally {
+    busy.value = false;
+  }
+}
+</script>
+
+<template>
+  <AuthLayout>
+    <template #pill>{{ $t('connect-title') }}</template>
+    <template #hero-title>{{ $t('connect-hero-title') }}</template>
+    <template #hero-subtitle>{{ $t('connect-hero-subtitle') }}</template>
+
+    <div class="flex flex-col gap-8">
+      <div>
+        <h1 class="text-2xl font-semibold text-primary">{{ $t('connect-title') }}</h1>
+        <p class="mt-2 text-sm text-secondary">{{ $t('connect-subtitle') }}</p>
+      </div>
+
+      <div
+        v-if="error"
+        class="flex items-center gap-2 rounded-lg border border-status-error/50 bg-status-error/10 px-4 py-3 text-sm text-status-error"
+      >
+        {{ error }}
+      </div>
+
+      <!-- Choose: cloud or self-hosted -->
+      <div v-if="mode === 'choose'" class="flex flex-col gap-4">
+        <Button variant="primary" block :loading="busy" @click="chooseCloud">
+          {{ $t('connect-cloud') }}
+        </Button>
+        <p class="-mt-2 text-center text-xs text-tertiary">{{ $t('connect-cloud-hint') }}</p>
+        <button
+          type="button"
+          class="text-sm font-medium text-accent hover:underline disabled:opacity-50"
+          :disabled="busy"
+          @click="mode = 'self-hosted'"
+        >
+          {{ $t('connect-self-hosted') }}
+        </button>
+      </div>
+
+      <!-- Self-hosted: enter a server URL -->
+      <form v-else class="flex flex-col gap-6" @submit.prevent="connectSelfHosted">
+        <FormInput
+          v-model="serverUrl"
+          type="url"
+          inputmode="url"
+          autocapitalize="none"
+          autocorrect="off"
+          spellcheck="false"
+          :label="$t('connect-server-label')"
+          :placeholder="$t('connect-server-placeholder')"
+          :disabled="busy"
+        />
+        <Button type="submit" variant="primary" block :loading="busy" :disabled="!serverUrl.trim()">
+          {{ $t('connect-submit') }}
+        </Button>
+        <button
+          type="button"
+          class="text-sm font-medium text-secondary hover:underline disabled:opacity-50"
+          :disabled="busy"
+          @click="mode = 'choose'; error = ''"
+        >
+          {{ $t('connect-back') }}
+        </button>
+      </form>
+    </div>
+  </AuthLayout>
+</template>

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -148,6 +148,18 @@ login-subtitle = Sign in to your account
 login-title = Welcome back
 # Brand hero pill on the onboarding page.
 auth-hero-pill = Self-hosted
+# Native-app first-run "choose your Nosdesk server" screen.
+connect-title = Connect to Nosdesk
+connect-subtitle = Choose the server to sign in to.
+connect-hero-title = Your helpdesk, everywhere
+connect-hero-subtitle = Connect the app to Nosdesk Cloud or your own self-hosted instance.
+connect-cloud = Nosdesk Cloud
+connect-cloud-hint = The official hosted service
+connect-self-hosted = Use a self-hosted server
+connect-server-label = Server URL
+connect-server-placeholder = https://help.yourcompany.com
+connect-submit = Connect
+connect-back = Back
 login-email-label = Email
 login-email-placeholder = Enter your email
 login-password-label = Password

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -99,6 +99,18 @@ login-subtitle = Connectez-vous à votre compte
 # Titre et hero d'authentification (machine, à relire par un locuteur natif).
 login-title = Bon retour
 auth-hero-pill = Auto-hébergé
+# Écran natif « choisir votre serveur » (machine, à relire par un locuteur natif).
+connect-title = Se connecter à Nosdesk
+connect-subtitle = Choisissez le serveur de connexion.
+connect-hero-title = Votre assistance, partout
+connect-hero-subtitle = Connectez l'application à Nosdesk Cloud ou à votre propre instance auto-hébergée.
+connect-cloud = Nosdesk Cloud
+connect-cloud-hint = Le service hébergé officiel
+connect-self-hosted = Utiliser un serveur auto-hébergé
+connect-server-label = URL du serveur
+connect-server-placeholder = https://aide.votreentreprise.com
+connect-submit = Se connecter
+connect-back = Retour
 login-email-label = E-mail
 login-email-placeholder = Saisissez votre e-mail
 login-password-label = Mot de passe

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -96,6 +96,18 @@ login-subtitle = Log in op uw account
 # Auth-titel en hero (machine, na te kijken door moedertaalspreker).
 login-title = Welkom terug
 auth-hero-pill = Zelf-gehost
+# Native "kies je server"-scherm (machine, nog na te kijken).
+connect-title = Verbinden met Nosdesk
+connect-subtitle = Kies de server om in te loggen.
+connect-hero-title = Je helpdesk, overal
+connect-hero-subtitle = Verbind de app met Nosdesk Cloud of je eigen zelf-gehoste instantie.
+connect-cloud = Nosdesk Cloud
+connect-cloud-hint = De officiële gehoste dienst
+connect-self-hosted = Een zelf-gehoste server gebruiken
+connect-server-label = Server-URL
+connect-server-placeholder = https://help.jouwbedrijf.com
+connect-submit = Verbinden
+connect-back = Terug
 login-email-label = E-mail
 login-email-placeholder = Voer uw e-mailadres in
 login-password-label = Wachtwoord


### PR DESCRIPTION
The native app's first-run **"choose your Nosdesk server"** screen, the UI on top of the server-picker plumbing (#46). Tauri-only; on the web it never renders.

## What's here
- **`ConnectServerView.vue`** — an `AuthLayout` screen (matches login) with a **"Nosdesk Cloud"** button and a **self-hosted URL field**. The field validates through the mobile plumbing (HTTPS + a probe that confirms it's a Nosdesk instance) and surfaces the error inline.
- **`platform/serverGate.ts`** — `needsServerSelection` ref + `initServerGate()` (decides on boot whether to show the screen) + `selectCloud()` / `connectTo()` (validate → `setServer` → dismiss). All `@nosdesk/mobile` access is via dynamic import, so the web bundle stays Tauri-free.
- **`main.ts`** calls `initServerGate()` after `configurePlatform()`; **`App.vue`** renders the screen (as a lazy async component) when `needsServerSelection`, ahead of the router.
- **i18n** — `connect-*` keys in en-US + machine fr-FR/nl-NL (flagged pending native review; en-AU/en-GB fall back to en-US).

## Flow
First Tauri launch with no stored server → connect screen → user picks Cloud or enters a self-hosted URL → validated + persisted → the app proceeds to the normal login against that server. Subsequent launches skip it.

## Verified
Frontend type-check, build (**`ConnectServerView` is its own 2.5 kB lazy chunk**, not in the web entry), and lint (eslint + `check-view-roots`). Can't be visually exercised here (renders only in Tauri); `tauri dev` (desktop) is how to eyeball it.
