### PR TITLE
fix(docker): copy workspace packages into the frontend build stage

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -126,13 +126,22 @@ RUN corepack enable
 
 WORKDIR /repo
 
-# Workspace manifests + lockfile first, for a cached dependency layer.
+# Workspace manifests + lockfile first, for a cached dependency layer. The
+# frontend imports the @nosdesk/core (and, via a lazy chunk, @nosdesk/mobile)
+# workspace packages, so their manifests must be present for the workspace-aware
+# `--filter ...` install to resolve them.
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY frontend/package.json ./frontend/
+COPY packages/core/package.json ./packages/core/
+COPY mobile/package.json ./mobile/
 RUN pnpm install --frozen-lockfile --filter nosdesk-frontend...
 
-# Frontend source.
+# Frontend source + the workspace package sources it resolves from (raw .ts,
+# consumed directly by vite). mobile/src only — mobile/src-tauri is the native
+# shell and irrelevant to the web build.
 COPY frontend ./frontend
+COPY packages/core ./packages/core
+COPY mobile/src ./mobile/src
 # Shared Fluent catalogues. Vite's `import.meta.glob` in
 # src/i18n/index.ts resolves `../../../i18n/locales/...` three levels up
 # from /repo/frontend/src/i18n/, which lands at /repo, so the catalogues


### PR DESCRIPTION
Every image build (the dev/staging image **and** release) has been failing since the `@nosdesk/core` extraction merged. The frontend now imports `@nosdesk/core` (and a lazy `@nosdesk/mobile` chunk), but the Dockerfile's `frontend-builder` stage only copied `frontend/` + the root manifests, so the workspace-aware install and the vite build couldn't resolve `@nosdesk/core`:

```
Rolldown failed to resolve import "@nosdesk/core/services/instanceConfig" from frontend/src/main.ts
```

(It passed locally only because cached `node_modules` masked it; surfaced by the dev-build's clean `--frozen-lockfile` install.)

Fix: copy `packages/core` (+ its manifest) and `mobile/src` (+ `mobile/package.json`) into the stage — `mobile/src` only, since `src-tauri` is the native shell, irrelevant to the web build. Same omission, and same fix, as the earlier `compose.dev.yaml` change.

Verified by dispatching the dev-build workflow on this branch (it's the clean-install path that originally caught the bug).