### PR TITLE
feat(mobile): keychain-backed SecureStore

### DIFF
--- a/frontend/src/platform/index.ts
+++ b/frontend/src/platform/index.ts
@@ -20,13 +20,13 @@ async function setupWebPlatform(): Promise<void> {
 }
 
 async function setupTauriPlatform(): Promise<void> {
-  const { bootstrapMobile, memorySecureStore } = await import('@nosdesk/mobile')
+  const { bootstrapMobile, tauriSecureStore } = await import('@nosdesk/mobile')
   // The server (cloud or self-hosted) comes from the persisted choice / the
   // connect screen, not a build constant. bootstrapMobile resolves it.
   await bootstrapMobile({
-    // TODO(tauri): swap memorySecureStore for a keychain-backed SecureStore once
-    // chosen on-device (see mobile/src/secureStore.ts). memory = login each cold start.
-    secureStore: memorySecureStore(),
+    // OS keychain (iOS Keychain / macOS) for the refresh token, so the session
+    // survives a cold app restart.
+    secureStore: tauriSecureStore(),
     logger: { isProd: import.meta.env.PROD },
   })
 }

--- a/mobile/src-tauri/Cargo.lock
+++ b/mobile/src-tauri/Cargo.lock
@@ -80,6 +80,8 @@ name = "app"
 version = "0.1.0"
 dependencies = [
  "log",
+ "security-framework",
+ "security-framework-sys",
  "serde",
  "serde_json",
  "tauri",
@@ -3077,6 +3079,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -26,3 +26,9 @@ tauri = { version = "2.11.3", features = [] }
 # tauri:// origin, so REST goes through this (see mobile/src/tauriHttpAdapter.ts).
 tauri-plugin-http = "2"
 tauri-plugin-log = "2"
+
+# OS keychain for the refresh token (see src/keychain.rs). The iOS Keychain
+# (and macOS for `tauri dev`) via SecItem, with explicit accessibility control.
+[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
+security-framework = "3"
+security-framework-sys = "2"

--- a/mobile/src-tauri/src/keychain.rs
+++ b/mobile/src-tauri/src/keychain.rs
@@ -1,0 +1,84 @@
+//! OS keychain storage for the auth refresh token.
+//!
+//! The genuine iOS Keychain (and the macOS keychain for `tauri dev`) via
+//! SecItem generic passwords, exposed as Tauri commands the JS `SecureStore`
+//! calls. The token is stored device-only (never iCloud-synced) with the
+//! default `WhenUnlocked` accessibility: readable while the device is unlocked,
+//! which it always is when the app is foreground doing a silent token refresh,
+//! and inaccessible while locked. Reads are non-interactive (no biometric
+//! prompt), so refresh stays silent. `WhenUnlocked` is deliberately more
+//! restrictive than `AfterFirstUnlock`: this is a foreground app, so the token
+//! is never read while the device is locked.
+
+const SERVICE: &str = "com.nosdesk.app";
+const ACCOUNT: &str = "refresh_token";
+
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+mod imp {
+    use super::{ACCOUNT, SERVICE};
+    use security_framework::passwords::{
+        delete_generic_password, get_generic_password, set_generic_password_options,
+        PasswordOptions,
+    };
+    use security_framework_sys::base::errSecItemNotFound;
+
+    pub fn save(token: &str) -> Result<(), String> {
+        let mut options = PasswordOptions::new_generic_password(SERVICE, ACCOUNT);
+        // Device-only: never replicated to iCloud or other devices.
+        options.set_access_synchronized(Some(false));
+        // Creates or updates (handles the token rotated on every refresh).
+        set_generic_password_options(token.as_bytes(), options).map_err(|e| e.to_string())
+    }
+
+    pub fn load() -> Result<Option<String>, String> {
+        match get_generic_password(SERVICE, ACCOUNT) {
+            Ok(bytes) => String::from_utf8(bytes)
+                .map(Some)
+                .map_err(|e| format!("keychain value not valid UTF-8: {e}")),
+            // No stored token -> a fresh / signed-out session, not an error.
+            Err(e) if e.code() == errSecItemNotFound => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    pub fn clear() -> Result<(), String> {
+        match delete_generic_password(SERVICE, ACCOUNT) {
+            Ok(()) => Ok(()),
+            // Already absent is success.
+            Err(e) if e.code() == errSecItemNotFound => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
+
+// Non-Apple targets (Linux/Windows desktop, Android) aren't built yet; the
+// Android Keystore / Secret Service paths would go here. Stub so the crate
+// still compiles everywhere.
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+mod imp {
+    const UNSUPPORTED: &str = "secure store is not implemented on this platform";
+    pub fn save(_token: &str) -> Result<(), String> {
+        Err(UNSUPPORTED.into())
+    }
+    pub fn load() -> Result<Option<String>, String> {
+        Err(UNSUPPORTED.into())
+    }
+    pub fn clear() -> Result<(), String> {
+        Err(UNSUPPORTED.into())
+    }
+}
+
+#[tauri::command]
+pub fn secure_store_save(token: String) -> Result<(), String> {
+    imp::save(&token)
+}
+
+#[tauri::command]
+pub fn secure_store_load() -> Result<Option<String>, String> {
+    imp::load()
+}
+
+#[tauri::command]
+pub fn secure_store_clear() -> Result<(), String> {
+    imp::clear()
+}

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -1,8 +1,16 @@
+mod keychain;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
     // Native HTTP client for the REST API (scoped by capabilities/default.json).
     .plugin(tauri_plugin_http::init())
+    // OS-keychain storage for the auth refresh token.
+    .invoke_handler(tauri::generate_handler![
+      keychain::secure_store_save,
+      keychain::secure_store_load,
+      keychain::secure_store_clear,
+    ])
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(

--- a/mobile/src/index.ts
+++ b/mobile/src/index.ts
@@ -17,5 +17,5 @@ export {
   DEFAULT_SERVER,
   type ServerValidation,
 } from './serverConfig'
-export { memorySecureStore, type SecureStore } from './secureStore'
+export { memorySecureStore, tauriSecureStore, type SecureStore } from './secureStore'
 export type { MobileLoggerOptions } from './loggerSetup'

--- a/mobile/src/secureStore.ts
+++ b/mobile/src/secureStore.ts
@@ -6,6 +6,8 @@
  * OS keychain (iOS Keychain / Android Keystore), never in `localStorage`. The
  * interface is async because native keychain access is.
  */
+import { invoke } from '@tauri-apps/api/core'
+
 export interface SecureStore {
   /** Read the persisted refresh token, or null if none. */
   load(): Promise<string | null>
@@ -32,22 +34,17 @@ export function memorySecureStore(): SecureStore {
   }
 }
 
-// Production keychain implementation (the one piece that genuinely needs
-// on-device evaluation before it's wired):
-//
-//   export function tauriSecureStore(): SecureStore {
-//     // Back the refresh token with the OS keychain (iOS Keychain / Android
-//     // Keystore). NOT Stronghold — the Tauri docs mark it deprecated/removed
-//     // in v3; NOT `@tauri-apps/plugin-store`, which is plaintext.
-//     //
-//     // `@impierce/tauri-plugin-keystore` exposes store()/retrieve()/remove(),
-//     // but it gates EVERY read behind biometrics — wrong for transparent
-//     // token refresh (it would prompt Face ID on each silent 401-refresh).
-//     // Pick a keychain plugin whose read is NOT biometric-gated (biometrics,
-//     // if wanted, belong on an explicit app-unlock, not on token reads), and
-//     // map it onto this interface.
-//   }
-//
-// Until then `memorySecureStore` is the default: the app works (no cold-start
-// persistence — a restart returns to login), which is fine for desktop dev and
-// the simulator smoke test. The interface makes the keychain swap one file.
+/**
+ * OS-keychain-backed store (iOS Keychain / macOS keychain), via the Rust
+ * `secure_store_*` Tauri commands (see mobile/src-tauri/src/keychain.rs). The
+ * token is held device-only, non-synced, readable without a biometric prompt so
+ * refresh stays silent. This is the production store; `memorySecureStore` is the
+ * dev/test fallback (no cold-start persistence).
+ */
+export function tauriSecureStore(): SecureStore {
+  return {
+    load: () => invoke<string | null>('secure_store_load'),
+    save: (token) => invoke<void>('secure_store_save', { token }),
+    clear: () => invoke<void>('secure_store_clear'),
+  }
+}


### PR DESCRIPTION
Replaces the in-memory `SecureStore` stub with the real **OS keychain**, so a logged-in session survives a cold app restart.

## Implementation
- `mobile/src-tauri/src/keychain.rs` — `secure_store_{save,load,clear}` Tauri commands over `security-framework`'s `SecItem` generic-password API: the **genuine iOS Keychain** (and macOS keychain for `tauri dev`). The token is:
  - **device-only** (`synchronized(false)`, never iCloud-synced),
  - **`WhenUnlocked`** accessibility (readable while unlocked — which it is during foreground refresh — locked otherwise; deliberately stricter than `AfterFirstUnlock` for an interactive app),
  - **silent, non-biometric** reads, so token refresh stays invisible,
  - **create-or-update**, so the per-refresh token rotation works; a missing item maps to `None`, not an error.
- `secureStore.ts` — `tauriSecureStore()` invokes the commands; the platform bootstrap uses it instead of `memorySecureStore()`.

## Why this approach (researched)
- The `keyring` crate **ignores the Keychain on iOS** (its docs: falls back to hardware-encrypted files), so it wouldn't actually give us the Keychain.
- `tauri-plugin-keyring` is immature (v0.2.0, unclear maintenance) — not something to depend on for the auth token in an OSS app.
- `security-framework` is the mature, de-facto Rust binding to Apple's Security framework; we own the ~80-line integration, no third-party Tauri plugin in the supply chain, no Swift.

## Verified
`cargo check` on **macOS and `aarch64-apple-ios`** (the latter proving security-framework builds for iOS), mobile + frontend type-check, full iOS build, on-device install. `Security.framework` was already linked in the project.

## Not yet
The end-to-end "login survives cold restart" test needs a working server to log into (Android Keystore is a later add; the non-Apple path is a stub).
