### PR TITLE
chore(mobile): gitignore google-services.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ fly.hosted-test.toml
 
 # Enterprise license signing key (private). Public counterpart is committed + embedded.
 backend/license_private.pem
+
+# Firebase client config (per-machine; contains the FCM API key)
+google-services.json


### PR DESCRIPTION
One-line follow-up to #117: ignore the per-machine Firebase `google-services.json` (contains the FCM API key; ships in the APK regardless). Keeps the raw file out of git.