### PR TITLE
feat(mobile): native OIDC sign-in against the hosted IdP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,6 +157,11 @@ MICROSOFT_REDIRECT_URI=http://localhost:3000/auth/microsoft/callback
 OIDC_CLIENT_ID=
 OIDC_CLIENT_SECRET=
 
+# Native (mobile app) OIDC client: the PUBLIC client id the app uses for its own
+# Authorization-Code + PKCE flow against the IdP (no secret). Register it on the
+# IdP with redirect_uri nosdesk://auth/callback. Defaults to "nosdesk-app".
+# OIDC_NATIVE_CLIENT_ID=nosdesk-app
+
 # Option 1: Auto-discovery (Recommended)
 # Just provide the issuer URL and endpoints are discovered automatically
 OIDC_ISSUER_URL=

--- a/backend/src/config_utils.rs
+++ b/backend/src/config_utils.rs
@@ -63,6 +63,13 @@ pub fn get_oidc_client_id() -> Result<String, ConfigError> {
     get_env_var("OIDC_CLIENT_ID")
 }
 
+/// Get the native-app OIDC client id: the *public* client the mobile app uses
+/// for its own Authorization-Code + PKCE flow against the IdP, distinct from the
+/// confidential web `OIDC_CLIENT_ID`. Defaults to `nosdesk-app`.
+pub fn get_oidc_native_client_id() -> String {
+    env::var("OIDC_NATIVE_CLIENT_ID").unwrap_or_else(|_| "nosdesk-app".to_string())
+}
+
 /// Get OIDC client secret
 pub fn get_oidc_client_secret() -> Result<String, ConfigError> {
     get_env_var("OIDC_CLIENT_SECRET")

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -177,7 +177,7 @@ pub(crate) fn complete_login_redirect(
 
 /// Create the session record, log the success event, and mint the login
 /// tokens. Shared by the JSON and redirect login finishers.
-fn establish_login_session(
+pub(crate) fn establish_login_session(
     user: crate::models::User,
     request: &HttpRequest,
     conn: &mut DbConnection,

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -1297,6 +1297,90 @@ fn safe_post_login_location(redirect_uri: &str) -> String {
 /// The issuer is used verbatim (no normalisation): it must byte-match the
 /// `iss` the control plane stored at projection time, which is the same
 /// string operators set as `OIDC_ISSUER_URL`.
+// ===== Native (mobile app) OIDC login =====
+
+/// Public OIDC config the native app needs to run its OWN Authorization-Code +
+/// PKCE flow against the IdP: the issuer (for discovery), the app's public
+/// client id, and the scopes. The app fetches this from whichever server it's
+/// connected to, so it targets the right IdP (staging vs prod) automatically.
+pub async fn native_oidc_config() -> HttpResponse {
+    if !config_utils::is_oidc_enabled() {
+        return errors::not_found("OIDC is not enabled");
+    }
+    let issuer = match config_utils::get_oidc_issuer_url() {
+        Ok(i) => i,
+        Err(_) => return errors::not_found("Native OIDC requires OIDC_ISSUER_URL"),
+    };
+    HttpResponse::Ok().json(json!({
+        "issuer": issuer,
+        "client_id": config_utils::get_oidc_native_client_id(),
+        "scopes": config_utils::get_oidc_scopes(),
+    }))
+}
+
+#[derive(Deserialize)]
+pub struct NativeOidcLoginRequest {
+    pub id_token: String,
+}
+
+/// Native-app OIDC login: the app has already run the Authorization-Code + PKCE
+/// flow against the IdP (as a public client) and posts the resulting ID token.
+/// We verify it (signature / issuer / audience / expiry), resolve the existing
+/// seat by `(issuer, sub)` — the same hosted resolution the web callback uses —
+/// and mint a normal product session, delivered as body tokens (bearer mode).
+pub async fn native_oidc_login(
+    db_pool: web::Data<Pool>,
+    body: web::Json<NativeOidcLoginRequest>,
+    request: HttpRequest,
+) -> impl Responder {
+    let native_client_id = config_utils::get_oidc_native_client_id();
+    let user_info = match oidc::verify_native_id_token(&body.id_token, &native_client_id).await {
+        Ok(u) => u,
+        Err(e) => {
+            warn!(error = %e, "native OIDC login: ID token rejected");
+            return errors::unauthorized("Invalid ID token");
+        }
+    };
+
+    let mut conn = match helpers::db_conn(&db_pool) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+
+    let iss = oidc_identity_issuer();
+    let email = user_info.email.clone().unwrap_or_default();
+    let email_verified = user_info.email_verified.unwrap_or(false);
+
+    let user = match crate::services::oauth_provisioning::resolve_user_by_identity_or_email(
+        &mut conn,
+        &iss,
+        &user_info.sub,
+        // Global login identity (central IdP), not workspace-scoped.
+        None,
+        &email,
+        email_verified,
+        &None,
+        &None,
+    ) {
+        Ok(Some(user)) => user,
+        Ok(None) => {
+            warn!(%email, "native OIDC login denied: no seat for this identity");
+            return errors::forbidden(CENTRAL_LOGIN_NO_SEAT_MSG);
+        }
+        Err(e) => {
+            error!(error = %e, "native OIDC login: seat resolution failed");
+            return errors::internal("Failed to authenticate user");
+        }
+    };
+
+    match crate::handlers::auth::establish_login_session(user, &request, &mut conn) {
+        Ok((response, tokens)) => {
+            crate::handlers::auth::build_auth_response(&request, response, &tokens)
+        }
+        Err(resp) => resp,
+    }
+}
+
 fn oidc_identity_issuer() -> String {
     issuer_for_identity(
         crate::middleware::DeploymentMode::current(),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1743,6 +1743,16 @@ async fn main() -> std::io::Result<()> {
                     .route("/oauth/authorize", web::post().to(handlers::oauth_authorize))
                     .route("/oauth/callback", web::get().to(handlers::oauth_callback))
                     .route("/oauth/logout", web::post().to(handlers::oauth_logout))
+                    // Native (mobile app) OIDC: the app runs its own PKCE flow
+                    // against the IdP, then logs in with the resulting id_token.
+                    .route(
+                        "/native-oidc-config",
+                        web::get().to(handlers::native_oidc_config),
+                    )
+                    .route(
+                        "/oidc/native-login",
+                        web::post().to(handlers::native_oidc_login),
+                    )
                     // Protected auth routes
                     .route("/me", web::get().to(handlers::get_current_user).wrap(actix_web::middleware::from_fn(cookie_auth_middleware)))
                     .route("/change-password", web::post().to(handlers::change_password).wrap(actix_web::middleware::from_fn(cookie_auth_middleware)))

--- a/backend/src/oidc.rs
+++ b/backend/src/oidc.rs
@@ -573,6 +573,53 @@ pub async fn exchange_code(
     Ok(user_info)
 }
 
+/// Verify an ID token presented by the native (mobile) app and return its user
+/// info.
+///
+/// The app is its own *public* OIDC client (`native_client_id`, no secret): it
+/// runs the Authorization-Code + PKCE flow against the IdP itself and posts the
+/// resulting ID token to the product, which trusts it only after this check. The
+/// token's audience is the native client, not the confidential web
+/// `OIDC_CLIENT_ID`, so we build a verifier for that audience (reusing the
+/// issuer's discovery + JWKS). We verify signature, issuer, audience and expiry.
+/// The `nonce` is the app's replay protection (it generated and verifies it),
+/// so it is intentionally not re-checked here.
+pub async fn verify_native_id_token(
+    id_token_str: &str,
+    native_client_id: &str,
+) -> Result<OidcUserInfo, String> {
+    use std::str::FromStr;
+
+    let config = OidcConfig::from_env()?;
+    let issuer_url = config
+        .issuer_url
+        .clone()
+        .ok_or_else(|| "Native OIDC login requires OIDC_ISSUER_URL (auto-discovery)".to_string())?;
+    let issuer = IssuerUrl::new(issuer_url).map_err(|e| format!("Invalid issuer URL: {e}"))?;
+
+    let core_metadata = CoreProviderMetadata::discover_async(issuer, &*OIDC_HTTP_CLIENT)
+        .await
+        .map_err(|e| format!("OIDC discovery failed: {e}"))?;
+
+    // Public client (no secret); the verifier checks the signature against the
+    // discovered JWKS plus issuer and audience (== native_client_id).
+    let native_client = CoreClient::from_provider_metadata(
+        core_metadata,
+        ClientId::new(native_client_id.to_string()),
+        None,
+    );
+
+    let id_token =
+        CoreIdToken::from_str(id_token_str).map_err(|e| format!("Malformed ID token: {e}"))?;
+
+    let verifier = native_client.id_token_verifier();
+    let claims = id_token
+        .claims(&verifier, |_: Option<&Nonce>| Ok::<(), String>(()))
+        .map_err(|e| format!("ID token verification failed: {e}"))?;
+
+    extract_user_info(claims, &config)
+}
+
 /// Verify ID token signature and claims
 fn verify_id_token(
     client: &OidcClientKind,

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -20,6 +20,7 @@ import Button from "@/components/common/Button.vue";
 import FormInput from "@/components/common/FormInput.vue";
 import PasswordInput from "@/components/common/PasswordInput.vue";
 import { extractErrorMessage } from "@/utils/errors";
+import { isTauriRuntime } from "@/platform";
 
 // Get branding and theme stores
 const brandingStore = useBrandingStore();
@@ -385,6 +386,25 @@ const handleOidcLoginClick = async () => {
   loadingAction.value = 'oidc';
   errorMessage.value = "";
   successMessage.value = "";
+
+  // Native app: the web redirect flow can't return to the app, so run the
+  // RFC 8252 native OIDC flow (system browser + PKCE) to get a bearer session,
+  // then hydrate the auth store from /me and route in. (No-op import on web.)
+  if (isTauriRuntime()) {
+    try {
+      const { loginWithOidc } = await import('@nosdesk/mobile');
+      await loginWithOidc();
+      await authStore.fetchUserData();
+      authStore.setAuthProvider('oidc');
+      const redirectPath = router.currentRoute.value.query.redirect?.toString() || "/";
+      router.push(redirectPath);
+    } catch (error) {
+      const err = error as Error;
+      errorMessage.value = err.message || "Sign-in failed";
+      loadingAction.value = null;
+    }
+    return;
+  }
 
   try {
     const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,7 +15,8 @@
     "@nosdesk/core": "workspace:*",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-http": "^2.0.0",
-    "axios": "^1.6.2"
+    "axios": "^1.6.2",
+    "tauri-plugin-web-auth-api": "^1.0.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.0.0",

--- a/mobile/src-tauri/Cargo.lock
+++ b/mobile/src-tauri/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-http",
  "tauri-plugin-log",
+ "tauri-plugin-web-auth",
 ]
 
 [[package]]
@@ -3796,6 +3797,18 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "tauri-plugin-web-auth"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4004df936c0afa23f97feada6eb683495e66b585770b81943dbda75998ad6295"
+dependencies = [
+ "serde",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -26,6 +26,9 @@ tauri = { version = "2.11.3", features = [] }
 # tauri:// origin, so REST goes through this (see mobile/src/tauriHttpAdapter.ts).
 tauri-plugin-http = "2"
 tauri-plugin-log = "2"
+# System-browser OAuth (ASWebAuthenticationSession / Custom Tabs) for the native
+# OIDC login against the central IdP (see mobile/src/oidc.ts).
+tauri-plugin-web-auth = "1"
 
 # OS keychain for the refresh token (see src/keychain.rs). The iOS Keychain
 # (and macOS for `tauri dev`) via SecItem, with explicit accessibility control.

--- a/mobile/src-tauri/capabilities/default.json
+++ b/mobile/src-tauri/capabilities/default.json
@@ -13,6 +13,8 @@
       "allow": [
         { "url": "https://**" }
       ]
-    }
+    },
+    "web-auth:default",
+    "web-auth:allow-authenticate"
   ]
 }

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ pub fn run() {
   tauri::Builder::default()
     // Native HTTP client for the REST API (scoped by capabilities/default.json).
     .plugin(tauri_plugin_http::init())
+    // System-browser OAuth (ASWebAuthenticationSession) for native OIDC login.
+    .plugin(tauri_plugin_web_auth::init())
     // OS-keychain storage for the auth refresh token.
     .invoke_handler(tauri::generate_handler![
       keychain::secure_store_save,

--- a/mobile/src/index.ts
+++ b/mobile/src/index.ts
@@ -10,6 +10,7 @@
  */
 export { bootstrapMobile, type MobileBootstrapOptions } from './bootstrap'
 export { setSession, clearSession, setServer } from './transport'
+export { loginWithOidc } from './oidc'
 export {
   getStoredServer,
   clearStoredServer,

--- a/mobile/src/oidc.ts
+++ b/mobile/src/oidc.ts
@@ -1,0 +1,146 @@
+/**
+ * Native OIDC login (RFC 8252): the app is its own public OIDC client.
+ *
+ * It runs the Authorization-Code + PKCE flow against the connected server's
+ * central IdP in the system browser (`ASWebAuthenticationSession` via
+ * tauri-plugin-web-auth), exchanges the code itself, then trades the resulting
+ * `id_token` for a product bearer session at the server's native-login endpoint
+ * (reusing the bearer transport + keychain). The IdP is touched only at login;
+ * the app then lives on the product session.
+ */
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import { authenticate } from 'tauri-plugin-web-auth-api'
+import { apiBaseUrl } from '@nosdesk/core/transport'
+import { setSession } from './transport'
+
+// Custom-scheme redirect registered for the public client on the IdP. iOS needs
+// no Info.plist entry: ASWebAuthenticationSession intercepts this scheme itself.
+const REDIRECT_URI = 'nosdesk://auth/callback'
+const CALLBACK_SCHEME = 'nosdesk'
+
+interface NativeOidcConfig {
+  issuer: string
+  client_id: string
+  scopes: string
+}
+
+interface OidcEndpoints {
+  authorization_endpoint: string
+  token_endpoint: string
+}
+
+// --- PKCE + random (Web Crypto; the webview is a secure context) ---
+
+function base64Url(bytes: Uint8Array): string {
+  let s = ''
+  for (const b of bytes) s += String.fromCharCode(b)
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function randomString(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength)
+  crypto.getRandomValues(bytes)
+  return base64Url(bytes)
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))
+  return base64Url(new Uint8Array(digest))
+}
+
+/** The `nonce` claim from a JWT id_token (decode only; app-side replay check). */
+function idTokenNonce(idToken: string): string | undefined {
+  const payload = idToken.split('.')[1]
+  if (!payload) return undefined
+  try {
+    return JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/'))).nonce
+  } catch {
+    return undefined
+  }
+}
+
+async function fetchConfig(): Promise<NativeOidcConfig> {
+  const res = await tauriFetch(`${apiBaseUrl()}/auth/native-oidc-config`, { method: 'GET' })
+  if (!res.ok) throw new Error(`This server doesn't support app sign-in (${res.status})`)
+  return (await res.json()) as NativeOidcConfig
+}
+
+async function discover(issuer: string): Promise<OidcEndpoints> {
+  const url = `${issuer.replace(/\/$/, '')}/.well-known/openid-configuration`
+  const res = await tauriFetch(url, { method: 'GET' })
+  if (!res.ok) throw new Error(`Identity provider discovery failed (${res.status})`)
+  return (await res.json()) as OidcEndpoints
+}
+
+function parseCallback(callbackUrl: string): { code: string; state: string } {
+  const u = new URL(callbackUrl)
+  const error = u.searchParams.get('error')
+  if (error) throw new Error(u.searchParams.get('error_description') || error)
+  const code = u.searchParams.get('code')
+  const state = u.searchParams.get('state')
+  if (!code || !state) throw new Error('Sign-in was cancelled')
+  return { code, state }
+}
+
+/**
+ * Run the full native OIDC login against the connected server. On success the
+ * session is set (refresh token persisted in the keychain) and the app is
+ * authenticated. Throws with a user-presentable message on failure.
+ */
+export async function loginWithOidc(): Promise<void> {
+  const cfg = await fetchConfig()
+  const endpoints = await discover(cfg.issuer)
+
+  const verifier = randomString(32)
+  const challenge = await pkceChallenge(verifier)
+  const state = randomString(16)
+  const nonce = randomString(16)
+
+  const authUrl = new URL(endpoints.authorization_endpoint)
+  authUrl.search = new URLSearchParams({
+    response_type: 'code',
+    client_id: cfg.client_id,
+    redirect_uri: REDIRECT_URI,
+    scope: cfg.scopes,
+    state,
+    nonce,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  }).toString()
+
+  // System browser; returns the nosdesk://auth/callback URL inline.
+  const { callbackUrl } = await authenticate({ url: authUrl.toString(), callbackScheme: CALLBACK_SCHEME })
+  const { code, state: returnedState } = parseCallback(callbackUrl)
+  if (returnedState !== state) throw new Error('Sign-in failed (state mismatch)')
+
+  // Public-client code exchange at the IdP (PKCE, no secret).
+  const tokenRes = await tauriFetch(endpoints.token_endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: REDIRECT_URI,
+      client_id: cfg.client_id,
+      code_verifier: verifier,
+    }).toString(),
+  })
+  if (!tokenRes.ok) throw new Error(`Sign-in failed at the identity provider (${tokenRes.status})`)
+  const tokenData = (await tokenRes.json()) as { id_token?: string }
+  if (!tokenData.id_token) throw new Error('Identity provider returned no ID token')
+  if (idTokenNonce(tokenData.id_token) !== nonce) throw new Error('Sign-in failed (nonce mismatch)')
+
+  // Trade the id_token for a product bearer session.
+  const loginRes = await tauriFetch(`${apiBaseUrl()}/auth/oidc/native-login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Auth-Mode': 'bearer' },
+    body: JSON.stringify({ id_token: tokenData.id_token }),
+  })
+  if (!loginRes.ok) {
+    if (loginRes.status === 403) throw new Error('Your account has no access on this server')
+    throw new Error(`Sign-in failed (${loginRes.status})`)
+  }
+  const session = (await loginRes.json()) as { access_token?: string; refresh_token?: string }
+  if (!session.access_token || !session.refresh_token) throw new Error('No session returned')
+  await setSession(session.access_token, session.refresh_token)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       axios:
         specifier: ^1.6.2
         version: 1.18.1
+      tauri-plugin-web-auth-api:
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@tauri-apps/cli':
         specifier: ^2.0.0
@@ -2076,6 +2079,9 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tauri-plugin-web-auth-api@1.0.0:
+    resolution: {integrity: sha512-g1uPl2OvFlDZBPUz+4B+AEPsGSMdH6BdnCl7UKXWu0sApRaoe+84rukh3C5o+QgZMVBUf1SyDYZB1hoL2UZwRA==}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -4048,6 +4054,10 @@ snapshots:
   tailwindcss@4.3.1: {}
 
   tapable@2.3.3: {}
+
+  tauri-plugin-web-auth-api@1.0.0:
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   tinyglobby@0.2.17:
     dependencies:


### PR DESCRIPTION
Lets the native app sign in to **hosted** Nosdesk, which authenticates everyone against the central IdP (`id.nosdesk.dev` / `id.nosdesk.com`) and disables local password login. The app becomes its own **public OIDC client** (RFC 8252), reusing the existing OIDC + bearer + keychain machinery.

## Flow
1. App fetches the connected server's `GET /api/auth/native-oidc-config` (issuer + public `client_id` + scopes) — so it targets the right IdP per server.
2. App runs **Authorization-Code + PKCE in the system browser** (`ASWebAuthenticationSession` via `tauri-plugin-web-auth`, `callbackScheme: nosdesk`), gets the code, exchanges it at the IdP itself, verifies the `nonce`.
3. App posts the `id_token` to `POST /api/auth/oidc/native-login`; the server verifies it (JWKS via the issuer, `iss`/`aud=native-client`/`exp`), resolves the existing seat by `(iss, sub)` (the **same hosted resolution** the web callback uses), and mints a normal **bearer session**.
4. App stores the product refresh token in the **keychain** and lives on the product session. The IdP is touched only at login.

## Why this shape (per the agreed plan)
App-as-public-client is higher quality than a server-mediated handoff: the deep-link leg carries a **PKCE-bound** code (un-exchangeable if intercepted), the web OIDC flow is **untouched**, and the system browser (not an embedded webview) is the RFC 8252 requirement. Backend is small: one verify helper + two handlers reusing `resolve_user_by_identity_or_email`, `establish_login_session`, `build_auth_response`.

## Changes
- **Backend:** `verify_native_id_token` (native audience) in `oidc.rs`; `native_oidc_config` + `native_oidc_login` handlers; `OIDC_NATIVE_CLIENT_ID` (default `nosdesk-app`); `establish_login_session` → `pub(crate)`. Web flow unchanged.
- **Mobile:** `mobile/src/oidc.ts` (PKCE via Web Crypto, system browser, code exchange, native-login); `tauri-plugin-web-auth` + capability (iOS needs no URL-scheme registration).
- **Frontend:** `LoginView` runs the native flow in Tauri then hydrates the auth store from `/me`; no-op on web (lazy Tauri-only chunk).

## Verified
Backend `cargo check` + 13/13 auth_providers tests; mobile + frontend type-check; frontend build + lint; `cargo check` for macOS **and `aarch64-apple-ios`** (web-auth + keychain).

## Prerequisite for the on-device test (ops, not code)
Register a **public** client `nosdesk-app` on the staging Hydra (`id.nosdesk.dev`): `token_endpoint_auth_method=none`, `response_types=[code]`, `grant_types=[authorization_code]`, `redirect_uris=[nosdesk://auth/callback]`, scopes `openid profile email`, PKCE enforced (same process as the existing `nosdesk-product` client). Then on device: connect to `nosdesk-dev.fly.dev` → Sign in → system-browser login at `id.nosdesk.dev` → returns authenticated; force-quit + reopen → still signed in.

## Out of scope
Android (Custom Tabs) wiring; the id_token crypto path's unit test (needs a mock IdP — covered by the on-device/staging test); native logout.
