### PR TITLE
feat(dashboard): responsive edit toolbar; route ConfirmModal through Button

### DIFF
--- a/frontend/src/components/common/Button.vue
+++ b/frontend/src/components/common/Button.vue
@@ -7,6 +7,8 @@ Variants:
   - primary       solid accent, the one main action per section
   - secondary     neutral filled, lower-emphasis affirmative actions
   - danger        solid red, prominent destructive CTAs (modal confirms)
+  - warning       solid amber, reversible-but-consequential confirms
+                  (reset to defaults, discard changes)
   - ghost         transparent neutral, low-emphasis / icon actions
   - ghost-danger  transparent red text, low-emphasis destructive actions
                   in dense rows (Revoke, Remove) where a filled red button
@@ -21,7 +23,7 @@ import Spinner from '@/components/common/Spinner.vue';
 import Icon from '@/components/common/Icon.vue';
 import type { IconName } from '@/components/common/icons';
 
-type Variant = 'primary' | 'secondary' | 'danger' | 'ghost' | 'ghost-danger';
+type Variant = 'primary' | 'secondary' | 'danger' | 'warning' | 'ghost' | 'ghost-danger';
 type Size = 'sm' | 'md' | 'lg';
 
 interface Props {
@@ -74,7 +76,11 @@ const sizeClasses: Record<Size, string> = {
 const variantClasses: Record<Variant, string> = {
   primary: 'bg-accent text-on-accent hover:opacity-90',
   secondary: 'bg-surface-alt text-primary border border-default hover:bg-surface-hover',
+  // `text-white` on danger/warning: same contrast tradeoff documented
+  // above (no theme-aware on-status token yet). Kept as-is so the
+  // existing filled-status buttons don't recolour.
   danger: 'bg-status-error text-white hover:opacity-90',
+  warning: 'bg-status-warning text-white hover:opacity-90',
   ghost: 'text-secondary hover:text-primary hover:bg-surface-hover',
   'ghost-danger': 'text-status-error hover:bg-status-error/10',
 };

--- a/frontend/src/components/common/ConfirmModal.vue
+++ b/frontend/src/components/common/ConfirmModal.vue
@@ -23,41 +23,26 @@ Usage:
 
     <template #footer>
       <div class="modal-actions">
-        <button
-          type="button"
-          class="text-secondary hover:text-primary hover:bg-surface-hover transition-colors"
-          @click="emit('close')"
+        <Button variant="ghost" @click="emit('close')">{{ cancelLabel }}</Button>
+        <Button
+          :variant="confirmVariant"
+          :disabled="confirmDisabled"
+          :loading="loading"
+          @click="emit('confirm')"
         >
-          {{ cancelLabel }}
-        </button>
-        <button
-          type="button"
-          :disabled="confirmDisabled || loading"
-          :class="[
-            'text-white transition-colors inline-flex items-center justify-center gap-2',
-            confirmDisabled && !loading
-              ? 'bg-surface-alt text-tertiary cursor-not-allowed'
-              : variant === 'danger'
-                ? 'bg-status-error hover:opacity-90'
-                : variant === 'warning'
-                  ? 'bg-status-warning hover:opacity-90'
-                  : 'bg-accent hover:opacity-90',
-          ]"
-          @click="confirmDisabled || loading ? undefined : emit('confirm')"
-        >
-          <Spinner v-if="loading" size="xs" />
           {{ confirmLabel }}
-        </button>
+        </Button>
       </div>
     </template>
   </Modal>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import Modal from '@/components/Modal.vue'
-import Spinner from '@/components/common/Spinner.vue'
+import Button from '@/components/common/Button.vue'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     show: boolean
     title: string
@@ -75,6 +60,15 @@ withDefaults(
     confirmDisabled: false,
     loading: false,
   },
+)
+
+// Map the semantic dialog variant onto the shared Button's variants.
+// `info` is the neutral affirmative confirm, so it takes the accent
+// primary (theme-aware on-accent foreground); danger / warning pass
+// through. Button disables itself while `disabled` or `loading`, so a
+// blocked confirm can't emit.
+const confirmVariant = computed(() =>
+  props.variant === 'danger' ? 'danger' : props.variant === 'warning' ? 'warning' : 'primary',
 )
 
 const emit = defineEmits<{

--- a/frontend/src/views/dashboard/DashboardEditBar.vue
+++ b/frontend/src/views/dashboard/DashboardEditBar.vue
@@ -57,15 +57,20 @@ function doReset() {
 </script>
 
 <template>
-  <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-surface-alt border border-default">
+  <!-- Responsive: on mobile the status sits on its own row above a
+       wrapping action cluster (nothing clips at narrow widths); from
+       sm up it collapses to a single row with the actions pushed to
+       the trailing edge. -->
+  <div
+    class="flex flex-col gap-2 px-3 py-2 rounded-lg bg-surface-alt border border-default sm:flex-row sm:items-center"
+  >
     <span class="inline-flex items-center gap-1.5 text-xs font-medium text-secondary">
       <span class="w-1.5 h-1.5 rounded-full bg-accent animate-pulse" aria-hidden="true" />
       <span v-if="store.isDirty">{{ t('dashboard-edit-bar-unsaved') }}</span>
       <span v-else>{{ t('dashboard-edit-bar-editing') }}</span>
     </span>
 
-    <span class="flex-1" />
-
+    <div class="flex flex-wrap items-center gap-1.5 sm:ml-auto sm:flex-nowrap">
     <!-- Undo / Redo. Disabled-when-empty rather than hidden so the
          shortcuts (Cmd-Z / Cmd-Shift-Z) have a discoverable mouse
          affordance and the bar's chrome doesn't shift width as the
@@ -92,7 +97,7 @@ function doReset() {
       <span class="sr-only">{{ t('dashboard-edit-bar-redo') }}</span>
     </button>
 
-    <span class="w-px h-5 bg-default mx-1" aria-hidden="true" />
+    <span class="hidden sm:block w-px h-5 bg-default mx-1" aria-hidden="true" />
 
     <button
       type="button"
@@ -137,6 +142,7 @@ function doReset() {
     >
       {{ store.isDirty ? t('dashboard-edit-bar-done') : t('dashboard-edit-bar-close') }}
     </button>
+    </div>
   </div>
 
   <AddWidgetModal :show="showAdd" @close="showAdd = false" />


### PR DESCRIPTION
## What & why

Two dashboard edit-mode polish items:

1. **The dashboard editor toolbar overflowed on mobile.** `DashboardEditBar` was a single flex row (status + undo/redo + Add widget + Reset + Discard + Done), which clipped at phone widths.
2. **The reset confirmation button was hand-rolled**, not using the shared button component or its theme-aware tokens.

## Changes

**`DashboardEditBar.vue` — responsive**
- Mobile: the "Editing / Unsaved" status sits on its own row above a wrapping action cluster, so nothing clips at narrow widths.
- `sm`+: collapses to a single row with the actions pushed to the trailing edge (`sm:ml-auto`).
- The inter-group divider is hidden on mobile (meaningless once the cluster wraps).

**`ConfirmModal.vue` + `Button.vue` — design-system button**
- `ConfirmModal`'s footer now renders through the shared `Button` (Cancel = `ghost`, confirm mapped by variant: danger→danger, warning→warning, info→primary). Removes the hand-rolled colour logic and manual spinner; `Button` owns loading/disabled.
- Added a `warning` variant to `Button` (it only had danger) so **no consumer's semantics change**.

### Blast radius

This lives at the shared `ConfirmModal` (~35 call sites), which is the right altitude rather than special-casing the dashboard:
- **danger** (22 uses) and **warning** (11 uses) confirm buttons are visually identical, just component-driven.
- **info / default** confirm buttons switch from `text-white` to the theme-aware `text-on-accent` foreground — a WCAG fix (white on brand orange was 3.86:1, under AA; on-accent resolves to black at 7.4:1 AAA).

## Verification

- `type-check` + `lint` pass.
- Driven headless: at 390px the toolbar stacks to two rows with no horizontal clip; at 1600px it's a single row. The reset modal confirm renders as a themed `warning` `Button` (full-width touch target on mobile bottom-sheet, right-aligned action row on desktop) with the `focus-visible` accent ring.