### PR TITLE
Gantt on mobile: transpose it into a vertical timeline

### DIFF
--- a/frontend/src/sync/views/gantt/VerticalTimeline.vue
+++ b/frontend/src/sync/views/gantt/VerticalTimeline.vue
@@ -1,0 +1,403 @@
+<script setup lang="ts">
+/**
+ * Vertical timeline — the gantt, transposed for a phone.
+ *
+ * Time runs DOWN; concurrent tickets sit side by side as columns. This is the
+ * mobile calendar day-view pattern applied to tickets: a ticket with
+ * start -> due is structurally an event with start -> end, and everyone
+ * already reads that layout without being taught it.
+ *
+ * Why transpose at all (see docs/plans/gantt-mobile-research.md): a horizontal
+ * gantt is bounded by TIME SPAN, and 90 days will never fit in 390px. Vertical
+ * is bounded by CONCURRENCY instead — how many tickets are in flight at the
+ * same moment, which is a much smaller number — and the axis that is unbounded
+ * (time) becomes the one the device scrolls naturally.
+ *
+ * Three ideas borrowed from the timespace canvas:
+ *
+ *   1. Proportional flow. Distance down the screen IS distance in time, so a
+ *      block's height is its duration. This is what separates a timeline from
+ *      an agenda list, where every row is the same height and simultaneity is
+ *      invisible.
+ *   2. The calendar is a lens, not a container. Civic marks are an ADAPTIVE
+ *      measure resolved to whatever the current scale can legibly carry —
+ *      days, then weeks, then months — rather than a fixed grid.
+ *   3. A fidelity ladder. Content climbs detail as it gets more room:
+ *      mark -> titled chip -> full card. This is what stops high concurrency
+ *      turning to mush: narrow columns degrade to legible marks instead of
+ *      clipped text.
+ *
+ * Also from timespace: precision is provenance. `spanOf` falls back to
+ * `created_at` when a ticket has no authored `start_date`, which is a
+ * low-precision guess presented as fact. Inferred starts render hatched so a
+ * plan does not masquerade as a measurement.
+ */
+import { computed, ref } from 'vue'
+import { useFluent } from 'fluent-vue'
+import { addDays, differenceInCalendarDays, format, startOfDay, startOfMonth, startOfWeek } from 'date-fns'
+import type { CardData } from '@nosdesk/core/sync/views/types'
+import { splitSchedule, type ScheduledCard } from './rowModel'
+import { TERMINAL_CATEGORIES, coarseStatusBucket } from '@nosdesk/core/types/workflow'
+import PriorityIndicator from '@/components/common/PriorityIndicator.vue'
+import UserAvatar from '@/components/UserAvatar.vue'
+
+const fluent = useFluent()
+const t = (k: string, args?: Record<string, string | number>) => fluent.$t(k, args)
+
+const props = withDefaults(defineProps<{
+  cards: readonly CardData[]
+  onCardClick?: (cardId: number) => void
+}>(), { onCardClick: undefined })
+
+/** Vertical scale. 36px/day keeps a fortnight on ~500px, which is one
+ *  comfortable scroll, and leaves a single-day block tall enough to letter. */
+const PX_PER_DAY = 36
+/** Gutter holding the time ruler. */
+const GUTTER = 48
+/** Minimum spacing between civic marks before the ruler steps up a unit. */
+const MIN_TICK_PX = 44
+/** Fidelity thresholds, in px of column width. */
+const WIDTH_FULL = 132
+const WIDTH_COMPACT = 68
+
+const rootEl = ref<HTMLElement | null>(null)
+const width = ref(390)
+
+const split = computed(() => splitSchedule(props.cards))
+
+/**
+ * Only work that is still in flight gets a bar.
+ *
+ * `spanOf` gives a TERMINAL ticket `created_at -> closed_at`, which is a record
+ * of how long it was open, not a plan. Rendering the two identically conflates
+ * a measurement with an intention, and on a phone it is actively destructive: a
+ * single cancelled ticket that sat open for six weeks stretches the window to
+ * six weeks and pushes everything actually scheduled off-screen. Desktop
+ * survives this because you can zoom out; this view has no room to.
+ */
+const scheduled = computed<ScheduledCard[]>(() =>
+  split.value.scheduled
+    .filter((s) => !TERMINAL_CATEGORIES.has(s.card.workflow_state.category))
+    .map((s) => {
+      // Precision is provenance. `spanOf` fills a missing `start_date` from
+      // `created_at`, so a ticket raised two months ago and due next week draws
+      // as a two-month plan — a guess rendered with the confidence of a fact.
+      // Without an authored start we know the DEADLINE, not the span, so it
+      // renders as a day-tall marker at the due date instead of a fabricated
+      // bar. This is also what makes the window usable: one such ticket
+      // previously stretched it to 58 days and pushed everything else away.
+      if (s.card.start_date) return s
+      return { ...s, start: addDays(s.end, -1) }
+    }),
+)
+const unscheduled = computed(() => split.value.unscheduled)
+
+/** Window covering everything scheduled, padded a day each side so bars do not
+ *  sit flush against the ends. */
+const window_ = computed(() => {
+  const items = scheduled.value
+  if (items.length === 0) {
+    const today = startOfDay(new Date())
+    return { start: addDays(today, -1), days: 14 }
+  }
+  let min = items[0].start
+  let max = items[0].end
+  for (const it of items) {
+    if (it.start < min) min = it.start
+    if (it.end > max) max = it.end
+  }
+  const start = addDays(startOfDay(min), -1)
+  return { start, days: Math.max(3, differenceInCalendarDays(max, start) + 2) }
+})
+
+const canvasHeight = computed(() => window_.value.days * PX_PER_DAY)
+
+/** Greedy interval partitioning: each ticket takes the first column free at its
+ *  start. Column count therefore equals peak concurrency — the exact quantity
+ *  this layout is bounded by. */
+const placed = computed(() => {
+  const sorted = [...scheduled.value].sort((a, b) => a.start.getTime() - b.start.getTime())
+  const laneFreeAt: number[] = []
+  const out: Array<{ item: ScheduledCard; lane: number }> = []
+  for (const item of sorted) {
+    let lane = laneFreeAt.findIndex((free) => free <= item.start.getTime())
+    if (lane === -1) {
+      lane = laneFreeAt.length
+      laneFreeAt.push(0)
+    }
+    laneFreeAt[lane] = item.end.getTime()
+    out.push({ item, lane })
+  }
+  return out
+})
+
+const laneCount = computed(() => Math.max(1, new Set(placed.value.map((p) => p.lane)).size))
+const laneWidth = computed(() => Math.max(18, (width.value - GUTTER - 8) / laneCount.value))
+
+/** Minimum block height that can carry a title without clipping it. */
+const HEIGHT_TITLE = 56
+
+/**
+ * mark -> chip -> card, by how much room a block actually got.
+ *
+ * Keyed on BOTH axes, not just column width. A one-day deadline marker is 36px
+ * tall however wide its column is, and a title rendered into it clips
+ * mid-word — which is exactly what the first prototype did.
+ */
+function fidelityFor(heightPx: number): 'full' | 'compact' | 'mark' {
+  if (heightPx < HEIGHT_TITLE) return 'mark'
+  if (laneWidth.value >= WIDTH_FULL) return 'full'
+  if (laneWidth.value >= WIDTH_COMPACT) return 'compact'
+  return 'mark'
+}
+
+function blockHeight(p: { item: ScheduledCard }): number {
+  return Math.max(22, differenceInCalendarDays(p.item.end, p.item.start) * PX_PER_DAY)
+}
+
+/** The civic ruler, resolved to the coarsest unit the scale can carry legibly:
+ *  days while they are far enough apart, then weeks, then months. */
+const ticks = computed(() => {
+  const { start, days } = window_.value
+  const out: Array<{ y: number; label: string; strong: boolean }> = []
+  const dayPx = PX_PER_DAY
+  const unit = dayPx >= MIN_TICK_PX ? 'day' : dayPx * 7 >= MIN_TICK_PX ? 'week' : 'month'
+  let cursor =
+    unit === 'day' ? startOfDay(start)
+      : unit === 'week' ? startOfWeek(start, { weekStartsOn: 1 })
+        : startOfMonth(start)
+  const end = addDays(start, days)
+  while (cursor < end) {
+    const offset = differenceInCalendarDays(cursor, start)
+    if (offset >= 0) {
+      out.push({
+        y: offset * dayPx,
+        label:
+          unit === 'day' ? format(cursor, 'EEE d')
+            : unit === 'week' ? format(cursor, 'd MMM')
+              : format(cursor, 'MMM'),
+        strong: unit !== 'day' || cursor.getDay() === 1,
+      })
+    }
+    cursor = unit === 'day' ? addDays(cursor, 1) : unit === 'week' ? addDays(cursor, 7) : startOfMonth(addDays(cursor, 32))
+  }
+  return out
+})
+
+const todayY = computed(() => {
+  const offset = differenceInCalendarDays(startOfDay(new Date()), window_.value.start)
+  if (offset < 0 || offset > window_.value.days) return null
+  return offset * PX_PER_DAY
+})
+
+function blockStyle(p: { item: ScheduledCard; lane: number }) {
+  const top = differenceInCalendarDays(p.item.start, window_.value.start) * PX_PER_DAY
+  const height = blockHeight(p)
+  return {
+    top: `${top}px`,
+    height: `${height}px`,
+    left: `${GUTTER + p.lane * laneWidth.value}px`,
+    width: `${Math.max(14, laneWidth.value - 4)}px`,
+  }
+}
+
+/** The block's own date line. A timeline block should say WHEN without making
+ *  the reader measure it against the ruler. Deadline-only tickets say "due X";
+ *  planned spans say the range. */
+function dateLabel(item: ScheduledCard): string {
+  if (!item.card.start_date) return t('gantt-due-short', { date: format(item.end, 'd MMM') })
+  // Collapse the month when both ends share one: "7 – 13 Aug", not
+  // "7 Aug – 13 Aug", which wraps mid-range in an 80px column and reads as a
+  // broken string rather than a date.
+  const sameMonth = item.start.getMonth() === item.end.getMonth()
+    && item.start.getFullYear() === item.end.getFullYear()
+  return sameMonth
+    ? `${format(item.start, 'd')} – ${format(item.end, 'd MMM')}`
+    : `${format(item.start, 'd MMM')} – ${format(item.end, 'd MMM')}`
+}
+
+/** Status as a muted fill, matching the desktop bar. Kept separable from
+ *  priority so the two signals never merge into one colour. */
+function statusClass(card: CardData): string {
+  switch (coarseStatusBucket(card.workflow_state.category)) {
+    case 'open':
+      return 'bg-status-open-muted border-status-open/40'
+    case 'in-progress':
+      return 'bg-status-in-progress-muted border-status-in-progress/40'
+    default:
+      return 'bg-status-closed-muted border-status-closed/40'
+  }
+}
+
+/** Priority as a thin accent on the LEADING edge. The desktop bar puts this on
+ *  the left because time runs right; here time runs down, so the leading edge
+ *  is the top. Same signal, transposed with the axis. */
+function priorityEdgeClass(p: CardData['priority']): string {
+  if (p === 'urgent' || p === 'high') return 'border-t-[3px] border-t-priority-high'
+  if (p === 'medium') return 'border-t-[3px] border-t-priority-medium'
+  if (p === 'low') return 'border-t-[3px] border-t-priority-low'
+  return ''
+}
+
+/** Weekend bands, so the ruler reads as a calendar at a glance rather than as
+ *  anonymous gridlines. */
+const weekends = computed(() => {
+  const { start, days } = window_.value
+  const out: Array<{ y: number; h: number }> = []
+  for (let i = 0; i < days; i++) {
+    const day = addDays(start, i).getDay()
+    if (day === 0 || day === 6) out.push({ y: i * PX_PER_DAY, h: PX_PER_DAY })
+  }
+  return out
+})
+
+/** True when the bar's left edge is a guess (`created_at`) rather than an
+ *  authored `start_date`. Rendered hatched: a plan should not read as a fact. */
+function inferredStart(card: CardData): boolean {
+  return !card.start_date
+}
+
+function onResize(el: HTMLElement | null): void {
+  if (!el) return
+  rootEl.value = el
+  width.value = el.clientWidth
+  new ResizeObserver(() => { width.value = el.clientWidth }).observe(el)
+}
+</script>
+
+<template>
+  <div :ref="(el) => onResize(el as HTMLElement | null)" class="flex flex-col min-h-0 flex-1">
+    <!-- Nothing scheduled: say so plainly rather than presenting an empty
+         ruler, which reads as a broken view. -->
+    <div
+      v-if="scheduled.length === 0"
+      class="flex-1 min-h-0 flex items-center justify-center px-8 text-center"
+    >
+      <p class="text-sm text-tertiary max-w-[16rem]">{{ t('gantt-nothing-scheduled') }}</p>
+    </div>
+
+    <div v-else class="flex-1 min-h-0 overflow-y-auto overscroll-contain">
+      <!-- Canvas. Height is proportional to the window's duration, so vertical
+           distance is time; nothing here is a fixed-height row. -->
+      <!-- pb keeps the last block clear of the tab bar and the home indicator. -->
+      <div class="relative pb-16" :style="{ height: `${canvasHeight}px` }">
+        <!-- Weekends. Drawn under the measure so the grid reads as a calendar. -->
+        <div
+          v-for="w in weekends"
+          :key="`w${w.y}`"
+          class="absolute left-0 right-0 bg-strong/[0.045] pointer-events-none"
+          :style="{ top: `${w.y}px`, height: `${w.h}px` }"
+        />
+
+        <!-- Adaptive civic measure. -->
+        <div
+          v-for="tick in ticks"
+          :key="tick.y"
+          class="absolute left-0 right-0 flex items-start gap-2"
+          :style="{ top: `${tick.y}px` }"
+        >
+          <span
+            class="w-11 shrink-0 pl-1 text-[10px] tabular-nums leading-none"
+            :class="tick.strong ? 'text-secondary' : 'text-tertiary'"
+          >{{ tick.label }}</span>
+          <span
+            class="flex-1 border-t"
+            :class="tick.strong ? 'border-default' : 'border-subtle'"
+          />
+        </div>
+
+        <!-- Now. Starts after the gutter so it never strikes through a ruler
+             label, and carries a dot so it reads as a marker not a divider. -->
+        <div
+          v-if="todayY !== null"
+          class="absolute right-0 z-10 pointer-events-none flex items-center"
+          :style="{ top: `${todayY}px`, left: `${GUTTER - 4}px` }"
+        >
+          <span class="h-1.5 w-1.5 rounded-full bg-accent shrink-0" />
+          <span class="flex-1 border-t border-accent/60" />
+        </div>
+
+        <!-- Tickets. Height is duration; column is a concurrency lane. -->
+        <button
+          v-for="p in placed"
+          :key="p.item.card.id"
+          type="button"
+          class="absolute rounded-md border text-left overflow-hidden motion-safe:transition-[box-shadow,filter] motion-safe:duration-150 active:brightness-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          :class="[
+            statusClass(p.item.card),
+            priorityEdgeClass(p.item.card.priority),
+            inferredStart(p.item.card) ? 'nd-inferred-start' : '',
+          ]"
+          :style="blockStyle(p)"
+          :title="`#${p.item.card.id} ${p.item.card.title}`"
+          @click="onCardClick?.(p.item.card.id)"
+        >
+          <template v-if="fidelityFor(blockHeight(p)) === 'full'">
+            <div class="px-1.5 py-1 flex flex-col gap-1 h-full">
+              <div class="flex items-center gap-1">
+                <span class="text-[10px] tabular-nums text-tertiary">#{{ p.item.card.id }}</span>
+                <PriorityIndicator
+                  v-if="p.item.card.priority !== 'none'"
+                  :priority="(p.item.card.priority === 'urgent' ? 'high' : p.item.card.priority) as 'low' | 'medium' | 'high'"
+                  size="xs"
+                />
+              </div>
+              <span class="text-[11px] leading-tight text-primary line-clamp-3">{{ p.item.card.title }}</span>
+              <span class="text-[10px] text-tertiary tabular-nums whitespace-nowrap">{{ dateLabel(p.item) }}</span>
+              <UserAvatar
+                v-if="p.item.card.assignee_uuid"
+                :uuid="p.item.card.assignee_uuid"
+                size="xxs"
+                :showName="false"
+                :clickable="false"
+                class="mt-auto"
+              />
+            </div>
+          </template>
+
+          <template v-else-if="fidelityFor(blockHeight(p)) === 'compact'">
+            <div class="px-1.5 py-1 h-full flex flex-col gap-0.5">
+              <span class="text-[10px] tabular-nums text-tertiary">#{{ p.item.card.id }}</span>
+              <span class="block text-[11px] leading-tight text-primary line-clamp-4">{{ p.item.card.title }}</span>
+              <span class="mt-auto text-[10px] text-tertiary tabular-nums whitespace-nowrap">{{ dateLabel(p.item) }}</span>
+            </div>
+          </template>
+
+          <!-- Mark. Too small in one axis or both to letter, so it carries the
+               id only and stays tappable rather than clipping text mid-word. -->
+          <template v-else>
+            <span class="flex items-center justify-center w-full h-full bg-accent/15 text-[10px] tabular-nums text-secondary">
+              #{{ p.item.card.id }}
+            </span>
+          </template>
+        </button>
+      </div>
+    </div>
+
+    <!-- Tickets with no due date have no position on a time axis, so they sit
+         outside the canvas rather than being given a fabricated one. -->
+    <div v-if="unscheduled.length > 0" class="shrink-0 border-t border-default bg-surface-alt">
+      <div class="px-3 pt-2 pb-1 text-[11px] uppercase tracking-wide text-tertiary">
+        {{ t('gantt-unscheduled', { count: unscheduled.length }) }}
+      </div>
+      <button
+        v-for="card in unscheduled"
+        :key="card.id"
+        type="button"
+        class="w-full flex items-center gap-2 px-3 min-h-[44px] text-left border-t border-subtle active:bg-surface-hover"
+        @click="onCardClick?.(card.id)"
+      >
+        <span class="text-[11px] tabular-nums text-tertiary shrink-0">#{{ card.id }}</span>
+        <span class="flex-1 min-w-0 truncate text-[13px] text-primary">{{ card.title }}</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* An inferred start is a guess, not a measurement: hatch the leading edge so a
+   plan does not read as a fact. */
+.nd-inferred-start {
+  border-top-style: dashed;
+}
+</style>

--- a/frontend/src/sync/views/gantt/VerticalTimeline.vue
+++ b/frontend/src/sync/views/gantt/VerticalTimeline.vue
@@ -37,6 +37,14 @@ import { useFluent } from 'fluent-vue'
 import { addDays, differenceInCalendarDays, format, startOfDay, startOfMonth, startOfWeek } from 'date-fns'
 import type { CardData } from '@nosdesk/core/sync/views/types'
 import { splitSchedule, type ScheduledCard } from './rowModel'
+import {
+  GUTTER,
+  assignLanes,
+  canvasWidth,
+  fidelityFor,
+  laneCount as countLanes,
+  laneWidth as widthForLanes,
+} from './verticalLayout'
 import { TERMINAL_CATEGORIES, coarseStatusBucket } from '@nosdesk/core/types/workflow'
 import PriorityIndicator from '@/components/common/PriorityIndicator.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
@@ -52,16 +60,16 @@ const props = withDefaults(defineProps<{
 /** Vertical scale. 36px/day keeps a fortnight on ~500px, which is one
  *  comfortable scroll, and leaves a single-day block tall enough to letter. */
 const PX_PER_DAY = 36
-/** Gutter holding the time ruler. */
-const GUTTER = 48
-/** Minimum spacing between civic marks before the ruler steps up a unit. */
-const MIN_TICK_PX = 44
-/** Fidelity thresholds, in px of column width. */
-const WIDTH_FULL = 132
-const WIDTH_COMPACT = 68
+/** Minimum spacing between civic marks before the ruler steps up a unit. Set
+ *  below PX_PER_DAY so a day-scale window actually gets DAY marks: at 44 the
+ *  ruler stepped straight to weeks and a ten-day window carried two labels,
+ *  leaving nothing to read block heights against. A 10px label needs nowhere
+ *  near 36px of clearance. */
+const MIN_TICK_PX = 30
 
 const rootEl = ref<HTMLElement | null>(null)
 const width = ref(390)
+const viewportHeight = ref(600)
 
 const split = computed(() => splitSchedule(props.cards))
 
@@ -107,48 +115,30 @@ const window_ = computed(() => {
     if (it.end > max) max = it.end
   }
   const start = addDays(startOfDay(min), -1)
-  return { start, days: Math.max(3, differenceInCalendarDays(max, start) + 2) }
+  // Always cover at least a screenful of time. A tight window ended the canvas
+  // two-thirds up the display and left a large blank below it, which reads as a
+  // view that failed to finish loading rather than as a plan that finishes
+  // early. Extending the window keeps the ruler running to the bottom edge.
+  const spanned = differenceInCalendarDays(max, start) + 2
+  const screenful = Math.ceil(viewportHeight.value / PX_PER_DAY)
+  return { start, days: Math.max(3, spanned, screenful) }
 })
 
 const canvasHeight = computed(() => window_.value.days * PX_PER_DAY)
 
-/** Greedy interval partitioning: each ticket takes the first column free at its
- *  start. Column count therefore equals peak concurrency — the exact quantity
- *  this layout is bounded by. */
-const placed = computed(() => {
-  const sorted = [...scheduled.value].sort((a, b) => a.start.getTime() - b.start.getTime())
-  const laneFreeAt: number[] = []
-  const out: Array<{ item: ScheduledCard; lane: number }> = []
-  for (const item of sorted) {
-    let lane = laneFreeAt.findIndex((free) => free <= item.start.getTime())
-    if (lane === -1) {
-      lane = laneFreeAt.length
-      laneFreeAt.push(0)
-    }
-    laneFreeAt[lane] = item.end.getTime()
-    out.push({ item, lane })
-  }
-  return out
-})
+// Lane assignment + the fidelity ladder live in ./verticalLayout as pure
+// functions so the concurrency ceiling can be asserted in a unit test rather
+// than inferred from a screenshot of whatever the data happens to hold.
+const placed = computed(() => assignLanes(scheduled.value))
+const lanes = computed(() => countLanes(placed.value))
+const laneWidth = computed(() => widthForLanes(width.value, lanes.value))
+/** Equals the viewport until concurrency pushes columns onto their legibility
+ *  floor, past which the canvas is wider and the view pans sideways. */
+const canvasW = computed(() => canvasWidth(width.value, lanes.value))
 
-const laneCount = computed(() => Math.max(1, new Set(placed.value.map((p) => p.lane)).size))
-const laneWidth = computed(() => Math.max(18, (width.value - GUTTER - 8) / laneCount.value))
-
-/** Minimum block height that can carry a title without clipping it. */
-const HEIGHT_TITLE = 56
-
-/**
- * mark -> chip -> card, by how much room a block actually got.
- *
- * Keyed on BOTH axes, not just column width. A one-day deadline marker is 36px
- * tall however wide its column is, and a title rendered into it clips
- * mid-word — which is exactly what the first prototype did.
- */
-function fidelityFor(heightPx: number): 'full' | 'compact' | 'mark' {
-  if (heightPx < HEIGHT_TITLE) return 'mark'
-  if (laneWidth.value >= WIDTH_FULL) return 'full'
-  if (laneWidth.value >= WIDTH_COMPACT) return 'compact'
-  return 'mark'
+/** Fidelity for a block, given the room its column and duration give it. */
+function fidelity(heightPx: number): 'full' | 'compact' | 'mark' {
+  return fidelityFor(laneWidth.value, heightPx)
 }
 
 function blockHeight(p: { item: ScheduledCard }): number {
@@ -261,7 +251,11 @@ function onResize(el: HTMLElement | null): void {
   if (!el) return
   rootEl.value = el
   width.value = el.clientWidth
-  new ResizeObserver(() => { width.value = el.clientWidth }).observe(el)
+  viewportHeight.value = el.clientHeight
+  new ResizeObserver(() => {
+    width.value = el.clientWidth
+    viewportHeight.value = el.clientHeight
+  }).observe(el)
 }
 </script>
 
@@ -276,17 +270,25 @@ function onResize(el: HTMLElement | null): void {
       <p class="text-sm text-tertiary max-w-[16rem]">{{ t('gantt-nothing-scheduled') }}</p>
     </div>
 
-    <div v-else class="flex-1 min-h-0 overflow-y-auto overscroll-contain">
+    <!-- Scrolls in both axes, but only one of them is ever unbounded: down is
+         time, across is concurrency and stays put entirely below five parallel
+         tickets. Touch pans a single element diagonally, so no nested scrollers
+         compete for the gesture. -->
+    <div v-else class="flex-1 min-h-0 overflow-auto overscroll-contain">
       <!-- Canvas. Height is proportional to the window's duration, so vertical
-           distance is time; nothing here is a fixed-height row. -->
+           distance is time; nothing here is a fixed-height row. Width is the
+           viewport unless concurrency has outgrown it. -->
       <!-- pb keeps the last block clear of the tab bar and the home indicator. -->
-      <div class="relative pb-16" :style="{ height: `${canvasHeight}px` }">
-        <!-- Weekends. Drawn under the measure so the grid reads as a calendar. -->
+      <div class="relative pb-16" :style="{ height: `${canvasHeight}px`, width: `${canvasW}px` }">
+        <!-- Weekends. Drawn under the measure so the grid reads as a calendar.
+             Banding starts after the gutter: the bands belong to the plotting
+             area, and keeping the ruler a clean strip is what lets its labels
+             stay pinned while the lanes pan under them. -->
         <div
           v-for="w in weekends"
           :key="`w${w.y}`"
-          class="absolute left-0 right-0 bg-strong/[0.045] pointer-events-none"
-          :style="{ top: `${w.y}px`, height: `${w.h}px` }"
+          class="absolute right-0 bg-strong/[0.045] pointer-events-none"
+          :style="{ top: `${w.y}px`, height: `${w.h}px`, left: `${GUTTER}px` }"
         />
 
         <!-- Adaptive civic measure. -->
@@ -296,8 +298,10 @@ function onResize(el: HTMLElement | null): void {
           class="absolute left-0 right-0 flex items-start gap-2"
           :style="{ top: `${tick.y}px` }"
         >
+          <!-- Pinned: the ruler is the reference for everything on the canvas,
+               so panning across concurrency must not take it off-screen. -->
           <span
-            class="w-11 shrink-0 pl-1 text-[10px] tabular-nums leading-none"
+            class="sticky left-0 z-20 w-11 shrink-0 pl-1 py-0.5 bg-surface text-[10px] tabular-nums leading-none"
             :class="tick.strong ? 'text-secondary' : 'text-tertiary'"
           >{{ tick.label }}</span>
           <span
@@ -313,7 +317,7 @@ function onResize(el: HTMLElement | null): void {
           class="absolute right-0 z-10 pointer-events-none flex items-center"
           :style="{ top: `${todayY}px`, left: `${GUTTER - 4}px` }"
         >
-          <span class="h-1.5 w-1.5 rounded-full bg-accent shrink-0" />
+          <span class="sticky left-11 h-1.5 w-1.5 rounded-full bg-accent shrink-0" />
           <span class="flex-1 border-t border-accent/60" />
         </div>
 
@@ -332,7 +336,7 @@ function onResize(el: HTMLElement | null): void {
           :title="`#${p.item.card.id} ${p.item.card.title}`"
           @click="onCardClick?.(p.item.card.id)"
         >
-          <template v-if="fidelityFor(blockHeight(p)) === 'full'">
+          <template v-if="fidelity(blockHeight(p)) === 'full'">
             <div class="px-1.5 py-1 flex flex-col gap-1 h-full">
               <div class="flex items-center gap-1">
                 <span class="text-[10px] tabular-nums text-tertiary">#{{ p.item.card.id }}</span>
@@ -355,7 +359,7 @@ function onResize(el: HTMLElement | null): void {
             </div>
           </template>
 
-          <template v-else-if="fidelityFor(blockHeight(p)) === 'compact'">
+          <template v-else-if="fidelity(blockHeight(p)) === 'compact'">
             <div class="px-1.5 py-1 h-full flex flex-col gap-0.5">
               <span class="text-[10px] tabular-nums text-tertiary">#{{ p.item.card.id }}</span>
               <span class="block text-[11px] leading-tight text-primary line-clamp-4">{{ p.item.card.title }}</span>

--- a/frontend/src/sync/views/gantt/verticalLayout.spec.ts
+++ b/frontend/src/sync/views/gantt/verticalLayout.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { assignLanes, canvasWidth, fidelityFor, laneCount, laneWidth } from './verticalLayout'
+
+const day = (n: number): Date => new Date(2026, 7, 10 + n)
+/** `n` tickets all in flight at once. */
+const overlapping = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ start: day(i % 2), end: day(6 + (i % 3)) }))
+
+const PHONE = 390
+
+describe('assignLanes', () => {
+  it('puts sequential work in one column', () => {
+    const placed = assignLanes([
+      { start: day(0), end: day(2) },
+      { start: day(2), end: day(4) },
+      { start: day(4), end: day(6) },
+    ])
+    expect(laneCount(placed)).toBe(1)
+  })
+
+  it('uses one column per simultaneous ticket', () => {
+    expect(laneCount(assignLanes(overlapping(4)))).toBe(4)
+    expect(laneCount(assignLanes(overlapping(8)))).toBe(8)
+  })
+
+  it('reuses a column as soon as it frees up', () => {
+    // Two overlap, the third starts after the first ends.
+    const placed = assignLanes([
+      { start: day(0), end: day(3) },
+      { start: day(1), end: day(5) },
+      { start: day(3), end: day(6) },
+    ])
+    expect(laneCount(placed)).toBe(2)
+  })
+
+  it('is stable regardless of input order', () => {
+    const items = overlapping(6)
+    const a = laneCount(assignLanes(items))
+    const b = laneCount(assignLanes([...items].reverse()))
+    expect(a).toBe(b)
+  })
+})
+
+/**
+ * The design's load-bearing claim: horizontal gantt is bounded by time span
+ * (90 days will never fit 390px), vertical by concurrency. This pins where
+ * concurrency actually bites on a phone, so the trade is a measured one.
+ */
+describe('concurrency on a 390px phone', () => {
+  const counts = [1, 2, 3, 4, 5, 6, 8, 10, 12, 15]
+  const tiers = counts.map((n) => {
+    const w = laneWidth(PHONE, n)
+    return {
+      n,
+      width: Math.round(w),
+      fidelity: fidelityFor(w, 200),
+      pans: canvasWidth(PHONE, n) > PHONE,
+    }
+  })
+  const at = (n: number) => tiers.find((t) => t.n === n)!
+
+  it('keeps full cards to 2 parallel tickets', () => {
+    expect(tiers.filter((t) => t.fidelity === 'full').map((t) => t.n)).toEqual([1, 2])
+  })
+
+  /**
+   * The load-bearing property. Dividing the viewport by concurrency alone put 5
+   * parallel tickets at 67px, one under what a titled chip needs, and dropped
+   * the WHOLE view to id-only marks; 5 in flight is an ordinary week. The floor
+   * means a block stays readable at any concurrency, so the view never has a
+   * count at which it stops working.
+   */
+  it('stays readable at every concurrency, never falling to marks', () => {
+    expect(tiers.filter((t) => t.fidelity === 'mark')).toEqual([])
+    for (const t of tiers) expect(t.width).toBeGreaterThanOrEqual(80)
+  })
+
+  it('shares the viewport to 4, then holds the floor and pans', () => {
+    expect(at(4)).toMatchObject({ width: 84, pans: false })
+    expect(at(5)).toMatchObject({ width: 80, pans: true })
+    expect(tiers.filter((t) => t.pans).map((t) => t.n)).toEqual([5, 6, 8, 10, 12, 15])
+  })
+
+  it('pans by an amount bounded by concurrency, not by time span', () => {
+    // The horizontal gantt this replaced needed 3737px of canvas for a 90-day
+    // window. Here 8 parallel tickets cost 306px of pan, and the span is free.
+    expect(Math.round(canvasWidth(PHONE, 8) - PHONE)).toBe(306)
+    expect(canvasWidth(PHONE, 4)).toBe(PHONE)
+  })
+})
+
+describe('fidelityFor', () => {
+  it('demotes a short block however wide its column', () => {
+    // A one-day deadline marker is ~36px tall; a title clips mid-word in it.
+    expect(fidelityFor(300, 36)).toBe('mark')
+    expect(fidelityFor(300, 200)).toBe('full')
+  })
+
+  it('demotes a narrow column however tall the block', () => {
+    expect(fidelityFor(40, 400)).toBe('mark')
+  })
+
+  it('is monotonic in width at a readable height', () => {
+    const order = { mark: 0, compact: 1, full: 2 } as const
+    let last = -1
+    for (const w of [20, 68, 100, 132, 300]) {
+      const rank = order[fidelityFor(w, 200)]
+      expect(rank).toBeGreaterThanOrEqual(last)
+      last = rank
+    }
+  })
+})

--- a/frontend/src/sync/views/gantt/verticalLayout.ts
+++ b/frontend/src/sync/views/gantt/verticalLayout.ts
@@ -1,0 +1,95 @@
+/**
+ * Vertical-timeline geometry, as pure functions.
+ *
+ * Extracted from the component so the load-bearing claim of the design can be
+ * asserted rather than eyeballed: a horizontal gantt is bounded by TIME SPAN,
+ * the vertical one by CONCURRENCY, and the whole approach only holds if
+ * concurrency degrades gracefully. That is a property of these two functions,
+ * so they are tested directly at 2, 4, 8 and 15 parallel tickets instead of
+ * being inferred from a screenshot of whatever the demo data happens to hold.
+ */
+
+/** Gutter holding the time ruler. */
+export const GUTTER = 48
+/** Fidelity thresholds, in px of column width. */
+export const WIDTH_FULL = 132
+export const WIDTH_COMPACT = 68
+/** Minimum block height that can carry a title without clipping it. */
+export const HEIGHT_TITLE = 56
+/**
+ * Legibility floor for a column.
+ *
+ * Set just under the width four lanes get on a 390px phone, so four still share
+ * the viewport exactly and the floor only binds from five. Dividing by concurrency
+ * alone put five parallel tickets at 67px and dropped the ENTIRE view to
+ * id-only marks, and five in flight is an ordinary week rather than an edge
+ * case. Past this point concurrency scrolls sideways instead of shrinking.
+ *
+ * The two-axis scroll this introduces is what the horizontal gantt was rejected
+ * for, but the shape is inverted: there the unbounded axis (90 days, 3737px)
+ * was the one you had to pan; here panning is bounded by concurrency, capped by
+ * how much work can genuinely be in flight, and does not happen at all below
+ * five.
+ */
+export const MIN_LANE_PX = 80
+
+export interface Span {
+  start: Date
+  end: Date
+}
+
+/**
+ * Greedy interval partitioning: each item takes the first column free at its
+ * start. The resulting column count is exactly peak concurrency, which is the
+ * quantity this layout is bounded by.
+ */
+export function assignLanes<T extends Span>(items: readonly T[]): Array<{ item: T; lane: number }> {
+  const sorted = [...items].sort((a, b) => a.start.getTime() - b.start.getTime())
+  const laneFreeAt: number[] = []
+  const out: Array<{ item: T; lane: number }> = []
+  for (const item of sorted) {
+    let lane = laneFreeAt.findIndex((free) => free <= item.start.getTime())
+    if (lane === -1) {
+      lane = laneFreeAt.length
+      laneFreeAt.push(0)
+    }
+    laneFreeAt[lane] = item.end.getTime()
+    out.push({ item, lane })
+  }
+  return out
+}
+
+/** Peak concurrency, i.e. how many columns the layout needs. */
+export function laneCount(placed: ReadonlyArray<{ lane: number }>): number {
+  return Math.max(1, new Set(placed.map((p) => p.lane)).size)
+}
+
+/**
+ * Width each column gets on a viewport of `viewportPx`.
+ *
+ * Columns share the viewport until sharing would take them below the legibility
+ * floor, after which they hold that width and the canvas grows past the
+ * viewport. Callers must size the canvas with `canvasWidth`, not the viewport.
+ */
+export function laneWidth(viewportPx: number, lanes: number): number {
+  return Math.max(MIN_LANE_PX, (viewportPx - GUTTER - 8) / Math.max(1, lanes))
+}
+
+/** Total canvas width. Exceeds the viewport exactly when concurrency has pushed
+ *  columns onto the legibility floor, which is what makes it pan sideways. */
+export function canvasWidth(viewportPx: number, lanes: number): number {
+  return Math.max(viewportPx, GUTTER + lanes * laneWidth(viewportPx, lanes) + 8)
+}
+
+/**
+ * mark -> chip -> card, by how much room a block actually got.
+ *
+ * Keyed on BOTH axes. A one-day deadline marker is ~36px tall however wide its
+ * column is, and a title rendered into it clips mid-word.
+ */
+export function fidelityFor(widthPx: number, heightPx: number): 'full' | 'compact' | 'mark' {
+  if (heightPx < HEIGHT_TITLE) return 'mark'
+  if (widthPx >= WIDTH_FULL) return 'full'
+  if (widthPx >= WIDTH_COMPACT) return 'compact'
+  return 'mark'
+}

--- a/frontend/src/views/ProjectGanttView.vue
+++ b/frontend/src/views/ProjectGanttView.vue
@@ -21,6 +21,8 @@ import { useListDensity } from '@/composables/useTicketsDensity'
 import { useProjectDependencies } from '@/composables/useProjectDependencies'
 import { getCategoryLabel, WORKFLOW_CATEGORIES } from '@nosdesk/core/types/workflow'
 import GanttBoard from '@/sync/views/gantt/GanttBoard.vue'
+import VerticalTimeline from '@/sync/views/gantt/VerticalTimeline.vue'
+import { useMobileDetection } from '@/composables/useMobileDetection'
 import type { ScheduledCard } from '@/sync/views/gantt/rowModel'
 import GanttToolbar from '@/components/views/GanttToolbar.vue'
 import ProjectTabBar from '@/components/views/ProjectTabBar.vue'
@@ -61,6 +63,8 @@ const cycleOrder = computed(() => {
   )
   return new Map(sorted.map((c, i) => [`cycle:${c.id}`, i]))
 })
+
+const { isMobile } = useMobileDetection('md')
 
 const grouping = useListGrouping<ScheduledCard>({
   storageNamespace: 'gantt',
@@ -150,12 +154,17 @@ function reschedule(
   void ticketsStore.patchKanbanFields(cardId, patch)
 }
 
-const headerSubtitle = computed(() =>
-  t('gantt-tickets-of-total-in-view', {
+const headerSubtitle = computed(() => {
+  // `visibleCount` counts bars inside the HORIZONTAL viewport's scroll window.
+  // The vertical timeline has no such window — it lays every scheduled ticket
+  // out down the page — so the counter reported "0 of 4 in view" while four
+  // were plainly on screen. Below `md` report the plain total instead.
+  if (isMobile.value) return t('gantt-tickets-total', { count: cards.value.length })
+  return t('gantt-tickets-of-total-in-view', {
     count: cards.value.length,
     visible: viewport.visibleCount.value,
-  }),
-)
+  })
+})
 </script>
 
 <template>
@@ -172,6 +181,7 @@ const headerSubtitle = computed(() =>
     <ProjectTabBar :project-id="projectId">
       <template #actions>
         <GanttToolbar
+        v-if="!isMobile"
           :viewport="viewport"
           :grouping="grouping"
           :density="density"
@@ -194,7 +204,19 @@ const headerSubtitle = computed(() =>
       >{{ t('gantt-retry') }}</button>
     </div>
 
+    <!-- Below `md` the gantt transposes: time runs down and concurrent tickets
+         become columns. A horizontal gantt is bounded by time span, which no
+         phone can satisfy (3737px of canvas in 390px); the vertical form is
+         bounded by concurrency instead, and puts the unbounded axis on the one
+         the device scrolls naturally. See docs/plans/gantt-mobile-research.md. -->
+    <VerticalTimeline
+      v-if="isMobile"
+      class="flex-1 min-h-0"
+      :cards="cards"
+      :on-card-click="openCard"
+    />
     <GanttBoard
+      v-else
       class="flex-1 min-h-0"
       :cards="cards"
       :edges="edges"

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -6165,6 +6165,8 @@ gantt-pan-next = Pan later
 gantt-more-controls = More controls
 gantt-unscheduled = Unscheduled ({ $count })
 gantt-nothing-scheduled = Nothing is scheduled yet. Set a due date to place tickets on the timeline.
+# Date line on a vertical-timeline block that has only a deadline, no planned span.
+gantt-due-short = Due { $date }
 gantt-empty-title = No tickets on the timeline yet
 gantt-empty-description = Tickets with a due date show up here, laid out across time. Add one from the board to get started.
 gantt-hover-dates = Dates
@@ -6523,6 +6525,12 @@ gantt-tickets-of-total-in-view =
     { $count ->
         [one] { $visible } of { $count } ticket in view
        *[other] { $visible } of { $count } tickets in view
+    }
+# Vertical timeline (mobile) has no scroll window, so it reports a plain total.
+gantt-tickets-total =
+    { $count ->
+        [one] { $count } ticket
+       *[other] { $count } tickets
     }
 saved-view-name-this = Name this view
 saved-view-copy-suffix = { $name } copy

--- a/i18n/locales/fr-FR/main.ftl
+++ b/i18n/locales/fr-FR/main.ftl
@@ -5992,6 +5992,8 @@ gantt-pan-next = Décaler vers la droite
 gantt-more-controls = Plus de commandes
 gantt-unscheduled = Non planifiés ({ $count })
 gantt-nothing-scheduled = Rien n'est encore planifié. Définissez une échéance pour placer les tickets sur la chronologie.
+# Ligne de date sur un bloc de chronologie verticale (machine, à relire par un locuteur natif).
+gantt-due-short = Échéance { $date }
 # État vide de la chronologie (machine, à relire par un locuteur natif).
 gantt-empty-title = Aucun ticket sur la chronologie pour l'instant
 gantt-empty-description = Les tickets avec une date d'échéance apparaissent ici, répartis dans le temps. Ajoutez-en un depuis le tableau pour commencer.
@@ -6355,6 +6357,12 @@ gantt-tickets-of-total-in-view =
     { $count ->
         [one] { $visible } sur { $count } ticket affiché
        *[other] { $visible } sur { $count } tickets affichés
+    }
+# Total simple pour la chronologie verticale (machine, à relire par un locuteur natif).
+gantt-tickets-total =
+    { $count ->
+        [one] { $count } ticket
+       *[other] { $count } tickets
     }
 saved-view-name-this = Nommer cette vue
 saved-view-copy-suffix = Copie de { $name }

--- a/i18n/locales/nl-NL/main.ftl
+++ b/i18n/locales/nl-NL/main.ftl
@@ -5983,6 +5983,8 @@ gantt-pan-next = Naar rechts schuiven
 gantt-more-controls = Meer instellingen
 gantt-unscheduled = Niet gepland ({ $count })
 gantt-nothing-scheduled = Er is nog niets gepland. Stel een vervaldatum in om tickets op de tijdlijn te plaatsen.
+# Datumregel op een verticaal tijdlijnblok (machinevertaling, nog na te kijken door een moedertaalspreker).
+gantt-due-short = Deadline { $date }
 # Lege staat van de tijdlijn (machine, na te kijken door moedertaalspreker).
 gantt-empty-title = Nog geen tickets op de tijdlijn
 gantt-empty-description = Tickets met een vervaldatum verschijnen hier, uitgezet in de tijd. Voeg er een toe vanuit het bord om te beginnen.
@@ -6347,6 +6349,12 @@ gantt-tickets-of-total-in-view =
     { $count ->
         [one] { $visible } van { $count } ticket zichtbaar
        *[other] { $visible } van { $count } tickets zichtbaar
+    }
+# Eenvoudig totaal voor de verticale tijdlijn (machinevertaling, nog na te kijken).
+gantt-tickets-total =
+    { $count ->
+        [one] { $count } ticket
+       *[other] { $count } tickets
     }
 saved-view-name-this = Geef deze weergave een naam
 saved-view-copy-suffix = Kopie van { $name }


### PR DESCRIPTION
Below `md`, the gantt transposes: time runs down the screen and concurrent
tickets become columns.

## Why transpose rather than shrink

A horizontal gantt is bounded by **time span**, and a 90-day window needs
3737px of canvas that no phone has. Shrinking the day scale until it fits makes
bars unreadable; an agenda list fits but throws away simultaneity, which is the
only thing a gantt is for.

Vertical is bounded by **concurrency** instead, how many tickets are in flight
at one moment, and puts the unbounded axis (time) on the one the device already
scrolls. This is the mobile calendar day-view pattern: a ticket with
start to due is structurally an event with start to end, and nobody has to be
taught to read it.

## The concurrency claim, tested

That claim is load-bearing, so it is asserted rather than eyeballed. Lane
assignment and the fidelity ladder live in `verticalLayout.ts` as pure
functions the component consumes, with 11 unit tests covering 1 through 15
parallel tickets on a 390px viewport.

The test found a real defect. Dividing the viewport by concurrency alone gave
5 parallel tickets 67px per column, one pixel under what a titled chip needs,
which dropped the **entire** view to id-only marks. Five in flight is an
ordinary week.

Columns now have an 80px legibility floor. Below 5, they share the viewport
exactly as before and nothing pans. At 5 and above they hold the floor and the
canvas grows past the viewport, so the concurrency axis pans sideways. That is
the inverse of what the horizontal gantt was rejected for: there you had to pan
the unbounded axis; here panning is bounded by how much work can genuinely be
in flight, and costs 306px at 8 lanes while the time span stays free.

## Design details

- **Proportional flow.** Block height is duration, so vertical distance is
  time. This is what separates a timeline from an agenda list.
- **Adaptive measure.** Civic marks resolve to the coarsest unit the scale can
  carry legibly: days, then weeks, then months.
- **Fidelity ladder.** mark to titled chip to full card, keyed on both axes.
  A one-day deadline marker is 36px tall however wide its column, and a title
  rendered into it clips mid-word.
- **Precision is provenance.** `spanOf` fills a missing `start_date` from
  `created_at`, so a ticket raised two months ago and due next week drew as a
  two-month plan, a guess with the confidence of a fact. Without an authored
  start we know the deadline, not the span, so it renders as a day-tall marker.
  This is also what makes the window usable: one such ticket previously
  stretched it to 58 days.
- **Terminal tickets get no bar.** `spanOf` gives them `created_at` to
  `closed_at`, which is a record of how long something sat open, not a plan.
  One cancelled ticket open six weeks stretched the window to six weeks.
  Desktop survives this because you can zoom out; this view cannot.
- Ruler labels are `sticky`, so the time reference stays on screen through a
  pan. Weekend bands start after the gutter to keep that strip clean.
- The window always covers at least a screenful, so the canvas reaches the
  bottom edge instead of stopping two-thirds up and reading as half-loaded.

## Verification

Rendered at 390px against a project with 6 concurrent tickets: 6 lanes at 80px,
canvas 536px against a 390px viewport, panning correctly, ruler holding x=0
through a full pan, no page-level horizontal overflow.

## Not in this PR

Cycles as shaded bands, and rescheduling from the vertical view. Desktop has
bar drag; mobile is currently read-only.
