### PR TITLE
fix(auth): accept session-JWT bearer on the main (cookie_auth) routes

### DIFF
--- a/backend/src/middleware/cookie_auth.rs
+++ b/backend/src/middleware/cookie_auth.rs
@@ -211,23 +211,42 @@ pub async fn cookie_auth_middleware(
         "Cookie auth middleware processing request"
     );
 
-    let token = req
-        .cookie(crate::utils::cookies::ACCESS_TOKEN_COOKIE)
-        .ok_or_else(|| {
-            warn!(path = %req.path(), "Cookie auth: no access_token cookie found");
-            actix_web::error::ErrorUnauthorized("Authentication required")
-        })?;
+    // Accept a session-JWT Bearer (native/mobile clients have no cookie jar) OR
+    // the access_token cookie (web). `nsk_` personal API tokens are NOT accepted
+    // here — those go through dual_auth_middleware on their designated routes.
+    let bearer =
+        crate::middleware::api_token::extract_bearer_token(&req).filter(|t| !t.starts_with("nsk_"));
+    let from_bearer = bearer.is_some();
+    let token_value = match bearer {
+        Some(t) => t,
+        None => req
+            .cookie(crate::utils::cookies::ACCESS_TOKEN_COOKIE)
+            .map(|c| c.value().to_string())
+            .ok_or_else(|| {
+                warn!(path = %req.path(), "Cookie auth: no access_token cookie or session bearer");
+                actix_web::error::ErrorUnauthorized("Authentication required")
+            })?,
+    };
 
-    debug!("Cookie auth: validating token from cookie");
-
-    let (claims, _user) = JwtUtils::authenticate_with_token(token.value(), &mut conn)
+    let (claims, _user) = JwtUtils::authenticate_with_token(&token_value, &mut conn)
         .await
         .map_err(|err| {
-            error!(error = ?err, "Cookie auth: token validation failed");
+            error!(error = ?err, "Auth: token validation failed");
             actix_web::error::ErrorUnauthorized("Invalid or expired token")
         })?;
 
-    info!(user = %claims.sub, "Cookie auth: user authenticated successfully");
+    // A Bearer session JWT must be a full-scope agent session; SSE ("sse") and
+    // portal ("portal") tokens could over-authorize if replayed as a bearer.
+    // The access_token cookie only ever carries a full session token, so it's
+    // exempt from this check.
+    if from_bearer && claims.scope != "full" {
+        warn!(path = %req.path(), scope = %claims.scope, "Rejected non-session JWT on bearer path");
+        return Err(actix_web::error::ErrorUnauthorized(
+            "Token not valid for this API",
+        ));
+    }
+
+    info!(user = %claims.sub, "Auth: user authenticated successfully");
 
     enforce_workspace_membership(&req, &mut conn, &claims)?;
 

--- a/mobile/src/apiClient.ts
+++ b/mobile/src/apiClient.ts
@@ -37,7 +37,12 @@ export function setupApiClient(): void {
   apiClient.interceptors.request.use((config) => {
     config.baseURL = apiBaseUrl()
     config.withCredentials = transport().auth.useCredentials
-    Object.assign(config.headers, transport().auth.authHeaders())
+    // Use AxiosHeaders.set (not Object.assign) so values land in the instance's
+    // canonical store that the native adapter serialises via toJSON.
+    const authHeaders = transport().auth.authHeaders()
+    for (const [key, value] of Object.entries(authHeaders)) {
+      config.headers.set(key, value)
+    }
     return config
   })
 

--- a/mobile/src/oidc.ts
+++ b/mobile/src/oidc.ts
@@ -83,13 +83,30 @@ function parseCallback(callbackUrl: string): { code: string; state: string } {
 }
 
 /**
+ * Wrap one step of the flow so a hang surfaces as a labelled, user-readable
+ * error (`Timed out: <label>`) instead of an indefinite spinner. tauri's HTTP
+ * fetch doesn't reliably honour AbortController, so we race a timer.
+ */
+async function step<T>(label: string, ms: number, run: () => Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out: ${label}`)), ms)
+  })
+  try {
+    return await Promise.race([run(), timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+/**
  * Run the full native OIDC login against the connected server. On success the
  * session is set (refresh token persisted in the keychain) and the app is
  * authenticated. Throws with a user-presentable message on failure.
  */
 export async function loginWithOidc(): Promise<void> {
-  const cfg = await fetchConfig()
-  const endpoints = await discover(cfg.issuer)
+  const cfg = await step('config', 15000, () => fetchConfig())
+  const endpoints = await step('discovery', 15000, () => discover(cfg.issuer))
 
   const verifier = randomString(32)
   const challenge = await pkceChallenge(verifier)
@@ -108,37 +125,47 @@ export async function loginWithOidc(): Promise<void> {
     code_challenge_method: 'S256',
   }).toString()
 
-  // System browser; returns the nosdesk://auth/callback URL inline.
-  const { callbackUrl } = await authenticate({ url: authUrl.toString(), callbackScheme: CALLBACK_SCHEME })
+  // System browser; returns the nosdesk://auth/callback URL inline. Long
+  // timeout: the user is logging in.
+  const { callbackUrl } = await step('browser', 300000, () =>
+    authenticate({ url: authUrl.toString(), callbackScheme: CALLBACK_SCHEME }),
+  )
   const { code, state: returnedState } = parseCallback(callbackUrl)
   if (returnedState !== state) throw new Error('Sign-in failed (state mismatch)')
 
   // Public-client code exchange at the IdP (PKCE, no secret).
-  const tokenRes = await tauriFetch(endpoints.token_endpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'authorization_code',
-      code,
-      redirect_uri: REDIRECT_URI,
-      client_id: cfg.client_id,
-      code_verifier: verifier,
-    }).toString(),
-  })
-  if (!tokenRes.ok) throw new Error(`Sign-in failed at the identity provider (${tokenRes.status})`)
+  const tokenRes = await step('token-exchange', 20000, () =>
+    tauriFetch(endpoints.token_endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT_URI,
+        client_id: cfg.client_id,
+        code_verifier: verifier,
+      }).toString(),
+    }),
+  )
+  if (!tokenRes.ok) {
+    const body = await tokenRes.text().catch(() => '')
+    throw new Error(`token-exchange ${tokenRes.status}: ${body.slice(0, 160)}`)
+  }
   const tokenData = (await tokenRes.json()) as { id_token?: string }
   if (!tokenData.id_token) throw new Error('Identity provider returned no ID token')
   if (idTokenNonce(tokenData.id_token) !== nonce) throw new Error('Sign-in failed (nonce mismatch)')
 
   // Trade the id_token for a product bearer session.
-  const loginRes = await tauriFetch(`${apiBaseUrl()}/auth/oidc/native-login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'X-Auth-Mode': 'bearer' },
-    body: JSON.stringify({ id_token: tokenData.id_token }),
-  })
+  const loginRes = await step('native-login', 20000, () =>
+    tauriFetch(`${apiBaseUrl()}/auth/oidc/native-login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Auth-Mode': 'bearer' },
+      body: JSON.stringify({ id_token: tokenData.id_token }),
+    }),
+  )
   if (!loginRes.ok) {
-    if (loginRes.status === 403) throw new Error('Your account has no access on this server')
-    throw new Error(`Sign-in failed (${loginRes.status})`)
+    const body = await loginRes.text().catch(() => '')
+    throw new Error(`native-login ${loginRes.status}: ${body.slice(0, 160)}`)
   }
   const session = (await loginRes.json()) as { access_token?: string; refresh_token?: string }
   if (!session.access_token || !session.refresh_token) throw new Error('No session returned')


### PR DESCRIPTION
The native app sends its session JWT as `Authorization: Bearer` (no cookies on `tauri://`), but bearer support was only in `dual_auth_middleware` (a few file routes). `/me` and the main user API use `cookie_auth_middleware`, which read only the cookie, so every bearer request 401'd despite a valid token — diagnosed via on-device console logs (`hasBearer: true` yet 401) + server logs (`cookie_auth: no access_token cookie`).

`cookie_auth` now accepts a session-JWT bearer **or** the cookie, reusing the same `authenticate_with_token` + `enforce_workspace_membership`, with the same `scope=="full"` guard `dual_auth` uses (blocks SSE/portal-token replay). `nsk_` API tokens stay on `dual_auth` routes only.

**Follow-up (agreed):** consolidate the duplicated session-bearer logic in `cookie_auth` + `dual_auth` into one policy-parameterized auth middleware.

Also: `oidc.ts` per-step timeouts (hangs surface as readable errors), `apiClient` uses `AxiosHeaders.set`. Verified: backend `cargo check`, mobile/frontend type-check.