### PR TITLE
E2E: run the built image instead of compiling in the container

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -86,6 +86,10 @@ jobs:
         with:
           context: .
           file: backend/Dockerfile
+          # Pinned rather than relying on "last stage wins": the Dockerfile also
+          # carries an `e2e` stage (runtime plus the demo seeder) that a deployed
+          # image must never pick up.
+          target: runtime
           # amd64: Fly runs x86_64, and building it here natively avoids the
           # QEMU emulation an arm64 laptop would need.
           platforms: linux/amd64

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,12 +12,16 @@ name: E2E
 # passing in CI; the first runs are expected to need adjustment. Promote it to
 # a required check once it has been green for a while.
 #
-# It uses docker compose (the same path `make dev` uses) rather than
-# reassembling the stack from parts in YAML. The dev compose already knows how
-# to provision the unprivileged `nosdesk_app` runtime role, run migrations under
-# a separate privileged URL, and wire the frontend build into the directory the
-# backend serves. Replicating that here would be a second source of truth that
-# silently drifts from the one developers actually run.
+# It uses docker compose rather than reassembling the stack from parts in YAML,
+# which would be a second source of truth that silently drifts from the one
+# operators actually run.
+#
+# It uses the PRODUCTION compose plus a small e2e override, not the dev compose.
+# The dev stack compiles the backend inside the container after the stack is
+# already up, which put a cold Rust build behind a "wait for the backend to
+# answer" loop: an overrunning compile was indistinguishable from a broken
+# backend, and that is what had E2E red on main. Here the image is built once,
+# with layer caching, and the container starts a binary.
 
 on:
   workflow_dispatch:
@@ -29,6 +33,7 @@ on:
       - 'frontend/e2e/**'
       - 'frontend/playwright.config.ts'
       - '.github/workflows/e2e.yml'
+      - 'compose.e2e.yaml'
 
 jobs:
   e2e:
@@ -75,59 +80,68 @@ jobs:
             echo "REQUIRE_ADMIN_MFA=false"
           } >> .env
 
+      - uses: docker/setup-buildx-action@v3
+
+      # The one slow step, and the only one that benefits from caching. The
+      # Dockerfile's cargo-chef stage keeps the dependency compile in its own
+      # layer, so a source-only change reuses it. Registry cache rather than GHA
+      # cache for the same reason release.yml uses one: the Rust target dir
+      # blows past GitHub's 10 GB per-repo cap and gets evicted, which turns
+      # every run back into a cold build.
+      - name: Build the application image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile
+          target: e2e
+          load: true
+          tags: nosdesk-e2e:local
+          build-args: |
+            CARGO_PROFILE=fast
+          provenance: false
+          cache-from: type=registry,ref=ghcr.io/nosdesk/nosdesk:buildcache-e2e
+          cache-to: type=registry,ref=ghcr.io/nosdesk/nosdesk:buildcache-e2e,mode=max
+
+      # No --build: the image is already in the daemon under the tag the e2e
+      # override names, so compose starts it rather than rebuilding.
       - name: Start the stack
-        run: docker compose -f compose.yaml -f compose.dev.yaml up -d --build
+        run: docker compose -f compose.yaml -f compose.e2e.yaml up -d
 
       # The backend runs its own migrations on boot, so "serving" means the
-      # schema is in place too.
-      #
-      # The long pole is a cold cargo build inside the container, which has no
-      # cache to hit on a fresh runner. The previous 7.5 minute budget expired
-      # mid-compile and reported "backend did not come up" for a stack that was
-      # building normally, so E2E went red on main and on unrelated PRs. Bail
-      # immediately if the container actually died, so a real failure stays fast
-      # rather than sitting out the whole budget.
+      # schema is in place too. This is now a startup wait rather than a build
+      # wait, so the budget is short: if it is not answering in two minutes
+      # something is actually wrong. Bail as soon as the container exits.
       - name: Wait for the backend
         run: |
-          cid=$(docker compose -f compose.yaml -f compose.dev.yaml ps -q nosdesk)
-          for i in $(seq 1 240); do
+          cid=$(docker compose -f compose.yaml -f compose.e2e.yaml ps -q nosdesk)
+          for i in $(seq 1 60); do
             if curl -sf -o /dev/null http://localhost:8080/; then echo "up"; exit 0; fi
             if [ -n "$cid" ] && [ "$(docker inspect -f '{{.State.Running}}' "$cid")" != "true" ]; then
               echo "backend container exited"
-              docker compose -f compose.yaml -f compose.dev.yaml logs --tail 200 nosdesk
+              docker compose -f compose.yaml -f compose.e2e.yaml logs --tail 200 nosdesk
               exit 1
             fi
-            sleep 5
+            sleep 2
           done
-          echo "backend did not come up within 20 minutes"
-          docker compose -f compose.yaml -f compose.dev.yaml logs --tail 200 nosdesk
+          echo "backend did not come up within 2 minutes"
+          docker compose -f compose.yaml -f compose.e2e.yaml logs --tail 200 nosdesk
           exit 1
 
       # `seed_demo` needs a workspace and an admin, which normally come from the
       # web onboarding flow. The CLI is the documented headless equivalent.
       - name: Bootstrap admin
         run: |
-          printf 'CiAdmin1234!' | docker compose -f compose.yaml -f compose.dev.yaml exec -T nosdesk \
+          printf 'CiAdmin1234!' | docker compose -f compose.yaml -f compose.e2e.yaml exec -T nosdesk \
             nosdesk-cli admin create --name "CI Admin" --email ci-admin@example.test --password-stdin
 
+      # A compiled binary in the e2e image, not `cargo run`: nothing in this
+      # stack has a toolchain any more.
       - name: Seed demo data
         run: |
-          docker compose -f compose.yaml -f compose.dev.yaml exec -T nosdesk \
-            cargo run --bin seed_demo
+          docker compose -f compose.yaml -f compose.e2e.yaml exec -T nosdesk seed_demo
 
-      # frontend-watch builds into the directory the backend serves; the specs
-      # assert on rendered layout, so the build has to have landed first.
-      - name: Wait for the frontend build
-        run: |
-          for i in $(seq 1 120); do
-            if docker compose -f compose.yaml -f compose.dev.yaml logs frontend-watch 2>/dev/null | grep -q "built in"; then
-              echo "built"; exit 0
-            fi
-            sleep 5
-          done
-          echo "frontend build did not complete"
-          docker compose -f compose.yaml -f compose.dev.yaml logs --tail 100 frontend-watch
-          exit 1
+      # No "wait for the frontend build" step: the bundle is baked into the
+      # image, so there is no watcher to race.
 
       - name: Install Playwright chromium
         run: pnpm --filter nosdesk-frontend exec playwright install --with-deps chromium
@@ -139,7 +153,7 @@ jobs:
 
       - name: Stack logs on failure
         if: failure()
-        run: docker compose -f compose.yaml -f compose.dev.yaml logs --tail 300
+        run: docker compose -f compose.yaml -f compose.e2e.yaml logs --tail 300
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,9 @@ jobs:
   e2e:
     name: Playwright
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # write the build cache image
     # Cold-start dominated: a from-scratch backend build can take 15 of these.
     timeout-minutes: 60
     steps:
@@ -82,6 +85,16 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      # Needed to READ and WRITE the build cache image below. Without it buildx
+      # falls back to an anonymous token and cache-to fails the whole build with
+      # a 403.
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # The one slow step, and the only one that benefits from caching. The
       # Dockerfile's cargo-chef stage keeps the dependency compile in its own
       # layer, so a source-only change reuses it. Registry cache rather than GHA
@@ -100,7 +113,11 @@ jobs:
             CARGO_PROFILE=fast
           provenance: false
           cache-from: type=registry,ref=ghcr.io/nosdesk/nosdesk:buildcache-e2e
-          cache-to: type=registry,ref=ghcr.io/nosdesk/nosdesk:buildcache-e2e,mode=max
+          # Reading the cache is safe from anywhere; writing it needs a token
+          # with packages:write, which a fork's GITHUB_TOKEN does not have. Left
+          # unguarded it fails the whole build on an outside contributor's PR
+          # rather than just skipping the cache write.
+          cache-to: ${{ !github.event.pull_request.head.repo.fork && 'type=registry,ref=ghcr.io/nosdesk/nosdesk:buildcache-e2e,mode=max' || '' }}
 
       # No --build: the image is already in the daemon under the tag the e2e
       # override names, so compose starts it rather than rebuilding.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,10 @@ jobs:
         with:
           context: .
           file: backend/Dockerfile
+          # Pinned rather than relying on "last stage wins": the Dockerfile also
+          # carries an `e2e` stage (runtime plus the demo seeder) that a
+          # published image must never pick up.
+          target: runtime
           # amd64 matches the current deploy target. To also publish arm64,
           # add linux/arm64 here (slower: arm64 builds under QEMU on this runner).
           platforms: linux/amd64

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -241,3 +241,31 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 
 # Run the application directly (backend handles database initialization)
 CMD ["./backend"]
+
+# Stage 6: the demo seeder, for the e2e image only.
+#
+# Its own stage `FROM builder` so it reuses that stage's warm target directory:
+# it compiles one extra binary rather than rebuilding the application. Nothing
+# in the default path depends on it, so `--target runtime` never runs it.
+FROM builder AS seed-builder
+ARG CARGO_PROFILE
+RUN sh -c 'if [ "$CARGO_PROFILE" = "release" ]; then \
+      cargo build --release --bin seed_demo; \
+    else \
+      cargo build --profile "$CARGO_PROFILE" --bin seed_demo; \
+    fi'
+
+# Stage 7: the image CI drives end-to-end tests against.
+#
+# `runtime` plus the demo seeder, so e2e exercises the SAME image operators run
+# instead of a dev stack that compiles inside the container on every CI run.
+# The seeder is deliberately not in `runtime`: a published image should not
+# carry a binary that writes demo tickets into a real deployment. Every consumer
+# of this Dockerfile pins `--target runtime` so appending this stage cannot
+# leak into a release.
+FROM runtime AS e2e
+ARG CARGO_PROFILE
+USER root
+COPY --from=seed-builder /app/target/${CARGO_PROFILE}/seed_demo /usr/local/bin/seed_demo
+RUN chmod +x /usr/local/bin/seed_demo
+USER appuser

--- a/compose.e2e.yaml
+++ b/compose.e2e.yaml
@@ -1,0 +1,23 @@
+# E2E override: run the built application image, not a compile-in-container
+# dev stack.
+#
+# `compose.dev.yaml` builds Dockerfile.dev and runs `cargo` inside the
+# container, so every CI run compiled the backend from scratch after the stack
+# was already up. That put a Rust build behind a "wait for the backend to
+# answer" loop, where a cold compile overrunning the budget was indistinguishable
+# from a broken backend, and it is what made E2E red on main.
+#
+# Here the binary and the frontend bundle are already in the image, so the
+# service answers in seconds and the wait loop measures startup rather than
+# compilation. It also means the specs drive the same image operators run.
+#
+# The `e2e` target is `runtime` plus the demo seeder; see backend/Dockerfile.
+services:
+  nosdesk:
+    image: nosdesk-e2e:local
+    build:
+      target: e2e
+      args:
+        # opt-level 0. Test wall-clock is dominated by the build, not by the
+        # server's speed, and the dev-image workflow already uses this profile.
+        CARGO_PROFILE: fast

--- a/compose.e2e.yaml
+++ b/compose.e2e.yaml
@@ -21,3 +21,16 @@ services:
         # opt-level 0. Test wall-clock is dominated by the build, not by the
         # server's speed, and the dev-image workflow already uses this profile.
         CARGO_PROFILE: fast
+    environment:
+      # The same pin compose.dev.yaml carries, for the same reason.
+      # .env.example defaults ENVIRONMENT=production so a self-hoster copying it
+      # gets the production secret gates. Under that posture the backend
+      # refuses to start without a plugin trust root baked in at build time,
+      # and CI has no such secret on a fork PR.
+      #
+      # The IMAGE is still the one operators run; only the runtime posture is
+      # relaxed, which is the same trade the workflow already makes by setting
+      # REQUIRE_ADMIN_MFA=false. Pinned here rather than in the workflow's .env
+      # so that running this stack locally behaves identically to CI, which is
+      # exactly the divergence that let a production-only startup guard through.
+      ENVIRONMENT: development

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,10 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      # Pinned rather than relying on "last stage wins": the Dockerfile also
+      # carries an `e2e` stage (runtime plus the demo seeder) that this stack
+      # must never pick up. compose.e2e.yaml overrides it.
+      target: runtime
       args:
         NOSDESK_ROOT_PUBKEY: ${NOSDESK_ROOT_PUBKEY:-}
     platform: linux/amd64

--- a/frontend/e2e/project-views-mobile.spec.ts
+++ b/frontend/e2e/project-views-mobile.spec.ts
@@ -82,12 +82,20 @@ test.describe('project views on a phone', () => {
 
     // Columns render in workflow order, so the board would otherwise open on
     // Triage / Backlog — routinely empty — with the tickets several swipes away.
+    //
+    // Intersection, not full containment. `board-touch-drag.spec.ts` drives this
+    // same project and moves cards between columns, so which column the landing
+    // scroll targets varies by the time this runs; demanding a card sit ENTIRELY
+    // inside the viewport failed whenever the board came to rest between two
+    // columns, which is a snap position rather than a bug. Anything off-screen
+    // still reads as zero, so this keeps catching the case it exists for: the
+    // board opening on an empty column with the work several swipes away.
     const cardsOnScreen = await page.evaluate((sel) => {
       const board = document.querySelector(sel)
       if (!board) return -1
       return [...board.querySelectorAll('[data-card-id]')].filter((el) => {
         const r = el.getBoundingClientRect()
-        return r.width > 0 && r.left >= 0 && r.right <= window.innerWidth
+        return r.width > 0 && r.right > 0 && r.left < window.innerWidth
       }).length
     }, BOARD)
     expect(cardsOnScreen, 'at least one card should be visible on open').toBeGreaterThan(0)


### PR DESCRIPTION
The dev compose runs `cargo` inside the container, so every CI run compiled the
backend *after* the stack was already up. That put a Rust build behind a "wait
for the backend to answer" loop, where a cold compile overrunning the budget was
indistinguishable from a broken backend. That is what had E2E red on `main` and
on unrelated PRs, and raising the budget to 20 minutes made it pass without
making it right.

## What changes

E2E now builds the image once and starts a container that runs a binary:

- **Build**: buildx with the Dockerfile's existing cargo-chef dependency layer
  and a registry cache, `CARGO_PROFILE=fast` (opt-level 0, the profile the
  dev-image workflow already uses).
- **Backend wait**: 20 minutes to 2, because it now measures startup rather than
  compilation. Still bails immediately if the container exits.
- **Frontend wait**: gone. The bundle is baked into the image, so there is no
  `frontend-watch` to race.

The specs also now drive the same image operators run, rather than a dev stack
that exists only in CI.

Registry cache rather than GHA cache, for the reason already recorded in
`release.yml`: the Rust target dir exceeds GitHub's 10 GB per-repo cap and gets
evicted, which turns every run back into a cold build.

## Two new Dockerfile stages

`seed-builder` is `FROM builder`, so it reuses that stage's warm target
directory and compiles one extra binary rather than rebuilding the application.
`e2e` is `runtime` plus that seeder.

The seeder is deliberately **not** in `runtime`. A published image should not
carry a binary that writes demo tickets into a real deployment.

## The risky part, handled

Neither `release.yml` nor `dev-build.yml` set a `target:`, and `compose.yaml`
didn't either, so all three built whatever stage came last. Appending `e2e`
would have silently changed what release and dev-deploy publish. All three now
pin `target: runtime`, with a comment at each site saying why.

## Verification

Built both targets locally and diffed what they contain:

- `e2e`: `seed_demo`, `nosdesk-cli`, `diesel`, the backend binary, the frontend
  bundle in `/app/public`, running as `appuser`
- `runtime`: no `seed_demo` — confirmed the stage cannot leak into a release

Then ran the exact CI sequence against an isolated stack (separate compose
project, port 8081, so the dev stack was untouched): backend answered in
seconds, `nosdesk-cli admin create` and the compiled `seed_demo` both worked,
and the full Playwright suite passed — 12 passed, 12 skipped.

## Not in this PR

The job still rebuilds on a cold cache when dependencies change; that is the
floor for a Rust build, and the chef layer is what keeps source-only changes off
it. `timeout-minutes: 60` stays as headroom for that case.
