### PR TITLE
fix(security): edition/environment hardening from the self-host vs hosted audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,10 @@ jobs:
           GREENMAIL_HOST: 127.0.0.1
           # Greenmail's IMAPS cert is self-signed. The channel's
           # insecure_skip_cert_verify flag is honoured automatically here
-          # because this job runs as non-production (ENVIRONMENT unset); the
-          # IMAP connector only ignores the flag when ENVIRONMENT=production.
+          # because cargo runs as development (backend/.cargo/config.toml sets
+          # ENVIRONMENT=development); the IMAP connector honours the flag only
+          # outside production (fail-closed: an unset ENVIRONMENT now assumes
+          # production, which is why cargo declares development explicitly).
         # --test-threads=1: both tests share the single `support`
         # mailbox and purge it on entry, so they must run serially.
         run: cargo test --test channels_email_imap_integration -- --ignored --test-threads=1

--- a/backend/.cargo/config.toml
+++ b/backend/.cargo/config.toml
@@ -32,6 +32,15 @@
 incremental = false
 
 [env]
+# Host/CI cargo invocations (`cargo test`, `cargo run`) declare themselves as
+# development so the fail-closed security posture (an unset ENVIRONMENT now
+# ASSUMES production — see config_utils::assume_production) doesn't trip the
+# test suite: login lockout / MFA rate-limit fail *open* on a Redis error,
+# IMAP/LDAP self-signed cert-skip is honoured (the Greenmail integration test
+# depends on this), and the boot secret gates stay lenient. Real production
+# runs the compiled binary without cargo, so it never reads this file and sets
+# ENVIRONMENT itself. A parent-shell ENVIRONMENT export takes precedence.
+ENVIRONMENT = "development"
 TEST_DATABASE_URL = "postgres://nosdesk:nosdesk_password@127.0.0.1:54329/nosdesk_test"
 # Redis for redis-backed integration tests (the collab ownership-claim
 # suite). Published on host loopback by compose.dev.yaml's redis

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -21,7 +21,9 @@ type EnvGet<'a> = &'a dyn Fn(&str) -> Option<String>;
 pub struct Config {
     /// Raw `ENVIRONMENT` value ("development" by default).
     pub environment: String,
-    /// `environment == "production"`, precomputed for the many call sites.
+    /// Whether to apply hardened production posture, precomputed for the boot
+    /// gates. Fail-closed (`config_utils::assume_production_from`): true unless
+    /// `ENVIRONMENT` is an explicit `development` / `dev` label.
     pub is_production: bool,
     pub host: String,
     pub port: u16,
@@ -82,7 +84,14 @@ impl Config {
     /// Never constructs global state.
     pub fn from_source(get: EnvGet, plugin_root_present: bool) -> Result<Config, std::io::Error> {
         let environment = get("ENVIRONMENT").unwrap_or_else(|| "development".to_string());
-        let is_production = environment == "production";
+        // Fail-closed: an unset / empty / non-canonical `ENVIRONMENT` (a prod
+        // deploy that forgot it, or `staging` / `prod` / `Production`) must still
+        // enforce the hardened secret gates below, matching how CSP/HSTS/cookies
+        // use `assume_production`. Only an explicit `development` / `dev` label
+        // opts out. Read the RAW getter here, not `environment` above, which has
+        // already defaulted an unset value to `development`.
+        let is_production =
+            crate::config_utils::assume_production_from(get("ENVIRONMENT").as_deref());
         info!("Environment: {}", environment);
 
         validate_jwt_secret(get, is_production)?;
@@ -298,10 +307,16 @@ mod tests {
     /// an explicit plugin-root-present flag. `plugin_root=true` keeps the
     /// plugin-root check from short-circuiting the production-only cases below.
     fn build(pairs: &[(&str, &str)], plugin_root: bool) -> Result<Config, std::io::Error> {
-        let map: HashMap<String, String> = pairs
+        let mut map: HashMap<String, String> = pairs
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
+        // Parsing-focused tests default to an explicit dev label so they don't
+        // trip the fail-closed production gates (an unset ENVIRONMENT now assumes
+        // production — see `unset_environment_assumes_production`). Tests that
+        // assert production pass `ENVIRONMENT=production`, which overrides this.
+        map.entry("ENVIRONMENT".to_string())
+            .or_insert_with(|| "development".to_string());
         let get = |k: &str| map.get(k).cloned();
         Config::from_source(&get, plugin_root)
     }
@@ -323,6 +338,19 @@ mod tests {
     fn jwt_missing_is_fatal() {
         let err = build(&[], true).unwrap_err();
         assert_eq!(err.to_string(), "JWT_SECRET must be set");
+    }
+
+    #[test]
+    fn unset_environment_assumes_production() {
+        // Fail-closed: with ENVIRONMENT absent entirely (bypassing the test
+        // helper's dev default), the hardened gates must fire rather than
+        // defaulting to permissive dev behaviour. A too-short JWT is rejected.
+        let get = |k: &str| match k {
+            "JWT_SECRET" => Some("short".to_string()),
+            _ => None,
+        };
+        let err = Config::from_source(&get, true).unwrap_err();
+        assert_eq!(err.to_string(), "JWT_SECRET is too short");
     }
 
     #[test]

--- a/backend/src/config_utils.rs
+++ b/backend/src/config_utils.rs
@@ -47,12 +47,22 @@ pub fn is_production() -> bool {
 /// than the permissive dev defaults. Set `ENVIRONMENT=development` (or `dev`)
 /// for intentional plaintext-HTTP local setups.
 pub fn assume_production() -> bool {
-    match env::var("ENVIRONMENT") {
-        Ok(v) => {
+    assume_production_from(env::var("ENVIRONMENT").ok().as_deref())
+}
+
+/// Pure, injectable form of [`assume_production`] for callers that read
+/// `ENVIRONMENT` through their own getter (e.g. `Config::from_source`, which is
+/// unit-tested with a mock env). Same fail-closed rule: production unless an
+/// explicit `development` / `dev` label. `None` (unset), empty, and unrecognised
+/// values all assume production. This is the single source of truth for
+/// "apply hardened security posture" — do not re-derive it inline.
+pub fn assume_production_from(value: Option<&str>) -> bool {
+    match value {
+        Some(v) => {
             let v = v.trim().to_ascii_lowercase();
             v.is_empty() || !(v == "development" || v == "dev")
         }
-        Err(_) => true,
+        None => true,
     }
 }
 

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -602,10 +602,9 @@ pub async fn login(
     let client_ip = crate::utils::client_ip::from_http_request(&request);
     let lockout_key = RateLimiter::login_attempt_key(&login_data.email, client_ip);
 
-    // Check if account is locked before any validation
-    let is_production = std::env::var("ENVIRONMENT")
-        .map(|v| v.to_lowercase() == "production")
-        .unwrap_or(false);
+    // Check if account is locked before any validation. Fail-closed detection:
+    // an unset/non-canonical ENVIRONMENT still denies on a Redis error below.
+    let is_production = crate::config_utils::assume_production();
 
     match RateLimiter::check_lockout(&redis_url, &lockout_key, MAX_LOGIN_ATTEMPTS).await {
         Ok(Some(remaining_seconds)) => {
@@ -859,9 +858,7 @@ pub async fn recovery_login(
         Ok(None) => {} // Not locked, continue
         Err(e) => {
             error!(error = %e, "Redis error checking account lockout for recovery login");
-            let is_production = std::env::var("ENVIRONMENT")
-                .map(|v| v.to_lowercase() == "production")
-                .unwrap_or(false);
+            let is_production = crate::config_utils::assume_production();
             if is_production {
                 return errors::service_unavailable(
                     "Authentication service temporarily unavailable. Please try again.",

--- a/backend/src/handlers/auth_providers.rs
+++ b/backend/src/handlers/auth_providers.rs
@@ -842,13 +842,20 @@ pub async fn oauth_callback(
                         }
                     }
                 } else {
-                    // Regular login/signup flow
+                    // Regular login/signup flow. `email_verified` is load-bearing:
+                    // `oauth_email_verified` reads it to decide whether an
+                    // email-matched account may be linked; omitting it made the
+                    // gate always read `false`, so a precreated user logging in via
+                    // OIDC for the first time never linked and a duplicate user was
+                    // minted (self-host) / seat recovery was dead (hosted). Mirror
+                    // the native path.
                     let oidc_user_info = serde_json::json!({
                         "id": user_info.sub,
                         "mail": user_info.email,
                         "displayName": user_info.name.clone().or_else(|| user_info.preferred_username.clone()),
                         "givenName": user_info.given_name,
                         "surname": user_info.family_name,
+                        "email_verified": user_info.email_verified,
                     });
 
                     let user = match resolve_login_user(

--- a/backend/src/handlers/channels.rs
+++ b/backend/src/handlers/channels.rs
@@ -206,7 +206,7 @@ fn validate_config(provider: &str, config: &JsonValue) -> Result<(), String> {
             // Skipping TLS verification is development-only. Refuse to store it
             // on a production deployment so it can't be enabled there at all
             // (the IMAP connector also hard-ignores it in production).
-            if cfg.insecure_skip_cert_verify && crate::config_utils::is_production() {
+            if cfg.insecure_skip_cert_verify && crate::config_utils::assume_production() {
                 return Err(
                     "Skip TLS certificate verification is only available in development"
                         .to_string(),

--- a/backend/src/handlers/collaboration.rs
+++ b/backend/src/handlers/collaboration.rs
@@ -2575,9 +2575,9 @@ pub async fn ws_handler(
     // hostname). This widens nothing security-wise: the allowlist
     // can't trust an origin that isn't already trusted for credentialed
     // HTTP.
-    let is_production = std::env::var("ENVIRONMENT")
-        .map(|v| v.to_lowercase() == "production")
-        .unwrap_or(false);
+    // Fail-closed detection: an unset/non-canonical ENVIRONMENT enforces the
+    // stricter production origin rules (allowlist required, Origin required).
+    let is_production = crate::config_utils::assume_production();
 
     match req.headers().get("Origin") {
         Some(origin) => {

--- a/backend/src/middleware/api_token.rs
+++ b/backend/src/middleware/api_token.rs
@@ -255,9 +255,9 @@ pub(crate) async fn authenticate<B: MessageBody>(
                 })?;
 
             // Scope guard (MANDATORY): only genuine agent sessions carry scope
-            // "full". SSE ("sse") / portal ("portal") tokens could over-authorize
-            // if replayed as a bearer; the cookie never carries them, so this
-            // guard is bearer-only.
+            // "full". Connection tokens ("sse" / "collab" / "portal") could
+            // over-authorize if replayed as a bearer OR replanted as the access
+            // cookie, so the same guard runs on the cookie path below.
             if claims.scope != "full" {
                 warn!(path = %req.path(), scope = %claims.scope, "Rejected non-session JWT on bearer path");
                 return Err(bearer_unauthorized(true, "Token not valid for this API"));
@@ -287,6 +287,16 @@ pub(crate) async fn authenticate<B: MessageBody>(
             error!(error = ?err, "Cookie auth: token validation failed");
             bearer_unauthorized(true, "Invalid or expired token")
         })?;
+
+    // Full-scope guard, mirroring the bearer path. Connection tokens
+    // (sse/collab/portal) ride in query strings, so they leak into logs /
+    // history / Referer; a leaked one must not be replantable as the access
+    // cookie to reach Any-scoped or file routes. A legitimate access cookie is
+    // always minted with scope "full".
+    if claims.scope != "full" {
+        warn!(path = %req.path(), scope = %claims.scope, "Rejected non-session JWT on cookie path");
+        return Err(bearer_unauthorized(true, "Token not valid for this API"));
+    }
 
     info!(user = %claims.sub, "Auth: user authenticated successfully");
 

--- a/backend/src/services/channels/email_imap.rs
+++ b/backend/src/services/channels/email_imap.rs
@@ -378,7 +378,7 @@ async fn open_session(
     // can never silently disable TLS validation (an MITM vector for mailbox
     // credentials). The save path also refuses to store it in production.
     let cert_verify_disabled =
-        config.insecure_skip_cert_verify && !crate::config_utils::is_production();
+        config.insecure_skip_cert_verify && !crate::config_utils::assume_production();
     if config.insecure_skip_cert_verify && !cert_verify_disabled {
         tracing::warn!(
             host = %config.host,

--- a/backend/src/services/ldap/connector.rs
+++ b/backend/src/services/ldap/connector.rs
@@ -82,7 +82,7 @@ pub async fn connect(settings: &WorkspaceLdapSettings) -> Result<Ldap, LdapConne
 
     // The cert-verify bypass is for internal self-signed CAs and is FORCED OFF
     // in production, mirroring the IMAP channel gate; prefer a supplied CA cert.
-    let skip_verify = !settings.verify_certs && !crate::config_utils::is_production();
+    let skip_verify = !settings.verify_certs && !crate::config_utils::assume_production();
     if !settings.verify_certs && !skip_verify {
         warn!(
             host,

--- a/backend/src/utils/mfa.rs
+++ b/backend/src/utils/mfa.rs
@@ -793,10 +793,9 @@ pub async fn check_mfa_rate_limit(user_uuid: &Uuid) -> bool {
         }
         Err(e) => {
             tracing::error!("MFA rate limit check failed for user {}: {}", user_uuid, e);
-            // Fail-closed in production (security-critical), fail-open in development (convenience)
-            let is_production = std::env::var("ENVIRONMENT")
-                .map(|v| v.to_lowercase() == "production")
-                .unwrap_or(false);
+            // Fail-closed in production (security-critical), fail-open in development (convenience).
+            // Fail-closed detection: an unset/non-canonical ENVIRONMENT denies.
+            let is_production = crate::config_utils::assume_production();
             if is_production {
                 tracing::warn!(
                     "Denying MFA attempt due to rate limit check failure (fail-closed mode)"

--- a/backend/src/utils/webauthn.rs
+++ b/backend/src/utils/webauthn.rs
@@ -34,11 +34,11 @@ impl WebAuthnConfig {
     /// In production, all WEBAUTHN_* variables are required.
     /// In development, defaults to localhost values.
     pub fn from_env() -> Result<Self> {
-        let environment = env::var("ENVIRONMENT")
-            .unwrap_or_else(|_| "development".to_string())
-            .to_lowercase();
-
-        let is_production = environment == "production";
+        // Fail-closed: an unset / non-canonical ENVIRONMENT requires explicit
+        // WEBAUTHN_RP_ID / WEBAUTHN_RP_ORIGIN rather than defaulting to the
+        // insecure localhost values (matches config_utils::assume_production,
+        // the single source of truth for hardened posture).
+        let is_production = crate::config_utils::assume_production();
 
         // In production, require explicit configuration
         let rp_id = match env::var("WEBAUTHN_RP_ID") {
@@ -94,10 +94,10 @@ impl WebAuthnConfig {
         }
 
         tracing::info!(
-            "WebAuthn configured: rp_id={}, rp_origin={}, environment={}",
+            "WebAuthn configured: rp_id={}, rp_origin={}, production={}",
             rp_id,
             rp_origin,
-            environment
+            is_production
         );
 
         Ok(Self {
@@ -130,16 +130,26 @@ impl WebAuthnConfig {
 // env-configured RP (`WEBAUTHN_RP_ID` / `WEBAUTHN_RP_ORIGIN`). Building per
 // request is cheap.
 
-/// Build the WebAuthn verifier for the current request. RP ID is the request's
-/// (validated) workspace host in hosted mode, or the env config in self-hosted
-/// mode. Returns an owned `Webauthn`; cheap to construct per call. Errors
-/// surface per request (not as a startup panic), so a hosted deploy needs no
-/// `WEBAUTHN_RP_*` env at all.
+/// Build the WebAuthn verifier for the current request. In **hosted** mode the
+/// RP ID/origin is the request's (validated) per-workspace host, so passkeys are
+/// scoped per host / custom domain. In **self-hosted** mode it is the env config
+/// (`WEBAUTHN_RP_ID` / `WEBAUTHN_RP_ORIGIN`). Returns an owned `Webauthn`; cheap
+/// to construct per call. Errors surface per request (not a startup panic), so a
+/// hosted deploy needs no `WEBAUTHN_RP_*` env at all.
+///
+/// The mode gate is essential: self-hosted requests **always** carry the
+/// bootstrap `WorkspaceContext`, so gating on that alone would force the per-host
+/// branch for every self-host deploy — deriving `https://{Host}` and thereby
+/// ignoring `WEBAUTHN_RP_*` and breaking passkeys over plain HTTP / localhost /
+/// behind a reverse proxy that rewrites Host.
 pub fn webauthn_for_request(req: &actix_web::HttpRequest) -> Result<Webauthn> {
-    match request_workspace_host(req) {
-        Some(host) => build_webauthn_for_host(&host),
-        None => WebAuthnConfig::from_env()?.build_webauthn(),
+    use crate::middleware::workspace_context::DeploymentMode;
+    if DeploymentMode::current() == DeploymentMode::Hosted {
+        if let Some(host) = request_workspace_host(req) {
+            return build_webauthn_for_host(&host);
+        }
     }
+    WebAuthnConfig::from_env()?.build_webauthn()
 }
 
 /// The host this request is actually served on (= the WebAuthn RP ID), when it


### PR DESCRIPTION
## Edition/environment hardening — self-host vs hosted audit fixes

From a read-only audit of the v1.1 feature set across self-hosted (Community, single-tenant) and hosted (Enterprise, multi-tenant). The load-bearing tenancy work (Model C membership gate on every path, RLS pinning, email transport selection, isolation) was confirmed correct on both sides; these four are the material correctness/hardening gaps found — verified in source before fixing.

### #1 — WebAuthn self-host RP was derived from the `Host` header (HIGH)
`webauthn_for_request` took the per-host branch whenever a `WorkspaceContext` existed — but self-host injects the bootstrap context on *every* request, so it always forced `https://{Host}`, ignoring `WEBAUTHN_RP_*` and **breaking passkeys over HTTP / localhost / behind a proxy**. Now gated on `DeploymentMode::Hosted`; self-host uses `WebAuthnConfig::from_env`. Fixed the docstring that had drifted from the code.

### #2 — OIDC web-login dropped `email_verified` (HIGH)
The rebuilt user JSON omitted the field, so the account-link gate always read `false`: a precreated user's first OIDC login minted a **duplicate user** (self-host) / seat recovery was dead (hosted). Now carried through, matching the native path. *(Follow-up worth doing: unify the web/native OIDC user-info builders so they can't drift again.)*

### #3 — Split production-detection; security gates failed *open* (HIGH)
CSP/HSTS/cookies already used fail-closed `assume_production`, but boot secret validation, login lockout, MFA rate-limit, IMAP/LDAP cert-skip, and the collab origin check used fail-*open* checks — so a prod deploy that forgot `ENVIRONMENT` (or set `prod`/`Production`) **hardened headers but booted with a placeholder JWT / default DB password and brute-forceable login**. Consolidated onto one fail-closed predicate (`assume_production` + a pure `assume_production_from` for `Config::from_source`); deleted the inline re-derivations. Host/CI cargo declares `ENVIRONMENT=development` (`backend/.cargo/config.toml`) so the suite stays lenient while real deploys fail closed; added a test pinning the unset→production contract.

### #4 — Cookie auth branch lacked the full-scope guard (MEDIUM)
The bearer path enforces `scope == "full"`; the cookie path didn't, on the assumption that "the cookie never carries connection tokens." A leaked `sse`/`collab` token (they ride in query strings → logs/history) replayed as the access cookie reached `Any`/file routes. Now enforced on both JWT entry points (kept out of the shared tail, which is also the `nsk_` API-token path).

### Verification
`cargo check --tests` clean; full lib suite green (1636 passed), including a new `unset_environment_assumes_production` test. Remaining audit findings (#5–#10 + lows) are captured in `docs/v1.1-edition-audit.md` for triage.
