### PR TITLE
feat(mobile): branded launch intro, no flash

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,10 +3,114 @@
   <head>
     <meta charset="UTF-8">
     <script src="/branding-init.js"></script>
+    <!--
+      Launch splash controller. Render-blocking (runs before first paint,
+      like branding-init.js) so it can set the splash colours from the
+      cached theme and mark the runtime BEFORE the splash element paints.
+      All splash JS lives here (external, origin-served) because the CSP
+      forbids inline scripts; the visuals below are inline <style>, which
+      the CSP allows.
+    -->
+    <script src="/splash.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=yes, viewport-fit=cover, interactive-widget=resizes-content">
     <meta name="HandheldFriendly" content="true">
+    <style>
+      /* Pre-mount launch splash. Covers the whole window from the first
+         painted frame until the app's first real screen is up, so the
+         native launch field hands off to the app with no white/light-gray
+         flash. Colours come from CSS vars set by splash.js (cached theme),
+         with a dark-brand default.
+
+         Loading: the N spins on its own axis. The glyph is 180-degree
+         rotationally symmetric, so every half-turn lands on an identical
+         N and the loop is seamless. Hand-off: a calm, quick crossfade
+         (field + mark fade together) while the spin keeps going, so the
+         mark is never in the way when the app appears. */
+      #app-splash {
+        position: fixed;
+        inset: 0;
+        z-index: 2147483647;
+        display: grid;
+        place-items: center;
+        overflow: hidden;
+        padding: env(safe-area-inset-top) env(safe-area-inset-right)
+                 env(safe-area-inset-bottom) env(safe-area-inset-left);
+      }
+      #app-splash .splash-bg {
+        position: absolute;
+        inset: 0;
+        background: var(--splash-bg, #08090a);
+        transition: opacity 300ms ease;
+      }
+      /* The N mark, drawn by masking the brand fill with the glyph. The
+         glyph is an inline data-URI (no fetch, no square flash). */
+      #app-splash .splash-n {
+        position: relative;
+        width: 74px;
+        height: 74px;
+        background-color: var(--splash-fg, #FF6B1A);
+        -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='78'%20height='78'%20viewBox='0%200%2078.4%2078.4'%3E%3Cpath%20d='m%2052.25,0%20h%2022.06%20v%2078.4%20l%20-20.58,-0.34%20-27.58,-36.29%20V%2078.39%20H%204.09%20V%200%20l%2020.64,0.06%2027.52,38.69%20z'/%3E%3C/svg%3E") center / contain no-repeat;
+        mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='78'%20height='78'%20viewBox='0%200%2078.4%2078.4'%3E%3Cpath%20d='m%2052.25,0%20h%2022.06%20v%2078.4%20l%20-20.58,-0.34%20-27.58,-36.29%20V%2078.39%20H%204.09%20V%200%20l%2020.64,0.06%2027.52,38.69%20z'/%3E%3C/svg%3E") center / contain no-repeat;
+        will-change: transform, opacity;
+      }
+      :root.runtime-web #app-splash .splash-n { display: none; }
+
+      @media (prefers-reduced-motion: no-preference) {
+        /* Loading spin. `rotate` and `scale` are separate transform
+           properties so the entrance scale and the spin compose instead
+           of fighting over `transform`. Gated to :not([data-exit]) so
+           the entrance stops on exit and the spin can carry over without
+           either out-specifying the exit rule. The spin timing is a
+           longer ease-in into a faster ease-out with a touch of back
+           (anticipation + overshoot), so each half-turn winds up and
+           snaps onto the next N. */
+        :root.runtime-app #app-splash:not([data-exit]) .splash-n {
+          animation:
+            splash-in 420ms ease-out both,
+            splash-spin 1s cubic-bezier(0.6, -0.12, 0.2, 1.22) 350ms infinite;
+        }
+      }
+      @keyframes splash-in {
+        from { opacity: 0; scale: 0.82; }
+        to   { opacity: 1; scale: 1; }
+      }
+      /* Rest as a readable N for the first ~60% of the cycle, then a
+         quick half-turn (wind-up + fast spin + overshoot-settle) onto
+         the next N. So it's mostly idle, with a snappy flip between. */
+      @keyframes splash-spin {
+        0%, 60% { rotate: 0deg; }
+        100%    { rotate: 180deg; }
+      }
+
+      /* Exit: a calm, quick crossfade. The spin keeps turning (same
+         params so it carries over without restarting) while the mark and
+         the field fade together. Nothing flashes, nothing zooms; the app
+         is usable the instant it shows through. */
+      #app-splash[data-exit] { pointer-events: none; }
+      #app-splash[data-exit] .splash-bg { opacity: 0; }
+      @media (prefers-reduced-motion: no-preference) {
+        :root.runtime-app #app-splash[data-exit] .splash-n {
+          animation:
+            splash-spin 1s cubic-bezier(0.6, -0.12, 0.2, 1.22) 350ms infinite,
+            splash-out 300ms ease forwards;
+        }
+      }
+      @keyframes splash-out {
+        from { opacity: 1; }
+        to   { opacity: 0; }
+      }
+
+      /* Reduced motion: static mark, plain quick crossfade, no spin. */
+      @media (prefers-reduced-motion: reduce) {
+        #app-splash[data-exit] .splash-n { transition: opacity 200ms ease; opacity: 0; }
+      }
+    </style>
   </head>
   <body>
+    <div id="app-splash" role="presentation" aria-hidden="true">
+      <div class="splash-bg"></div>
+      <div class="splash-n"></div>
+    </div>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/frontend/public/splash.js
+++ b/frontend/public/splash.js
@@ -1,0 +1,101 @@
+/*
+ * Launch-splash controller. Loaded render-blocking from <head> (before
+ * first paint), so it sets the splash colours + runtime marker before
+ * the #app-splash element paints, then tears the splash down once the
+ * app's first screen is up.
+ *
+ * Why a separate file (not inline in index.html): the app CSP is
+ * `script-src 'self' 'unsafe-eval'` with no 'unsafe-inline'/nonce, so
+ * inline scripts are blocked. An origin-served file is 'self'-allowed.
+ * The splash visuals/animation are inline <style> (CSP allows that).
+ *
+ * Contract with the rest of the app:
+ *   - `main.ts` sets `data-ready` on #app-splash after the first real
+ *     screen has painted (double-rAF post-mount).
+ *   - the resolved theme is cached in localStorage `nosdesk_launch_theme`
+ *     by the theme store, so the field + N match the user's theme.
+ */
+(function () {
+  var MIN_DISPLAY_MS = 700 // app: keep the intro up long enough for a sheen pass
+  var SAFETY_MS = 5000 // never trap the splash if `data-ready` never comes
+  var FADE_MS = 360 // covers the crossfade exit (300ms) + buffer
+
+  var root = document.documentElement
+
+  // --- Colours (before first paint) --------------------------------------
+  var bg = null
+  var fg = null
+  try {
+    var cached = JSON.parse(localStorage.getItem('nosdesk_launch_theme') || '{}')
+    if (cached && typeof cached.app === 'string') bg = cached.app
+    if (cached && typeof cached.accent === 'string') fg = cached.accent
+  } catch (e) {
+    /* private mode / malformed: fall through to defaults */
+  }
+  // First launch (no cache): match OS appearance so a light-mode user
+  // never gets a dark flash; dark brand is the default field.
+  var prefersDark = !window.matchMedia || window.matchMedia('(prefers-color-scheme: dark)').matches
+  if (!bg) bg = prefersDark ? '#08090a' : '#f3f4f6'
+  if (!fg) fg = '#FF6B1A'
+  root.style.setProperty('--splash-bg', bg)
+  root.style.setProperty('--splash-fg', fg)
+
+  // Runtime marker gates the animated N to the mobile app (set before
+  // paint so plain web never even flashes the mark). `window.isTauri`
+  // is injected by Tauri before the page loads.
+  var isApp = !!window.isTauri
+  root.classList.add(isApp ? 'runtime-app' : 'runtime-web')
+
+  // --- Teardown ----------------------------------------------------------
+  function whenReady(el, done, minMs) {
+    var startT = Date.now()
+    var fired = false
+    function fire() {
+      if (fired) return
+      fired = true
+      setTimeout(done, Math.max(0, minMs - (Date.now() - startT)))
+    }
+    if (el.hasAttribute('data-ready')) {
+      fire()
+      return
+    }
+    var obs = new MutationObserver(function () {
+      if (el.hasAttribute('data-ready')) {
+        obs.disconnect()
+        fire()
+      }
+    })
+    obs.observe(el, { attributes: true, attributeFilter: ['data-ready'] })
+    // Safety net: a hung boot must not trap the splash.
+    setTimeout(function () {
+      obs.disconnect()
+      fire()
+    }, SAFETY_MS)
+  }
+
+  function exit(el) {
+    el.setAttribute('data-exit', '')
+    // A CSS animation drives the longest part of the exit, so a plain
+    // timer (not transitionend, which fires on the shorter bg fade) is
+    // the deterministic removal trigger. Removing the node leaves zero
+    // residual layer.
+    setTimeout(function () {
+      if (el.parentNode) el.parentNode.removeChild(el)
+    }, FADE_MS)
+  }
+
+  function start() {
+    var el = document.getElementById('app-splash')
+    if (!el) return
+    // App: full intro with a minimum on-screen time. Web: no branded
+    // intro (the N is hidden via runtime-web) — the themed field just
+    // covers the pre-mount flash and leaves as soon as the app is ready.
+    whenReady(el, function () { exit(el) }, isApp ? MIN_DISPLAY_MS : 0)
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start)
+  } else {
+    start()
+  }
+})()

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,7 +4,7 @@ import { initServerGate } from './platform/serverGate'
 
 import { interceptConsole } from './utils/remoteLogger'
 
-import { createApp } from 'vue'
+import { createApp, nextTick } from 'vue'
 import { createPinia } from 'pinia'
 import { PiniaColada } from '@pinia/colada'
 
@@ -68,6 +68,19 @@ async function bootstrap() {
   // 'host' and never rejects, so it can't block or break the mount.
   await Promise.all([fetchInstanceConfig(), router.isReady()])
   app.mount('#app')
+
+  // Signal the launch splash (public/splash.js) that the first real
+  // screen is up so it can hand off. Double-rAF after nextTick waits
+  // for the mounted screen to actually paint, so the fade never starts
+  // over a blank frame. Whichever screen mounted first (connect-server,
+  // login, or the app shell) is a real branded screen; auth resolving
+  // later doesn't matter here.
+  await nextTick()
+  requestAnimationFrame(() =>
+    requestAnimationFrame(() => {
+      document.getElementById('app-splash')?.setAttribute('data-ready', '')
+    }),
+  )
 }
 
 void bootstrap()

--- a/frontend/src/themes/utils/cssInjector.ts
+++ b/frontend/src/themes/utils/cssInjector.ts
@@ -117,6 +117,22 @@ ${colors.syntax ? Object.entries(colors.syntax).map(([key, value]) => `
 
   // Store active theme ID for reference
   root.dataset.theme = theme.meta.id
+
+  // Cache the resolved app background + accent for the next cold
+  // launch. The pre-mount splash (`public/splash.js`) reads this so
+  // its background and the "N" match the user's real theme before
+  // any Vue/JS has run. Mirrors the `nosdesk_branding_cache` pattern
+  // read by `branding-init.js`. Best-effort: localStorage can throw
+  // in private mode, and a stale cache only costs one off-theme
+  // launch frame.
+  try {
+    localStorage.setItem(
+      'nosdesk_launch_theme',
+      JSON.stringify({ app: colors.app, accent: colors.accent }),
+    )
+  } catch {
+    // ignore: splash falls back to prefers-color-scheme + dark brand
+  }
 }
 
 /**

--- a/mobile/src-tauri/.gitignore
+++ b/mobile/src-tauri/.gitignore
@@ -10,6 +10,12 @@
 # tracked, so a build regenerates a correct project.
 /gen/apple/app.xcodeproj/
 
+# NOTE: gen/apple/LaunchScreen.storyboard and Assets.xcassets/LaunchBackground
+# .colorset ARE tracked and intentionally customized (brand launch field, no
+# white flash). `tauri ios build` does NOT touch them; only a manual
+# `tauri ios init` re-scaffold would. If you ever re-init, re-apply the
+# LaunchBackground colorset + the storyboard's named-colour background.
+
 # The Android Studio project is tracked (like gen/apple) so the manifest
 # customization (the nosdesk:// OIDC intent-filter) and the adaptive launcher
 # icons are reproducible. The nested gen/android/.gitignore + app/.gitignore

--- a/mobile/src-tauri/gen/apple/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/mobile/src-tauri/gen/apple/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.953",
+          "green" : "0.957",
+          "blue" : "0.965",
+          "alpha" : "1.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.031",
+          "green" : "0.035",
+          "blue" : "0.039",
+          "alpha" : "1.000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/mobile/src-tauri/gen/apple/LaunchScreen.storyboard
+++ b/mobile/src-tauri/gen/apple/LaunchScreen.storyboard
@@ -3,7 +3,7 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17122"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -15,7 +15,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <!-- Brand launch field. `LaunchBackground` colorset:
+                             light #f3f4f6 / dark #08090a, matches the app so
+                             the native launch frame hands off to the web
+                             splash with no flash. Intentional edit; re-apply
+                             if `tauri ios init` is ever re-run. -->
+                        <color key="backgroundColor" name="LaunchBackground"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -23,8 +28,8 @@
         </scene>
     </scenes>
     <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
+        <namedColor name="LaunchBackground">
+            <color red="0.03137254901960784" green="0.03529411764705882" blue="0.03921568627450981" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -31,13 +31,57 @@ pub fn run() {
       // desktop web build is untouched.
       #[cfg(target_os = "ios")]
       {
-        use objc2::msg_send;
         use objc2::runtime::AnyObject;
+        use objc2::{class, msg_send};
         use tauri::Manager;
         if let Some(webview) = app.get_webview_window("main") {
           let _ = webview.with_webview(|pw| unsafe {
             let wk = pw.inner() as *mut AnyObject;
             let _: () = msg_send![wk, setAllowsBackForwardNavigationGestures: true];
+
+            // Paint the webview with the appearance-aware `LaunchBackground`
+            // colour (light #f3f4f6 / dark #08090a, the same colorset the
+            // launch storyboard uses) and make it non-opaque, so that
+            // colour shows before the web content paints instead of the
+            // default white backing. This is what removes the white launch
+            // flash; the scroll view is painted too so overscroll doesn't
+            // expose white. Colour resolved from the asset catalog by name.
+            let name: *mut AnyObject = msg_send![
+              class!(NSString),
+              stringWithUTF8String: b"LaunchBackground\0".as_ptr() as *const std::os::raw::c_char
+            ];
+            let color: *mut AnyObject = msg_send![class!(UIColor), colorNamed: name];
+            if !color.is_null() {
+              let _: () = msg_send![wk, setOpaque: false];
+              let _: () = msg_send![wk, setBackgroundColor: color];
+              let scroll: *mut AnyObject = msg_send![wk, scrollView];
+              if !scroll.is_null() {
+                let _: () = msg_send![scroll, setBackgroundColor: color];
+                // Stop iOS auto-adjusting the scroll view's content inset
+                // to the safe area. With the default `.automatic`, the
+                // native layer pads a strip at the bottom (home-indicator
+                // area) that our full-bleed CSS (viewport-fit=cover +
+                // env() padding) doesn't fill, so that strip shows the
+                // window background as a white sliver. `.never` (raw value
+                // 2) makes the web content full-bleed, so CSS owns all the
+                // inset padding and there is no uncovered strip.
+                let _: () = msg_send![scroll, setContentInsetAdjustmentBehavior: 2_i64];
+              }
+              // Paint the layers BEHIND the webview too: the host view
+              // controller's view (webview superview) and the window.
+              // A non-opaque webview reveals these in any region it
+              // doesn't fully cover (the bottom safe-area / home-
+              // indicator strip), which is where the white bottom
+              // sliver came from.
+              let superview: *mut AnyObject = msg_send![wk, superview];
+              if !superview.is_null() {
+                let _: () = msg_send![superview, setBackgroundColor: color];
+              }
+              let window: *mut AnyObject = msg_send![wk, window];
+              if !window.is_null() {
+                let _: () = msg_send![window, setBackgroundColor: color];
+              }
+            }
           });
         }
       }


### PR DESCRIPTION
## What & why

Cold-launching the iOS app flashed black → white → black before the dashboard. This replaces that with a themed brand field and a spinning-N loading state that hands off to the app with a calm crossfade. No jarring flash, and it's fast/repeatable enough to not grate on the 100th open.

## Native (iOS) — `mobile/src-tauri/`
- **WKWebView background**: `lib.rs` paints the webview (non-opaque), its scroll view, superview, and window with an appearance-aware `LaunchBackground` colour, so no white backing shows before the web content paints (the source of the white flash).
- **White bottom sliver**: root-caused to iOS's default `scrollView.contentInsetAdjustmentBehavior = .automatic`, which pads a safe-area strip that the full-bleed CSS doesn't fill, exposing the window background. Fixed with `.never`; the app already owns its safe-area padding (`env(safe-area-inset-*)` throughout), so nothing slides under the home indicator.
- **Launch storyboard** uses a new `LaunchBackground` colorset (light `#f3f4f6` / dark `#08090a`) instead of `systemBackgroundColor` (white in light mode). `.gitignore` notes these edits are intentional.

## Web / shared — `frontend/`
- Pre-mount `#app-splash` overlay in `index.html` (inline `<style>` + external `public/splash.js`) covers the boot window. **CSP-safe**: the app CSP forbids inline scripts, so all JS is in the origin-served `splash.js`; visuals are inline `<style>` only.
- **Loading**: the N mark spins on its 180° rotational symmetry (verified) so every half-turn lands on an identical N and the loop is seamless — it rests as a readable N, then does a quick ease-in-out-back flip. Drawn via a CSS mask of the glyph (no fetch, no square flash).
- **Hand-off**: `main.ts` sets `data-ready` after the first real screen paints (double-rAF post-mount); `splash.js` owns the min-display / safety-timeout / teardown and crossfades the field + mark out. `cssInjector.ts` caches the resolved theme so the splash matches the user's theme next launch.
- **Scope**: the animated intro is mobile-only (`window.isTauri`); plain web page-loads only get the anti-flash themed field (dark-theme users no longer see the light-gray pre-mount flash).

## Verification
- `type-check` + `lint` + `cargo check --target aarch64-apple-ios` pass.
- Every animation state verified frame-by-frame in **Playwright WebKit** (the real engine): mask renders, 180° symmetry, spin curve (anticipation → fast → overshoot → settle), hold-then-flip rhythm, and the exit fading the mark to opacity 0.
- Driven on the iOS Simulator (recorded cold launch: no white/light-gray frame anywhere) and installed/tested on a physical device across several iterations.

Isolated from the in-progress pull-to-refresh / haptics work (only my `lib.rs` webview hunk is included, not the haptics plugin registration).