### PR TITLE
Notifications: Android FCM push (plugin + Firebase wiring)

### DIFF
--- a/mobile/src-tauri/gen/android/app/build.gradle.kts
+++ b/mobile/src-tauri/gen/android/app/build.gradle.kts
@@ -70,3 +70,7 @@ dependencies {
 }
 
 apply(from = "tauri.build.gradle.kts")
+
+// FCM: reads app/google-services.json. Applied last so it sees the android
+// config above. Requires google-services.json in this module (gen/android/app/).
+apply(plugin = "com.google.gms.google-services")

--- a/mobile/src-tauri/gen/android/build.gradle.kts
+++ b/mobile/src-tauri/gen/android/build.gradle.kts
@@ -6,6 +6,8 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.11.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25")
+        // FCM: processes app/google-services.json into the build.
+        classpath("com.google.gms:google-services:4.4.2")
     }
 }
 

--- a/mobile/tauri-plugin-push/android/build.gradle.kts
+++ b/mobile/tauri-plugin-push/android/build.gradle.kts
@@ -41,8 +41,8 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     implementation(project(":tauri-android"))
-    // NOTE: FCM (firebase-messaging) is intentionally NOT added yet — it would
-    // require google-services.json to build. The Android token path is a stub
-    // until FCM is provisioned; add `com.google.firebase:firebase-messaging` +
-    // the google-services Gradle plugin then.
+    // Firebase Cloud Messaging. The BoM pins compatible versions; the app module
+    // applies the google-services plugin (needs google-services.json).
+    implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
+    implementation("com.google.firebase:firebase-messaging")
 }

--- a/mobile/tauri-plugin-push/android/src/main/AndroidManifest.xml
+++ b/mobile/tauri-plugin-push/android/src/main/AndroidManifest.xml
@@ -1,3 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <!-- FCM service (foreground display; background is auto-handled). -->
+        <service
+            android:name="com.nosdesk.plugin.push.PushMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <!-- Channel a backgrounded FCM notification auto-posts to. -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="nosdesk_notifications" />
+    </application>
 </manifest>

--- a/mobile/tauri-plugin-push/android/src/main/java/PendingNotification.kt
+++ b/mobile/tauri-plugin-push/android/src/main/java/PendingNotification.kt
@@ -1,0 +1,45 @@
+package com.nosdesk.plugin.push
+
+import android.content.Intent
+
+/** The context-only fields FCM delivers in a tapped notification's `data`. */
+data class TappedNotification(
+    val ndType: String?,
+    val entityType: String?,
+    val entityId: Int?,
+    val ticketId: Int?,
+)
+
+/**
+ * Buffers the last tapped notification for the JS layer to drain via
+ * `get_pending_notification` — the single source of truth for deep-linking,
+ * mirroring the iOS side. Populated from the launch intent (cold-start tap) and
+ * `onNewIntent` (warm tap); FCM puts the message's `data` payload into the
+ * intent extras as strings when the user taps a notification.
+ */
+object PendingNotification {
+    @Volatile
+    private var pending: TappedNotification? = null
+
+    fun capture(intent: Intent?) {
+        val extras = intent?.extras ?: return
+        val ndType = extras.getString("nd_type")
+        val entityType = extras.getString("entity_type")
+        val ticketId = extras.getString("ticket_id")
+        // Only our FCM notifications carry these keys; ignore other intents.
+        if (ndType == null && entityType == null && ticketId == null) return
+        pending = TappedNotification(
+            ndType = ndType,
+            entityType = entityType,
+            entityId = extras.getString("entity_id")?.toIntOrNull(),
+            ticketId = ticketId?.toIntOrNull(),
+        )
+    }
+
+    /** Read-and-clear: whichever trigger drains first wins, the rest are no-ops. */
+    fun take(): TappedNotification? {
+        val current = pending
+        pending = null
+        return current
+    }
+}

--- a/mobile/tauri-plugin-push/android/src/main/java/PushMessagingService.kt
+++ b/mobile/tauri-plugin-push/android/src/main/java/PushMessagingService.kt
@@ -1,0 +1,48 @@
+package com.nosdesk.plugin.push
+
+import android.app.PendingIntent
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+/**
+ * FCM service. A BACKGROUNDED message auto-displays (the backend sends a
+ * `notification` block) and Firebase handles it; this service only covers the
+ * FOREGROUND case (Firebase doesn't auto-display then) by building the same
+ * notification, wiring its tap to re-open the app with the `data` extras so
+ * deep-linking still works. Token refresh is a no-op — the app re-reads the
+ * token via `get_token` on each login/launch.
+ */
+class PushMessagingService : FirebaseMessagingService() {
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        PushPlugin.createDefaultChannel(this)
+        val title = message.notification?.title ?: return
+        val body = message.notification?.body
+
+        val launch = packageManager.getLaunchIntentForPackage(packageName)?.apply {
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            // Carry the FCM `data` so a foreground-tap deep-links like a background one.
+            message.data.forEach { (key, value) -> putExtra(key, value) }
+        }
+        val contentIntent = PendingIntent.getActivity(
+            this,
+            0,
+            launch,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val builder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle(title)
+            .setAutoCancel(true)
+            .setContentIntent(contentIntent)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+        if (body != null) builder.setContentText(body)
+
+        NotificationManagerCompat.from(this)
+            .notify(message.messageId?.hashCode() ?: 0, builder.build())
+    }
+}

--- a/mobile/tauri-plugin-push/android/src/main/java/PushPlugin.kt
+++ b/mobile/tauri-plugin-push/android/src/main/java/PushPlugin.kt
@@ -2,38 +2,74 @@ package com.nosdesk.plugin.push
 
 import android.Manifest
 import android.app.Activity
-import android.content.pm.PackageManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
 import android.os.Build
-import androidx.core.content.ContextCompat
+import app.tauri.PermissionState
 import app.tauri.annotation.Command
+import app.tauri.annotation.Permission
+import app.tauri.annotation.PermissionCallback
 import app.tauri.annotation.TauriPlugin
 import app.tauri.plugin.Invoke
 import app.tauri.plugin.JSObject
 import app.tauri.plugin.Plugin
+import com.google.firebase.messaging.FirebaseMessaging
+
+const val NOTIFICATION_CHANNEL_ID = "nosdesk_notifications"
+private const val ALIAS_NOTIFICATIONS = "postNotification"
 
 /**
- * Android push plugin — STUB until FCM is provisioned.
+ * Android push plugin (FCM). Mirrors the iOS plugin's contract:
+ * - `request_permission` — prompt for POST_NOTIFICATIONS (Android 13+; a no-op
+ *   grant below that), then report the result.
+ * - `get_token` — the FCM registration token.
+ * - `get_pending_notification` — drain the buffered tap for deep-linking.
  *
- * `request_permission` reports whether `POST_NOTIFICATIONS` is granted (always
- * true below Android 13, which has no runtime notification permission).
- * `get_token` returns `null`: obtaining an FCM registration token needs the
- * Firebase SDK + `google-services.json`, which aren't set up yet. When they are,
- * add `firebase-messaging` to build.gradle.kts and return
- * `FirebaseMessaging.getInstance().token` here. The backend already routes
- * `android` device tokens to FCM (Step 4), so only this method changes.
+ * Notification display is FCM's (the backend sends a `notification` block, so a
+ * backgrounded message auto-displays and the tap opens the app with the `data`
+ * as intent extras); this plugin captures that intent (cold start in `load`,
+ * warm tap in `onNewIntent`) into [PendingNotification]. Foreground display +
+ * token refresh live in [PushMessagingService].
  */
-@TauriPlugin
+@TauriPlugin(
+    permissions = [
+        Permission(strings = [Manifest.permission.POST_NOTIFICATIONS], alias = ALIAS_NOTIFICATIONS),
+    ]
+)
 class PushPlugin(private val activity: Activity) : Plugin(activity) {
+
+    override fun load(webView: android.webkit.WebView) {
+        super.load(webView)
+        createDefaultChannel(activity)
+        // Cold-start tap: the launcher intent carries the FCM `data` extras.
+        PendingNotification.capture(activity.intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        // Warm tap (singleTask activity re-used): capture the new intent.
+        PendingNotification.capture(intent)
+    }
+
     @Command
     fun requestPermission(invoke: Invoke) {
-        val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            ContextCompat.checkSelfPermission(
-                activity,
-                Manifest.permission.POST_NOTIFICATIONS,
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            true
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            getPermissionState(ALIAS_NOTIFICATIONS) == PermissionState.GRANTED
+        ) {
+            resolveGranted(invoke, true)
+            return
         }
+        requestPermissionForAlias(ALIAS_NOTIFICATIONS, invoke, "permissionCallback")
+    }
+
+    @PermissionCallback
+    fun permissionCallback(invoke: Invoke) {
+        resolveGranted(invoke, getPermissionState(ALIAS_NOTIFICATIONS) == PermissionState.GRANTED)
+    }
+
+    private fun resolveGranted(invoke: Invoke, granted: Boolean) {
         val ret = JSObject()
         ret.put("granted", granted)
         invoke.resolve(ret)
@@ -41,20 +77,37 @@ class PushPlugin(private val activity: Activity) : Plugin(activity) {
 
     @Command
     fun getToken(invoke: Invoke) {
-        // No FCM yet — see class doc.
-        val ret = JSObject()
-        ret.put("token", null as String?)
-        invoke.resolve(ret)
+        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+            val ret = JSObject()
+            ret.put("token", if (task.isSuccessful) task.result else null)
+            invoke.resolve(ret)
+        }
     }
 
     @Command
     fun getPendingNotification(invoke: Invoke) {
-        // No FCM / tap handling yet — nothing pending.
+        val pending = PendingNotification.take()
         val ret = JSObject()
-        ret.put("ndType", null as String?)
-        ret.put("entityType", null as String?)
-        ret.put("entityId", null as Int?)
-        ret.put("ticketId", null as Int?)
+        ret.put("ndType", pending?.ndType)
+        ret.put("entityType", pending?.entityType)
+        ret.put("entityId", pending?.entityId)
+        ret.put("ticketId", pending?.ticketId)
         invoke.resolve(ret)
+    }
+
+    companion object {
+        /** The default channel FCM notifications post to (Android 8+ requires one). */
+        fun createDefaultChannel(context: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            val manager =
+                context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (manager.getNotificationChannel(NOTIFICATION_CHANNEL_ID) != null) return
+            val channel = NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                "Notifications",
+                NotificationManager.IMPORTANCE_HIGH,
+            )
+            manager.createNotificationChannel(channel)
+        }
     }
 }


### PR DESCRIPTION
Implements the Android half of `tauri-plugin-push` — the iOS half shipped in #115, backend FCM sender + content enrichment in #114/#116. **Proven on-device** (Galaxy A22 5G, Android 13): token registration, enriched mention + assignment pushes, and notification-tap deep-link to the ticket all verified against `nosdesk-dev`.

## What's here
- **PushPlugin.kt** — `get_token` (FirebaseMessaging), `request_permission` (`POST_NOTIFICATIONS` via `requestPermissionForAlias` on Android 13+), `get_pending_notification` (drains the tap buffer). Captures the tapped notification's `data` extras from the launch intent (cold start, in `load()`) and `onNewIntent` (warm tap) into `PendingNotification` — single source of truth, mirroring the iOS design.
- **PushMessagingService** (FCM) — foreground display (backgrounded auto-displays via Firebase); tap re-opens the app carrying the `data` extras so deep-linking works in both states.
- **PendingNotification.kt** — the tap buffer (`capture`/`take`).
- Default notification channel + manifest service/channel meta-data.
- **Gradle** — `firebase-messaging` (BoM 33.7.0) in the plugin; `google-services` plugin applied to the app module (reads `gen/android/app/google-services.json`, gitignored).

## Notes
- No swizzling needed — the Tauri Android Plugin base forwards `onNewIntent` and provides permission helpers, so this is cleaner than the iOS side.
- JS (`push.ts`) and backend already handle the `android` platform + route tokens to FCM v1; no changes there.
- Backend needs `NOSDESK_FCM_SERVICE_ACCOUNT` (set on `nosdesk-dev`); `project_id` derives from the service-account JSON.
- Frontend/backend CI doesn't build the Android app — this was validated on-device rather than in CI.