### PR TITLE
feat(dashboard): add-widget preview grid + resize-preview scroll fix

### DIFF
--- a/frontend/src/views/dashboard/AddWidgetModal.vue
+++ b/frontend/src/views/dashboard/AddWidgetModal.vue
@@ -19,7 +19,8 @@ import Modal from '@/components/Modal.vue'
 import { useFluent } from 'fluent-vue'
 import { useQuery } from '@pinia/colada'
 import { useDashboardLayoutStore } from '@/stores/dashboardLayout'
-import { savedViewWidgetId } from './widgets'
+import { savedViewWidgetId, widgetPreviewKind, savedViewPreviewKind } from './widgets'
+import WidgetPreview from './WidgetPreview.vue'
 import { savedViewsService, type SavedView } from '@/services/savedViewsService'
 
 const fluent = useFluent()
@@ -95,7 +96,7 @@ watch(
 </script>
 
 <template>
-  <Modal :show="show" :title="t('dashboard-add-widget-title')" size="md" @close="emit('close')">
+  <Modal :show="show" :title="t('dashboard-add-widget-title')" size="lg" @close="emit('close')">
     <div class="flex flex-col gap-3">
       <!-- Tabs. Inline counts beside each tab label so the user
            sees what's pickable in each category without flicking
@@ -141,15 +142,20 @@ watch(
         >
           {{ t('dashboard-add-widget-all-added') }}
         </div>
-        <ul v-else class="flex flex-col gap-1">
+        <ul v-else class="grid grid-cols-2 gap-2 sm:grid-cols-3">
           <li v-for="w in store.addable" :key="w.id">
             <button
               type="button"
-              class="w-full text-left flex flex-col gap-0.5 p-3 rounded-lg border border-default hover:border-accent hover:bg-surface-hover transition-colors"
+              class="group flex h-full w-full flex-col overflow-hidden rounded-lg border border-default text-left transition-colors hover:border-accent"
               @click="chooseSystem(w.id)"
             >
-              <span class="text-sm font-medium text-primary">{{ t(w.titleKey) }}</span>
-              <span class="text-xs text-tertiary">{{ t(w.descriptionKey) }}</span>
+              <div class="aspect-[16/9] w-full border-b border-default bg-surface-alt p-2.5">
+                <WidgetPreview :kind="widgetPreviewKind(w.id)" />
+              </div>
+              <div class="flex flex-1 flex-col gap-0.5 p-2.5 group-hover:bg-surface-hover">
+                <span class="text-sm font-medium text-primary">{{ t(w.titleKey) }}</span>
+                <span class="line-clamp-2 text-xs text-tertiary">{{ t(w.descriptionKey) }}</span>
+              </div>
             </button>
           </li>
         </ul>
@@ -172,17 +178,22 @@ watch(
         >
           {{ t('dashboard-add-widget-saved-views-empty') }}
         </div>
-        <ul v-else class="flex flex-col gap-1">
+        <ul v-else class="grid grid-cols-2 gap-2 sm:grid-cols-3">
           <li v-for="v in pickableSavedViews" :key="v.uuid">
             <button
               type="button"
-              class="w-full text-left flex flex-col gap-0.5 p-3 rounded-lg border border-default hover:border-accent hover:bg-surface-hover transition-colors"
+              class="group flex h-full w-full flex-col overflow-hidden rounded-lg border border-default text-left transition-colors hover:border-accent"
               @click="chooseSavedView(v)"
             >
-              <span class="text-sm font-medium text-primary">{{ v.name }}</span>
-              <span class="text-xs text-tertiary">
-                {{ t(`dashboard-saved-view-viz-label-${v.viz_type ?? 'list'}`) }}
-              </span>
+              <div class="aspect-[16/9] w-full border-b border-default bg-surface-alt p-2.5">
+                <WidgetPreview :kind="savedViewPreviewKind(v.viz_type)" />
+              </div>
+              <div class="flex flex-1 flex-col gap-0.5 p-2.5 group-hover:bg-surface-hover">
+                <span class="text-sm font-medium text-primary">{{ v.name }}</span>
+                <span class="text-xs text-tertiary">
+                  {{ t(`dashboard-saved-view-viz-label-${v.viz_type ?? 'list'}`) }}
+                </span>
+              </div>
             </button>
           </li>
         </ul>

--- a/frontend/src/views/dashboard/DashboardGrid.vue
+++ b/frontend/src/views/dashboard/DashboardGrid.vue
@@ -395,6 +395,13 @@ watch(ghostVisible, (visible) => {
 // change is committed to the store once on pointerup, so the whole
 // gesture is a single undo step rather than one per frame.
 const resizePreview = ref<{ id: string; span: WidgetSpan; rowSpan: WidgetSpan } | null>(null)
+/** Height floor held while a menu-hover resize preview is active. A
+ *  preview re-packs the grid live; without this, previewing a *smaller*
+ *  size shortens the page, and if the widget sits near the bottom the
+ *  scroll container clamps upward — yanking the open menu out from under
+ *  the cursor. Freezing the grid's min-height at its pre-preview value
+ *  lets a preview grow the page (top stays put) but never shrink it. */
+const reservedMinHeight = ref<number | null>(null)
 /** True only while a pointer resize gesture is in flight (not for
  *  menu hover previews). Drives the size badge + lattice underlay. */
 const resizeActive = ref(false)
@@ -558,6 +565,20 @@ function onPreviewResize(entry: LayoutEntry, intent: ResizePreviewIntent | null)
     id: entry.id,
     span: intent.span ?? effectiveSpanFor(entry),
     rowSpan: intent.rowSpan ?? rowSpanFor(entry),
+  }
+}
+
+/** The resize context menu opened or closed. Hold the grid's height at
+ *  its open-time value for the whole session so any preview (including a
+ *  smaller one) can't shorten the page and jump the scroll out from
+ *  under the open menu. Released on close, which also reverts any
+ *  uncommitted preview. */
+function onSizeMenuToggle(open: boolean) {
+  if (open) {
+    reservedMinHeight.value = gridEl.value?.offsetHeight ?? null
+  } else {
+    reservedMinHeight.value = null
+    resizePreview.value = null
   }
 }
 
@@ -749,7 +770,10 @@ const underlayCellCount = computed(() => {
       store.editMode && 'select-none',
       dragState.isDragging && 'cursor-grabbing',
     ]"
-    :style="{ '--dash-row-unit': '8.5rem' }"
+    :style="{
+      '--dash-row-unit': '8.5rem',
+      minHeight: reservedMinHeight !== null ? `${reservedMinHeight}px` : undefined,
+    }"
   >
     <!-- Lattice underlay: faint cell outlines while a drag or resize
          gesture is live, so the snapping is legible. Absolutely
@@ -799,6 +823,7 @@ const underlayCellCount = computed(() => {
       @resize="(span) => commitSpan(entry, span)"
       @resize-row="(rowSpan) => commitRowSpan(entry, rowSpan)"
       @preview-resize="(intent) => onPreviewResize(entry, intent)"
+      @size-menu-toggle="(open) => onSizeMenuToggle(open)"
       @move="(dir) => moveWidget(originalIndex, dir)"
       @handle-pointerdown="(e) => onWidgetHandlePointerDown(originalIndex, e)"
       @resize-pointerdown="(e, axis) => onResizePointerDown(originalIndex, e, axis)"

--- a/frontend/src/views/dashboard/DashboardWidgetShell.vue
+++ b/frontend/src/views/dashboard/DashboardWidgetShell.vue
@@ -276,6 +276,7 @@ function onContextMenu(e: MouseEvent) {
   menuX.value = e.clientX
   menuY.value = e.clientY
   menuOpen.value = true
+  ctx?.onSizeMenuToggle(true)
 }
 
 /** Map a size menu id to its preview intent; null for other items. */
@@ -311,6 +312,7 @@ function onMenuUnhighlight(id: string) {
 function onMenuClose() {
   menuOpen.value = false
   ctx?.onPreviewResize(null)
+  ctx?.onSizeMenuToggle(false)
 }
 
 /** Keyboard model on the focused card (edit mode only, and only

--- a/frontend/src/views/dashboard/WidgetFrame.vue
+++ b/frontend/src/views/dashboard/WidgetFrame.vue
@@ -90,6 +90,7 @@ const emit = defineEmits<{
   (e: 'resize', span: WidgetSpan): void
   (e: 'resize-row', rowSpan: WidgetSpan): void
   (e: 'preview-resize', intent: ResizePreviewIntent | null): void
+  (e: 'size-menu-toggle', open: boolean): void
   (e: 'move', dir: MoveDirection): void
   (e: 'handle-pointerdown', ev: PointerEvent): void
   /** A resize handle was pressed. The grid owns the gesture (it has
@@ -110,6 +111,7 @@ const context: DashboardWidgetContext = {
   onResize: (span) => emit('resize', span),
   onResizeRow: (rowSpan) => emit('resize-row', rowSpan),
   onPreviewResize: (intent) => emit('preview-resize', intent),
+  onSizeMenuToggle: (open) => emit('size-menu-toggle', open),
   onMove: (dir) => emit('move', dir),
   onHide: () => emit('hide'),
   onHandlePointerDown: (e) => emit('handle-pointerdown', e),

--- a/frontend/src/views/dashboard/WidgetPreview.vue
+++ b/frontend/src/views/dashboard/WidgetPreview.vue
@@ -1,0 +1,133 @@
+<!--
+Static thumbnail for the add-widget picker: a small, themed SVG that
+mirrors the *layout* of a widget (a big metric + delta + sparkline, a
+metric rail, the net-flow area, labelled bars, a contribution heatmap,
+ticket rows, status rows) without rendering the real component or
+fetching data. Illustrative only — `aria-hidden`; the picker cell
+carries the accessible title. The numbers are placeholder decoration.
+-->
+<script setup lang="ts">
+import type { WidgetPreviewKind } from './widgets'
+
+defineProps<{ kind: WidgetPreviewKind }>()
+
+// Deterministic per-cell heatmap intensities (no Math.random so the
+// thumbnail is stable across renders).
+const HEAT: number[] = Array.from({ length: 7 * 16 }, (_, i) => {
+  const v = ((i * 37) % 11) / 10 // 0..1 pseudo-spread
+  return 0.12 + v * 0.7
+})
+</script>
+
+<template>
+  <svg
+    viewBox="0 0 120 68"
+    class="h-full w-full"
+    preserveAspectRatio="xMidYMid meet"
+    aria-hidden="true"
+    font-family="inherit"
+  >
+    <!-- KPI tile: label, big number, delta chip, sparkline. -->
+    <template v-if="kind === 'kpi'">
+      <rect x="12" y="10" width="30" height="4" rx="2" class="text-tertiary" fill="currentColor" opacity="0.5" />
+      <text x="12" y="40" font-size="24" font-weight="700" class="text-primary" fill="currentColor">128</text>
+      <text x="60" y="24" font-size="9" font-weight="600" class="text-status-success" fill="currentColor">▲ 8%</text>
+      <path
+        d="M12,60 L28,53 L44,56 L60,47 L76,51 L92,44 L108,49 L108,62 L12,62 Z"
+        class="text-accent"
+        fill="currentColor"
+        opacity="0.16"
+      />
+      <polyline
+        points="12,60 28,53 44,56 60,47 76,51 92,44 108,49"
+        fill="none"
+        class="text-accent"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </template>
+
+    <!-- Metric rail: divided columns, each a number + sparkline + label. -->
+    <template v-else-if="kind === 'kpi-rail'">
+      <line x1="42" y1="10" x2="42" y2="58" class="text-default" stroke="currentColor" stroke-width="1" opacity="0.3" />
+      <line x1="80" y1="10" x2="80" y2="58" class="text-default" stroke="currentColor" stroke-width="1" opacity="0.3" />
+      <g v-for="(col, i) in [{ x: 10, n: '42' }, { x: 48, n: '37' }, { x: 86, n: '12' }]" :key="i">
+        <text :x="col.x" y="28" font-size="15" font-weight="700" class="text-primary" fill="currentColor">{{ col.n }}</text>
+        <polyline
+          :points="`${col.x},46 ${col.x + 8},41 ${col.x + 16},44 ${col.x + 24},36`"
+          fill="none"
+          :class="i === 1 ? 'text-status-success' : 'text-accent'"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <rect :x="col.x" y="52" width="22" height="4" rx="2" class="text-tertiary" fill="currentColor" opacity="0.5" />
+      </g>
+    </template>
+
+    <!-- Net-flow: diverging area around a centre axis. -->
+    <template v-else-if="kind === 'area'">
+      <line x1="8" y1="36" x2="112" y2="36" class="text-default" stroke="currentColor" stroke-width="1" opacity="0.5" />
+      <path d="M8,36 C22,18 34,15 50,26 C58,31 66,34 72,36 L8,36 Z" class="text-accent" fill="currentColor" opacity="0.22" />
+      <path d="M72,36 C84,45 92,51 104,48 C108,47 110,46 112,46 L112,36 Z" class="text-status-success" fill="currentColor" opacity="0.22" />
+      <path
+        d="M8,36 C22,18 34,15 50,26 C58,31 66,34 72,36 C84,45 92,51 104,48 C108,47 110,46 112,46"
+        fill="none"
+        class="text-secondary"
+        stroke="currentColor"
+        stroke-width="1.75"
+        opacity="0.75"
+      />
+    </template>
+
+    <!-- Horizontal bars: label · track+fill · value. -->
+    <template v-else-if="kind === 'bars'">
+      <g v-for="(row, i) in [{ w: 58, o: 0.85 }, { w: 42, o: 0.6 }, { w: 30, o: 0.45 }, { w: 18, o: 0.35 }]" :key="i">
+        <rect x="8" :y="14 + i * 12" width="20" height="6" rx="2" class="text-secondary" fill="currentColor" opacity="0.4" />
+        <rect x="34" :y="14 + i * 12" width="62" height="6" rx="3" class="text-default" fill="currentColor" opacity="0.18" />
+        <rect x="34" :y="14 + i * 12" :width="row.w" height="6" rx="3" class="text-accent" fill="currentColor" :opacity="row.o" />
+        <rect x="100" :y="14 + i * 12" width="12" height="6" rx="2" class="text-tertiary" fill="currentColor" opacity="0.4" />
+      </g>
+    </template>
+
+    <!-- Contribution heatmap: 7 day rows × 16 week columns. -->
+    <template v-else-if="kind === 'heatmap'">
+      <template v-for="r in 7" :key="r">
+        <rect
+          v-for="c in 16"
+          :key="c"
+          :x="10 + (c - 1) * 6.6"
+          :y="8 + (r - 1) * 7.4"
+          width="5.2"
+          height="5.2"
+          rx="1.2"
+          class="text-accent"
+          fill="currentColor"
+          :opacity="HEAT[(r - 1) * 16 + (c - 1)]"
+        />
+      </template>
+    </template>
+
+    <!-- Ticket rows: priority marker, title line, meta line, status pill. -->
+    <template v-else-if="kind === 'list'">
+      <g v-for="(row, i) in [{ y: 11, p: 'text-status-error' }, { y: 31, p: 'text-accent' }, { y: 51, p: 'text-tertiary' }]" :key="i">
+        <rect x="8" :y="row.y" width="3" height="13" rx="1.5" :class="row.p" fill="currentColor" opacity="0.9" />
+        <rect x="18" :y="row.y" width="66" height="5" rx="2.5" class="text-secondary" fill="currentColor" opacity="0.45" />
+        <rect x="18" :y="row.y + 8" width="42" height="4" rx="2" class="text-tertiary" fill="currentColor" opacity="0.45" />
+        <rect x="96" :y="row.y + 1" width="16" height="7" rx="3.5" class="text-default" fill="currentColor" opacity="0.22" />
+      </g>
+    </template>
+
+    <!-- Status rows: coloured health dot, name line, meta line. -->
+    <template v-else-if="kind === 'status'">
+      <g v-for="(row, i) in [{ y: 11, s: 'text-status-success' }, { y: 31, s: 'text-status-error' }, { y: 51, s: 'text-tertiary' }]" :key="i">
+        <circle cx="13" :cy="row.y + 5" r="3.5" :class="row.s" fill="currentColor" />
+        <rect x="24" :y="row.y" width="58" height="5" rx="2.5" class="text-secondary" fill="currentColor" opacity="0.45" />
+        <rect x="24" :y="row.y + 8" width="40" height="4" rx="2" class="text-tertiary" fill="currentColor" opacity="0.45" />
+      </g>
+    </template>
+  </svg>
+</template>

--- a/frontend/src/views/dashboard/widgetContext.ts
+++ b/frontend/src/views/dashboard/widgetContext.ts
@@ -37,6 +37,10 @@ export interface DashboardWidgetContext {
    *  store; the grid re-packs around the previewed footprint until
    *  cleared with `null`. */
   onPreviewResize: (intent: ResizePreviewIntent | null) => void
+  /** The resize context menu opened (`true`) or closed (`false`). Lets
+   *  the grid freeze its height for the menu session so a preview can't
+   *  jump the scroll. */
+  onSizeMenuToggle: (open: boolean) => void
   /** Keyboard repositioning of the focused widget. */
   onMove: (dir: MoveDirection) => void
   onHide: () => void

--- a/frontend/src/views/dashboard/widgets.ts
+++ b/frontend/src/views/dashboard/widgets.ts
@@ -46,6 +46,52 @@ export function savedViewWidgetId(uuid: string): string {
   return `${SAVED_VIEW_WIDGET_PREFIX}${uuid}`
 }
 
+/** Preview illustration kind for the add-widget picker. Each maps to a
+ *  small themed thumbnail in `WidgetPreview.vue` — an abstract read of
+ *  the widget's shape, not a live render. */
+export type WidgetPreviewKind = 'kpi' | 'kpi-rail' | 'area' | 'bars' | 'heatmap' | 'list' | 'status'
+
+const PREVIEW_BY_ID: Record<string, WidgetPreviewKind> = {
+  'assigned-tickets': 'list',
+  'requested-tickets': 'list',
+  'ticket-volume': 'kpi-rail',
+  'tickets-created': 'kpi',
+  'tickets-resolved': 'kpi',
+  'tickets-open': 'kpi',
+  'tickets-over-time': 'area',
+  'volume-by-category': 'bars',
+  'volume-by-priority': 'bars',
+  'unassigned-queue': 'list',
+  'recently-viewed': 'list',
+  'starred-docs': 'list',
+  'my-devices': 'list',
+  'channel-health': 'status',
+  'activity-heatmap': 'heatmap',
+  'knowledge-gaps': 'list',
+  'sla-health': 'kpi-rail',
+}
+
+/** Preview kind for a registry widget id (falls back to a list shape). */
+export function widgetPreviewKind(id: string): WidgetPreviewKind {
+  return PREVIEW_BY_ID[id] ?? 'list'
+}
+
+/** Preview kind for a saved view's `viz_type`. */
+export function savedViewPreviewKind(vizType: string | undefined): WidgetPreviewKind {
+  switch (vizType) {
+    case 'kpi_tile':
+      return 'kpi'
+    case 'line':
+      return 'area'
+    case 'horizontal_bar':
+      return 'bars'
+    case 'heatmap':
+      return 'heatmap'
+    default:
+      return 'list'
+  }
+}
+
 function savedViewUuidFromId(id: string): string {
   return id.slice(SAVED_VIEW_WIDGET_PREFIX.length)
 }


### PR DESCRIPTION
## Dashboard: add-widget preview grid + resize-preview scroll fix

Two independent dashboard changes (one commit each).

### Preview thumbnails in the add-widget picker
The picker was a plain text list (title + description). It's now a grid of cards, each with a small themed **thumbnail of the widget's shape**, so it's clear what you're adding before you add it.

- `WidgetPreview.vue` renders a static SVG per shape — `kpi` (big number + delta + sparkline), `kpi-rail`, `area` (the net-flow diverging shape), `bars` (label · track+fill · value), `heatmap` (7 days × weeks), `list` (priority marker + rows), `status` (health dots). No real component render, no data fetching — purely illustrative and `aria-hidden`.
- `widgets.ts` maps each registry id to a preview kind (`widgetPreviewKind`), plus `savedViewPreviewKind(viz_type)` for the saved-views tab. Studying the real components corrected two mappings: SLA health is a 4-metric rail (not a gauge), and channel health uses the dedicated status-dot shape.
- `AddWidgetModal` switches both tabs to a 2/3-column grid and grows to `size="lg"`.

### Fix: resize preview no longer jumps the scroll
Hovering a widget's Width/Height context-menu options re-packs the grid live to preview the new size (intentional). But previewing a **smaller** size shortened the page, and for a widget near the bottom the scroll container clamped upward — yanking the open menu out from under the cursor.

Fix: hold the grid's height at its value **when the menu opens**, for the whole menu session, via a new `onSizeMenuToggle(open)` context signal (shell → WidgetFrame → grid). A preview can grow the page (the widget's top is anchored, so nothing above moves) but never shrink it; the floor releases on close/commit. Tied to the menu open/close rather than per-hover, because the menu clears its preview on every option-leave — which reset the earlier per-hover attempt.

### Verification
Frontend `type-check` + `eslint` clean.
