### PR TITLE
fix(backend): exempt native OIDC login from CSRF

### DIFF
--- a/backend/src/utils/csrf.rs
+++ b/backend/src/utils/csrf.rs
@@ -124,6 +124,10 @@ where
             || path == "/api/auth/oauth/authorize"
             || path == "/api/auth/oauth/callback"
             || path == "/api/auth/oauth/logout"
+            // Native-app OIDC login: a pre-session bearer POST with no cookies,
+            // so there's no session for CSRF to protect (same as the login
+            // endpoints above).
+            || path == "/api/auth/oidc/native-login"
             || path == "/api/auth/setup/admin"
             || path == "/api/auth/setup/status"
             || path.starts_with("/api/auth/setup/restore/")


### PR DESCRIPTION
`/api/auth/oidc/native-login` is a pre-session bearer POST with no cookies (like the other login endpoints), but it wasn't on the CSRF exempt list, so the native app's login was 403'd (`CSRF failed: Both header and cookie missing`) before reaching the handler. The app mislabeled that 403 as "no access on this server". Adds it next to the existing `oauth/authorize`+`oauth/callback` exemptions. Diagnosed from the staging product logs.