### PR TITLE
Kanban on mobile: drag-to-edge panning, and a bottom-sheet composer that works

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,8 @@ jobs:
   e2e:
     name: Playwright
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Cold-start dominated: a from-scratch backend build can take 15 of these.
+    timeout-minutes: 60
     steps:
       # The Rust image build plus the runner's preinstalled toolchains will
       # otherwise fill the disk, as the backend job already found.
@@ -79,13 +80,26 @@ jobs:
 
       # The backend runs its own migrations on boot, so "serving" means the
       # schema is in place too.
+      #
+      # The long pole is a cold cargo build inside the container, which has no
+      # cache to hit on a fresh runner. The previous 7.5 minute budget expired
+      # mid-compile and reported "backend did not come up" for a stack that was
+      # building normally, so E2E went red on main and on unrelated PRs. Bail
+      # immediately if the container actually died, so a real failure stays fast
+      # rather than sitting out the whole budget.
       - name: Wait for the backend
         run: |
-          for i in $(seq 1 90); do
+          cid=$(docker compose -f compose.yaml -f compose.dev.yaml ps -q nosdesk)
+          for i in $(seq 1 240); do
             if curl -sf -o /dev/null http://localhost:8080/; then echo "up"; exit 0; fi
+            if [ -n "$cid" ] && [ "$(docker inspect -f '{{.State.Running}}' "$cid")" != "true" ]; then
+              echo "backend container exited"
+              docker compose -f compose.yaml -f compose.dev.yaml logs --tail 200 nosdesk
+              exit 1
+            fi
             sleep 5
           done
-          echo "backend did not come up"
+          echo "backend did not come up within 20 minutes"
           docker compose -f compose.yaml -f compose.dev.yaml logs --tail 200 nosdesk
           exit 1
 
@@ -105,7 +119,7 @@ jobs:
       # assert on rendered layout, so the build has to have landed first.
       - name: Wait for the frontend build
         run: |
-          for i in $(seq 1 60); do
+          for i in $(seq 1 120); do
             if docker compose -f compose.yaml -f compose.dev.yaml logs frontend-watch 2>/dev/null | grep -q "built in"; then
               echo "built"; exit 0
             fi

--- a/frontend/e2e/board-touch-drag.spec.ts
+++ b/frontend/e2e/board-touch-drag.spec.ts
@@ -58,13 +58,49 @@ test.describe('kanban touch drag', () => {
     await touch.start(card!.x, card!.y)
     // Past the long-press threshold (350ms) without moving.
     await page.waitForTimeout(500)
-    await touch.drag(card!.x, card!.y, 200, page, 14)
+    // Deliberately a SHORT move that stays out of the edge bands: a drag held
+    // near an edge is supposed to auto-pan (see the next test), so a long drag
+    // here would assert the opposite of the intended behaviour.
+    await touch.drag(card!.x, card!.y, 30, page, 6)
 
     const during = await boardScrollLeft(page)
     await touch.end()
     await page.waitForTimeout(1200)
 
-    expect(during, 'once the hold has activated, the drag owns the gesture').toBe(before)
+    expect(during, 'away from the edges the drag owns the gesture, no panning').toBe(before)
+  })
+
+  /**
+   * Drag-to-edge auto-pan. This silently did nothing for the whole of the
+   * board's mobile life: `scroll-snap-type: x mandatory` (mobile-only, for
+   * finger-flick column paging) snapped back every one of the edge scroller's
+   * ~12px-per-frame increments, so the board never moved while a card was held
+   * at the edge.
+   */
+  test('holding a dragged card at the edge pans the board', async ({ page, context }) => {
+    await login(page)
+    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+
+    const card = await visibleCard(page)
+    expect(card).not.toBeNull()
+
+    const before = await boardScrollLeft(page)
+    const width = page.viewportSize()!.width
+    // Head for whichever edge the board can actually scroll towards.
+    const towardsRight = before < 10
+    const edgeX = towardsRight ? width - 8 : 8
+
+    const touch = await Touch.create(context, page)
+    await touch.start(card!.x, card!.y)
+    await page.waitForTimeout(500)
+    await touch.move(edgeX, card!.y)
+    // Hold still at the edge: panning is driven by a rAF loop reading the last
+    // pointer position, not by further movement.
+    await page.waitForTimeout(1200)
+    const during = await boardScrollLeft(page)
+    await touch.end()
+
+    expect(during, 'the board should pan while a card is held at the edge').not.toBe(before)
   })
 
   test('dropping on another column moves the card', async ({ page, context }) => {

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -29,10 +29,23 @@ export async function login(page: Page): Promise<void> {
  * The pool loads AFTER mount, so asserting immediately reads an empty board.
  * This is not cosmetic: the kanban landing scroll originally hooked `onMounted`
  * and silently did nothing for exactly this reason.
+ *
+ * Pass `waitFor` whenever the assertion needs data on screen. The bare form is
+ * a fixed settle, which is a duration standing in for a condition: it is enough
+ * on a laptop and not on a loaded CI runner, where the landing-scroll test
+ * measured an empty board and failed both attempts while passing locally.
+ * Layout assertions that hold on an empty view can keep using the bare form.
  */
-export async function gotoAndSettle(page: Page, path: string): Promise<void> {
+export async function gotoAndSettle(page: Page, path: string, waitFor?: string): Promise<void> {
   await page.goto(path, { waitUntil: 'domcontentloaded' })
-  await page.waitForTimeout(4000)
+  if (waitFor === undefined) {
+    await page.waitForTimeout(4000)
+    return
+  }
+  await page.waitForSelector(waitFor, { timeout: 30_000 })
+  // The landing scroll runs on the tick after the cards arrive, so the element
+  // existing is not yet the board having settled where it opens.
+  await page.waitForTimeout(750)
 }
 
 /** Real touch events through CDP. Playwright's `touchscreen` only taps, and a

--- a/frontend/e2e/project-views-mobile.spec.ts
+++ b/frontend/e2e/project-views-mobile.spec.ts
@@ -72,7 +72,13 @@ test.describe('project views on a phone', () => {
 
   test('the board opens on a column that has work in it', async ({ page }) => {
     await login(page)
-    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`, '[data-card-id]')
+
+    // Separated from the visibility check on purpose: without this, a pool that
+    // had not hydrated yet reads as "the board opened on the wrong column",
+    // which is how this failed in CI while the landing scroll was working.
+    const cardsRendered = await page.locator('[data-card-id]').count()
+    expect(cardsRendered, 'the project should have cards to land on').toBeGreaterThan(0)
 
     // Columns render in workflow order, so the board would otherwise open on
     // Triage / Backlog — routinely empty — with the tickets several swipes away.

--- a/frontend/src/composables/useDragEdgeScroll.ts
+++ b/frontend/src/composables/useDragEdgeScroll.ts
@@ -10,6 +10,17 @@ export interface DragEdgeScrollTarget {
 const EDGE_BAND = 180
 /** Maximum scroll velocity (px per frame at ~60fps). */
 const EDGE_MAX = 12
+/** Cap the band at a fraction of the axis so a narrow viewport keeps a neutral
+ *  middle. At a flat 180px on a 390px phone the two bands leave a 30px gap, so
+ *  nearly every drag auto-pans and the board feels like it is fleeing the
+ *  finger. 20% gives ~78px bands there and is a no-op on desktop, where 180px
+ *  is already well under the cap. */
+const EDGE_BAND_MAX_FRACTION = 0.2
+
+/** The band actually used for an axis of the given length. */
+export function bandForAxis(axisLength: number, band = EDGE_BAND): number {
+  return Math.min(band, Math.floor(axisLength * EDGE_BAND_MAX_FRACTION))
+}
 
 export function scrollDeltaForEdge(
   pointer: number,
@@ -126,13 +137,13 @@ export function createDragEdgeScroller(options?: {
     for (const { el, axes } of getTargets(x, y)) {
       if (!el.isConnected) continue
       if (axes === 'x' || axes === 'both') {
-        const dx = scrollDeltaForEdge(x, 0, viewW, band, maxSpeed)
+        const dx = scrollDeltaForEdge(x, 0, viewW, bandForAxis(viewW, band), maxSpeed)
         if (dx !== 0 && el.scrollWidth > el.clientWidth) {
           el.scrollLeft += dx
         }
       }
       if (axes === 'y' || axes === 'both') {
-        const dy = scrollDeltaForEdge(y, 0, viewH, band, maxSpeed)
+        const dy = scrollDeltaForEdge(y, 0, viewH, bandForAxis(viewH, band), maxSpeed)
         if (dy !== 0 && el.scrollHeight > el.clientHeight) {
           el.scrollTop += dy
         }

--- a/frontend/src/composables/useProjectTicketLink.ts
+++ b/frontend/src/composables/useProjectTicketLink.ts
@@ -1,7 +1,9 @@
 import { useAggregate } from '@nosdesk/core/sync/composables'
 import * as pool from '@nosdesk/core/sync/pool'
 import { projectService } from '@nosdesk/core/services/projectService'
+import { useToastStore } from '@nosdesk/core/stores/toast'
 import { logger } from '@nosdesk/core/utils/logger'
+import { translate } from '@/i18n'
 import type { ProjectTicketAssoc } from '@/composables/useProjectTickets'
 
 export function projectTicketLinkKey(projectId: number, ticketId: number): string {
@@ -38,6 +40,14 @@ export function useProjectTicketLink() {
     } catch (err) {
       logger.error('Failed to add ticket to project', { projectId, ticketId, error: err })
       pool.remove('project_ticket', key)
+      // Tell the user. The optimistic row is rolled back above, so without this
+      // the ticket simply blinks out of the board and the composer closes as
+      // though it worked — the failure is invisible. Members hit this routinely:
+      // linking requires agent privileges and the API answers 403.
+      useToastStore().error(
+        translate('project-link-ticket-failed'),
+        err instanceof Error ? err.message : undefined,
+      )
       return false
     }
   }

--- a/frontend/src/sync/views/KanbanBoard.vue
+++ b/frontend/src/sync/views/KanbanBoard.vue
@@ -54,6 +54,8 @@ import {
   useTicketDrag,
 } from '@/composables/useTicketDrag'
 import { useProjectTicketLink } from '@/composables/useProjectTicketLink'
+import { subscribe } from '@/sync/lifecycle'
+import { useMyWorkspacesStore } from '@/stores/myWorkspaces'
 import ResponsiveMenu from '@/components/common/ResponsiveMenu.vue'
 import { useMobileDetection } from '@/composables/useMobileDetection'
 
@@ -95,6 +97,27 @@ const props = withDefaults(defineProps<{
 
 const ticketsStore = useSyncTicketsStore()
 const workflowStatesStore = useWorkflowStatesStore()
+const myWorkspaces = useMyWorkspacesStore()
+
+/**
+ * Warm the workspace pool before offering existing tickets to link.
+ *
+ * `quickAddMatches` reads `ticketsStore.all()`, which only holds what the
+ * subscribed groups have bootstrapped. The project route subscribes to
+ * `project:N` alone, so on a cold load the pool contains this project's tickets
+ * and nothing else — every candidate is filtered out as already-on-board and
+ * the composer silently offers nothing. It only ever appeared to work because
+ * the tickets and projects lists subscribe to the workspace group, leaving the
+ * pool warm when you navigate in from one. Deep-link straight to a board, which
+ * is the normal case on a phone, and half the composer does nothing.
+ *
+ * `subscribe` is idempotent, so opening the composer repeatedly costs nothing.
+ */
+function warmTicketPool(): void {
+  const id = myWorkspaces.activeWorkspaceId
+  if (id == null) return
+  void subscribe(`workspace:${id}`)
+}
 const { linkToProject } = useProjectTicketLink()
 
 // ---------------------------------------------------------------
@@ -663,6 +686,7 @@ const boardAnchor = computed(() => ({
 }))
 
 function openAddSheet(cat: WorkflowStateCategory): void {
+  warmTicketPool()
   quickAddCategory.value = cat
   quickAddTitle.value = ''
   quickAddHighlight.value = -1
@@ -695,6 +719,7 @@ function openQuickAdd(cat: WorkflowStateCategory): void {
     openAddSheet(cat)
     return
   }
+  warmTicketPool()
   quickAddCategory.value = cat
   quickAddTitle.value = ''
   quickAddHighlight.value = -1

--- a/frontend/src/sync/views/KanbanBoard.vue
+++ b/frontend/src/sync/views/KanbanBoard.vue
@@ -54,6 +54,8 @@ import {
   useTicketDrag,
 } from '@/composables/useTicketDrag'
 import { useProjectTicketLink } from '@/composables/useProjectTicketLink'
+import ResponsiveMenu from '@/components/common/ResponsiveMenu.vue'
+import { useMobileDetection } from '@/composables/useMobileDetection'
 
 /** Sub-lane keys are derived from the secondary axis value:
  *   - assignee_uuid: the uuid string, or '__none__' if null
@@ -632,7 +634,67 @@ watch(quickAddTitle, () => {
   quickAddHighlight.value = quickAddTitle.value.trim() ? 0 : -1
 })
 
+/**
+ * Below `md` the composer is a bottom sheet instead of an inline input.
+ *
+ * The inline version is a desktop interaction that does not survive touch: its
+ * option rows commit on `mousedown.prevent` (a trick to beat the input's blur,
+ * which behaves differently under touch), the input closes the composer on
+ * blur so a tap on a suggestion could dismiss the list before it registered,
+ * the dropdown opens upward inside a ~290px column, its rows are ~26px tall,
+ * and the on-screen keyboard covers the very area the suggestions render in.
+ *
+ * `ResponsiveMenu` renders the same slot as a popover on desktop and a
+ * dismissible bottom sheet below `md`, so only the presentation differs — the
+ * state and both commit paths (`submitQuickAdd` / `addExisting`) are shared.
+ */
+const { isMobile } = useMobileDetection('md')
+// Shares `quickAddCategory` with the inline composer rather than tracking its
+// own column: `quickAddMatches` keys off it, so a separate ref left the sheet
+// permanently empty. `sheetOpen` is the only extra state — which presentation
+// is showing.
+const sheetOpen = ref(false)
+const sheetLane = computed<Lane | null>(
+  () => lanes.value.find((l) => l.id === quickAddCategory.value) ?? null,
+)
+const boardAnchor = computed(() => ({
+  type: 'element' as const,
+  element: () => boardEl.value,
+}))
+
+function openAddSheet(cat: WorkflowStateCategory): void {
+  quickAddCategory.value = cat
+  quickAddTitle.value = ''
+  quickAddHighlight.value = -1
+  sheetOpen.value = true
+}
+
+function closeAddSheet(): void {
+  sheetOpen.value = false
+  closeQuickAdd()
+}
+
+async function sheetCreate(): Promise<void> {
+  const lane = sheetLane.value
+  if (!lane) return
+  await submitQuickAdd(lane)
+  closeAddSheet()
+}
+
+async function sheetAddExisting(ticketId: number): Promise<void> {
+  const lane = sheetLane.value
+  if (!lane) return
+  await addExisting(lane, ticketId)
+  closeAddSheet()
+}
+
 function openQuickAdd(cat: WorkflowStateCategory): void {
+  // Touch gets the sheet; pointer devices keep the inline composer, which is
+  // faster for successive entry and has working keyboard navigation.
+  if (isMobile.value) {
+    openAddSheet(cat)
+    return
+  }
   quickAddCategory.value = cat
   quickAddTitle.value = ''
   quickAddHighlight.value = -1
@@ -783,9 +845,19 @@ function affectedDevicesTooltip(card: CardData): string {
          Lanes grow with their cards — no nested column scrollports. Column
          headers use position:sticky against this element so they pin while
          the board scrolls. -->
+    <!-- `scroll-snap-type: none` while dragging, as an INLINE style.
+         Column snapping (max-md:snap-mandatory) is for finger-flick paging, but
+         it also snaps back every small programmatic scroll, which silently
+         killed drag-to-edge auto-pan on mobile: ten successive `scrollLeft -=
+         12` (what the edge scroller does per frame) moved the board 0px, while
+         a single -200 jump moved it. Desktop never saw this because the snap
+         classes are `max-md:`. Inline rather than a `snap-none` class because
+         two competing `scroll-snap-type` utilities would be resolved by
+         stylesheet order, not by which one we wrote last. -->
     <div
       ref="boardEl"
       class="kanban-board flex flex-1 min-h-0 min-w-0 overflow-x-auto overflow-y-auto max-md:snap-x max-md:snap-mandatory"
+      :style="dragState.isDragging ? { scrollSnapType: 'none' } : undefined"
       @click="clearSelection"
       @dragover="onExternalDragOver"
       @drop="onExternalDrop"
@@ -979,7 +1051,7 @@ function affectedDevicesTooltip(card: CardData): string {
             v-if="onQuickAdd && lane.defaultState"
             class="relative px-1.5 pb-1.5 pt-0.5 shrink-0"
           >
-            <template v-if="quickAddCategory === lane.id">
+            <template v-if="quickAddCategory === lane.id && !sheetOpen">
               <input
                 :ref="(el) => focusQuickAdd(el as Element | null)"
                 v-model="quickAddTitle"
@@ -1048,6 +1120,80 @@ function affectedDevicesTooltip(card: CardData): string {
     </div>
 
     <!-- Floating drag preview -->
+    <!-- Mobile composer. Rows are >=44px and the whole surface is
+         screen-anchored, so neither the column width nor the on-screen
+         keyboard squeezes it. Commits on `click`, not `mousedown`. -->
+    <ResponsiveMenu
+      :open="sheetOpen && sheetLane !== null"
+      :anchor="boardAnchor"
+      :title="sheetLane ? t('kanban-quick-add-aria', { column: sheetLane.label }) : ''"
+      role="dialog"
+      :auto-focus="false"
+      @close="closeAddSheet"
+    >
+      <div class="flex flex-col min-h-0">
+        <div class="p-3 border-b border-subtle shrink-0">
+          <input
+            v-model="quickAddTitle"
+            type="text"
+            enterkeyhint="done"
+            class="w-full min-h-[44px] rounded-lg border border-default bg-surface px-3 text-[15px] text-primary placeholder:text-tertiary focus:outline-none focus:ring-2 focus:ring-accent"
+            :placeholder="projectId != null ? t('kanban-composer-placeholder') : t('kanban-quick-add-placeholder')"
+          />
+        </div>
+
+        <div class="overflow-y-auto min-h-0">
+          <button
+            v-if="quickAddCanCreate"
+            type="button"
+            class="w-full flex items-center gap-2 px-3 min-h-[52px] text-left text-[15px] text-primary border-b border-subtle active:bg-surface-hover"
+            @click="sheetCreate"
+          >
+            <span class="text-accent shrink-0 text-lg leading-none">+</span>
+            <span class="truncate">{{ t('kanban-composer-create', { title: quickAddTitle.trim() }) }}</span>
+          </button>
+
+          <div
+            v-if="quickAddMatches.length > 0"
+            class="px-3 pt-3 pb-1 text-[11px] uppercase tracking-wide text-tertiary"
+          >
+            {{ quickAddTitle.trim() ? t('kanban-composer-existing') : t('kanban-composer-recent') }}
+          </div>
+
+          <button
+            v-for="match in quickAddMatches"
+            :key="match.id"
+            type="button"
+            class="w-full flex items-center gap-2.5 px-3 min-h-[52px] py-2 text-left border-b border-subtle active:bg-surface-hover"
+            @click="sheetAddExisting(match.id)"
+          >
+            <span class="text-tertiary tabular-nums shrink-0 text-[13px]">#{{ match.id }}</span>
+            <span class="flex-1 min-w-0 truncate text-[15px] text-primary">{{ match.title }}</span>
+            <PriorityIndicator
+              v-if="match.priority && match.priority !== 'none'"
+              :priority="(match.priority === 'urgent' ? 'high' : match.priority) as 'low' | 'medium' | 'high'"
+              size="xs"
+            />
+            <UserAvatar
+              v-if="match.assignee_uuid"
+              :uuid="match.assignee_uuid"
+              size="xxs"
+              :showName="false"
+              :clickable="false"
+              class="shrink-0"
+            />
+          </button>
+
+          <p
+            v-if="!quickAddCanCreate && quickAddMatches.length === 0"
+            class="px-3 py-6 text-center text-sm text-tertiary"
+          >
+            {{ t('kanban-composer-recent') }}
+          </p>
+        </div>
+      </div>
+    </ResponsiveMenu>
+
     <TicketDragPreview
       v-if="kanbanDragPreview"
       :ticket="kanbanDragPreview.ticket"

--- a/frontend/src/sync/views/drag.ts
+++ b/frontend/src/sync/views/drag.ts
@@ -112,6 +112,11 @@ export function useDragDrop(options: UseDragDropOptions): {
     // Suppress text selection during drag.
     document.body.style.userSelect = 'none'
     edgeScroller.start()
+    // Seed the scroller with where the finger actually is. It defaults to
+    // (0, 0), which sits deep in the left edge band, so a long-press that has
+    // not moved yet would auto-pan the board away at full speed until the first
+    // pointermove corrected it.
+    edgeScroller.update(startX, startY)
   }
 
   function reset(): void {

--- a/frontend/src/sync/views/gantt/useBarDrag.ts
+++ b/frontend/src/sync/views/gantt/useBarDrag.ts
@@ -66,6 +66,7 @@ export function useBarDrag(options: {
   let mode: BarDragMode | null = null
   let dragging = false
   let downX = 0
+  let downY = 0
   let downDay = 0
   let suppressClick = false
   // Hold-to-drag on touch, shared with the kanban. Resize handles are exempt:
@@ -101,6 +102,7 @@ export function useBarDrag(options: {
     pointerId = event.pointerId
     mode = m
     downX = event.clientX
+    downY = event.clientY
     downDay = dayAt(event.clientX)
     dragging = m !== 'move' // handles drag immediately; body waits for threshold
     preview.value = {
@@ -114,6 +116,7 @@ export function useBarDrag(options: {
     if (dragging) {
       options.onDragStart?.()
       edgeScroller.start()
+      edgeScroller.update(downX, downY)
     }
     window.addEventListener('pointermove', onPointerMove)
     window.addEventListener('pointerup', onPointerUp)
@@ -124,6 +127,8 @@ export function useBarDrag(options: {
       dragging = true
       options.onDragStart?.()
       edgeScroller.start()
+      // Seed the pointer, or the scroller pans from its (0, 0) default.
+      edgeScroller.update(downX, downY)
       document.body.style.userSelect = 'none'
     })
   }

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -2832,6 +2832,9 @@ project-cycles-confirm-complete-backlog = { $count ->
 project-cycles-move-to = Move to { $name }
 project-cycles-remove-from-cycle = Remove from cycle
 project-cycles-ticket-menu = Ticket actions
+# Shown when linking an existing ticket to a project fails (e.g. the user
+# lacks agent privileges and the API answers 403).
+project-link-ticket-failed = Could not add that ticket to the project
 project-cycles-promote-blocked-title = A cycle is already active
 project-cycles-promote-blocked = Only one cycle can be active per project. Complete or archive the current cycle first.
 project-cycles-promote-blocked-ok = Got it

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -2669,6 +2669,8 @@ project-cycles-confirm-complete-backlog = { $count ->
 project-cycles-move-to = Déplacer vers { $name }
 project-cycles-remove-from-cycle = Retirer du cycle
 project-cycles-ticket-menu = Actions du ticket
+# Échec de l'ajout d'un ticket à un projet (machine, à relire par un locuteur natif).
+project-link-ticket-failed = Impossible d'ajouter ce ticket au projet
 project-cycles-promote-blocked-title = Un cycle est déjà actif
 project-cycles-promote-blocked = Un seul cycle peut être actif par projet. Terminez ou archivez d'abord le cycle en cours.
 project-cycles-promote-blocked-ok = Compris

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -2666,6 +2666,8 @@ project-cycles-confirm-complete-backlog = { $count ->
 project-cycles-move-to = Verplaatsen naar { $name }
 project-cycles-remove-from-cycle = Uit cyclus verwijderen
 project-cycles-ticket-menu = Ticketacties
+# Koppelen van ticket aan project mislukt (machinevertaling, nog na te kijken).
+project-link-ticket-failed = Kan dat ticket niet aan het project toevoegen
 project-cycles-promote-blocked-title = Er is al een actieve cyclus
 project-cycles-promote-blocked = Per project kan maar één cyclus actief zijn. Rond de huidige cyclus eerst af of archiveer deze.
 project-cycles-promote-blocked-ok = Begrepen


### PR DESCRIPTION
Two mobile kanban problems, found by driving the board on a phone.

## Drag to the edge now pans the board

Dragging a card to the edge of the screen previously did nothing: the board
scrolls horizontally, but with a card in hand there was no way to reach a
column that was off-screen, so cross-column moves were impossible on a phone.

The edge scroller now activates on the drag axis, with the band capped at 20%
of the axis length so it stays proportional on a narrow viewport instead of
swallowing most of the screen. Both drag paths (`drag.ts` for kanban,
`useBarDrag.ts` for gantt bars) seed the scroller with the start position, so
a drag that begins inside the band pans immediately rather than waiting for
the first move event.

Scroll snapping is disabled for the duration of a drag. Snap points fought the
programmatic scroll and dragged the board back to the nearest column.

## Adding an existing ticket is a bottom sheet, and it works

The composer was a desktop dropdown rendered on a phone. It is now a
`ResponsiveMenu` bottom sheet, matching the convention used elsewhere.

Two bugs behind it:

- **Cold pool.** The composer searched the ticket pool, but the project route
  only subscribes to `project:<id>`, so on a cold load the pool held nothing to
  search and the sheet came up empty. It now warms `workspace:<id>` when the
  sheet opens.
- **Silent 403.** Linking failed with no feedback at all for a user without
  agent privileges. It now raises a toast.

## Verification

Playwright with CDP `Input.dispatchTouchEvent` (Chromium only, which is why the
spec drives touch through CDP rather than the iPhone device preset, whose
WebKit engine the runner does not have). Covers long-press to lift, drag to the
edge, pan, and drop into a previously off-screen column.
