### PR TITLE
Mobile project views: open the timeline on the work, and a colour/logging cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ google-services.json
 # Playwright e2e artifacts (frontend/)
 test-results/
 playwright-report/
+
+# Playwright saved auth session (live cookies)
+frontend/playwright/.auth/

--- a/backend/seeds/demo.json
+++ b/backend/seeds/demo.json
@@ -111,7 +111,7 @@
       "title": "Outlook not syncing shared mailbox after migration",
       "body_md": "The `ops@` shared mailbox stopped syncing in Outlook after we moved to 365. New mail only shows up on the web, not the desktop app. Removing and re-adding the account didn't help.",
       "category": "Bug", "priority": "high", "state_category": "active",
-      "requester": "noah", "assignee": "priya", "project": "m365", "cycle": "m365_rollout", "device": "lt0052", "created_days_ago": 4,
+      "requester": "noah", "assignee": "priya", "project": "m365", "cycle": "m365_rollout", "device": "lt0052", "start_in_days": -3, "due_in_days": 4, "created_days_ago": 4,
       "comments": [
         { "author": "priya", "body": "Automapping is stale post-migration. I'll remove the auto-mapped entry and re-add the mailbox manually - that usually forces a clean resync.", "minutes_after": 200 }
       ]
@@ -149,7 +149,7 @@
       "title": "Wi-Fi dead zone in Building B kitchen",
       "body_md": "No usable Wi-Fi in the Building B kitchen and breakout area. Signal drops to nothing about halfway down the corridor. Several people can't take calls there.",
       "category": "Bug", "priority": "medium", "state_category": "active",
-      "requester": "noah", "assignee": "tom", "device": "ap_b2k", "project": "network", "cycle": "net_install", "created_days_ago": 6,
+      "requester": "noah", "assignee": "tom", "device": "ap_b2k", "project": "network", "cycle": "net_install", "start_in_days": -1, "due_in_days": 6, "created_days_ago": 6,
       "comments": [
         { "author": "tom", "body": "Survey confirmed the gap. New AP (NET-APB2K) is on order for the kitchen; cabling run scheduled with the install wave.", "minutes_after": 240, "internal": true }
       ]
@@ -217,7 +217,7 @@
       "title": "OneDrive sync errors after migration",
       "body_md": "OneDrive shows a red X and 'sync pending' on dozens of files since the rollout. Some documents won't open because they're 'still uploading'.",
       "category": "Bug", "priority": "medium", "state_category": "active",
-      "requester": "grace", "assignee": "priya", "project": "m365", "cycle": "m365_rollout", "device": "lt0051", "created_days_ago": 5,
+      "requester": "grace", "assignee": "priya", "project": "m365", "cycle": "m365_rollout", "device": "lt0051", "start_in_days": -1, "due_in_days": 9, "created_days_ago": 5,
       "comments": [
         { "author": "priya", "body": "A few filenames have characters 365 rejects (colons and trailing spaces). I'll send a list to rename, then reset the sync client.", "minutes_after": 340 }
       ]
@@ -316,7 +316,7 @@
       "title": "Switch B-1 port flapping - network drops in Building B",
       "body_md": "Building B keeps losing network for 10-20 seconds at a time, several times an hour. Affects everyone on that floor. Started yesterday afternoon.",
       "category": "Bug", "priority": "urgent", "state_category": "active",
-      "requester": "noah", "assignee": "tom", "device": "sw_b1", "project": "network", "cycle": "net_install", "created_days_ago": 2,
+      "requester": "noah", "assignee": "tom", "device": "sw_b1", "project": "network", "cycle": "net_install", "start_in_days": -2, "due_in_days": 5, "created_days_ago": 2,
       "comments": [
         { "author": "tom", "body": "Uplink port on Switch B-1 is flapping - logs show link up/down every few minutes. Moving the uplink to a spare port now and will replace the SFP.", "minutes_after": 40 },
         { "author": "noah", "body": "Much better since lunchtime, no drops so far.", "minutes_after": 480 },
@@ -336,7 +336,7 @@
       "title": "SharePoint permissions wrong after migration",
       "body_md": "After the rollout, the whole Sales team can see the Deals Confidential SharePoint library. It should be restricted to directors only. This is sensitive - please fix urgently.",
       "category": "Bug", "priority": "high", "state_category": "active",
-      "requester": "liam", "assignee": "priya", "project": "m365", "cycle": "m365_rollout", "created_days_ago": 6,
+      "requester": "liam", "assignee": "priya", "project": "m365", "cycle": "m365_rollout", "start_in_days": 2, "due_in_days": 11, "created_days_ago": 6,
       "comments": [
         { "author": "priya", "body": "Confirmed - broken inheritance during migration re-granted the parent group. I've removed the inherited access and restored the directors-only permission. Auditing who accessed it in the window.", "minutes_after": 70 },
         { "author": "elena", "body": "Access logs show no downloads by non-directors during the exposure window. Documenting for the security record.", "minutes_after": 300, "internal": true }
@@ -416,7 +416,7 @@
       "title": "Cannot print to Building B printers over VPN",
       "body_md": "When I'm on VPN from home I can't see or print to any Building B printers. In the office it's fine. Several of the Ops team have the same issue.",
       "category": "Bug", "priority": "medium", "state_category": "active",
-      "requester": "noah", "assignee": "tom", "project": "network", "created_days_ago": 4,
+      "requester": "noah", "assignee": "tom", "project": "network", "start_in_days": 0, "due_in_days": 8, "created_days_ago": 4,
       "comments": [
         { "author": "tom", "body": "The print subnet isn't in the split-tunnel routes for the VPN. I'll add the Building B print range to the profile.", "minutes_after": 280 }
       ]
@@ -452,7 +452,7 @@
       "title": "Slow file transfers to Building B server",
       "body_md": "Copying files to the Building B file server is crawling - a 500 MB folder takes 20+ minutes. From Building A it's fine.",
       "category": "Bug", "priority": "medium", "state_category": "backlog",
-      "requester": "noah", "project": "network", "created_days_ago": 20
+      "requester": "noah", "project": "network", "due_in_days": 12, "created_days_ago": 20
     },
     {
       "title": "Request: onboarding checklist automation",

--- a/backend/src/bin/seed_demo.rs
+++ b/backend/src/bin/seed_demo.rs
@@ -123,6 +123,18 @@ struct DemoTicket {
     #[serde(default)]
     device: Option<String>,
     created_days_ago: i64,
+    /// Planned span, relative to seed time and signed the natural way round:
+    /// negative is in the past, positive in the future. Both optional and
+    /// independent — `due_in_days` alone is a deadline with no planned start,
+    /// which the timeline draws as a day-tall marker rather than a bar.
+    ///
+    /// Only meaningful on non-terminal tickets: the timeline filters finished
+    /// work out, and a plan attached to something already closed reads as a
+    /// record rather than an intention.
+    #[serde(default)]
+    start_in_days: Option<i64>,
+    #[serde(default)]
+    due_in_days: Option<i64>,
     #[serde(default)]
     closed_hours_after: Option<i64>,
     #[serde(default)]
@@ -448,8 +460,14 @@ fn seed(
             verification_state: None,
             origin_channel_id: None,
             triage_state: None,
-            due_date: None,
-            start_date: None,
+            // Signed the natural way round in the dataset, so `+3` reads as
+            // "three days from now" rather than needing a mental negation.
+            due_date: dt
+                .due_in_days
+                .map(|d| (now + Duration::days(d)).naive_utc()),
+            start_date: dt
+                .start_in_days
+                .map(|d| (now + Duration::days(d)).naive_utc()),
             recurrence_rule: None,
             recurrence_template_id: None,
             resolution_notes: None,

--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -1,0 +1,21 @@
+import { test as setup } from '@playwright/test'
+import { AUTH_STATE, login } from './helpers'
+
+/**
+ * Log in once per run and save the session for every other project to reuse.
+ *
+ * Each spec used to drive the full login form itself. At 15 specs that is 15
+ * round trips through a real auth flow, and it was the last remaining source of
+ * flake in the suite: a single `page.waitForURL` exceeding the 60s local timeout
+ * failed a spec that was asserting nothing about login.
+ *
+ * The app's session is HTTP cookies (access / refresh / CSRF) plus a couple of
+ * localStorage keys, and `storageState` captures both, so a restored context is
+ * authenticated exactly as a freshly logged-in one is.
+ *
+ * This runs before the seed contract, which then also gets to skip logging in.
+ */
+setup('authenticate', async ({ page }) => {
+  await login(page)
+  await page.context().storageState({ path: AUTH_STATE })
+})

--- a/frontend/e2e/board-touch-drag.spec.ts
+++ b/frontend/e2e/board-touch-drag.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 import {
   BOARD,
-  PROJECT_WITH_TICKETS,
+  PROJECT_BOARD,
   Touch,
   boardScrollLeft,
   columnOfCard,
@@ -28,7 +28,7 @@ test.describe('kanban touch drag', () => {
 
   test('a quick swipe on a card pans the board', async ({ page, context }) => {
     await login(page)
-    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+    await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`)
 
     const card = await visibleCard(page)
     expect(card, 'a card should be on screen; the board lands on a populated column').not.toBeNull()
@@ -48,7 +48,7 @@ test.describe('kanban touch drag', () => {
 
   test('holding a card picks it up, and the board stays put', async ({ page, context }) => {
     await login(page)
-    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+    await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`)
 
     const card = await visibleCard(page)
     expect(card).not.toBeNull()
@@ -79,7 +79,7 @@ test.describe('kanban touch drag', () => {
    */
   test('holding a dragged card at the edge pans the board', async ({ page, context }) => {
     await login(page)
-    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+    await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`)
 
     const card = await visibleCard(page)
     expect(card).not.toBeNull()
@@ -105,7 +105,7 @@ test.describe('kanban touch drag', () => {
 
   test('dropping on another column moves the card', async ({ page, context }) => {
     await login(page)
-    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+    await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`)
 
     const card = await visibleCard(page)
     expect(card).not.toBeNull()
@@ -125,6 +125,7 @@ test.describe('kanban touch drag', () => {
     // against shared demo data, so the starting column varies between runs.
     const after = await columnOfCard(page, card!.id)
     expect(after, `#${card!.id} should have left "${from}"`).not.toBe(from)
+
   })
 })
 
@@ -135,7 +136,7 @@ test.describe('kanban mouse drag', () => {
    *  is asserted too: it must still promote on distance, with no hold. */
   test('dragging with a mouse still moves a card', async ({ page }) => {
     await login(page)
-    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`)
+    await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`)
 
     const card = await visibleCard(page)
     expect(card).not.toBeNull()

--- a/frontend/e2e/board-touch-drag.spec.ts
+++ b/frontend/e2e/board-touch-drag.spec.ts
@@ -8,7 +8,6 @@ import {
   dragDirection,
   panDirection,
   gotoAndSettle,
-  login,
   visibleCard,
 } from './helpers'
 
@@ -27,7 +26,6 @@ test.describe('kanban touch drag', () => {
   test.skip(({ hasTouch }) => !hasTouch, 'touch-only behaviour')
 
   test('a quick swipe on a card pans the board', async ({ page, context }) => {
-    await login(page)
     await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`)
 
     const card = await visibleCard(page)
@@ -47,7 +45,6 @@ test.describe('kanban touch drag', () => {
   })
 
   test('holding a card picks it up, and the board stays put', async ({ page, context }) => {
-    await login(page)
     await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`)
 
     const card = await visibleCard(page)
@@ -78,7 +75,6 @@ test.describe('kanban touch drag', () => {
    * at the edge.
    */
   test('holding a dragged card at the edge pans the board', async ({ page, context }) => {
-    await login(page)
     await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`)
 
     const card = await visibleCard(page)
@@ -104,7 +100,6 @@ test.describe('kanban touch drag', () => {
   })
 
   test('dropping on another column moves the card', async ({ page, context }) => {
-    await login(page)
     await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`)
 
     const card = await visibleCard(page)
@@ -135,7 +130,6 @@ test.describe('kanban mouse drag', () => {
   /** The touch work refactored the shared activation path, so the mouse path
    *  is asserted too: it must still promote on distance, with no hold. */
   test('dragging with a mouse still moves a card', async ({ page }) => {
-    await login(page)
     await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`)
 
     const card = await visibleCard(page)

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -121,6 +121,29 @@ export interface BoardCard {
   y: number
 }
 
+/** A planned block in the mobile vertical timeline. The E2E drag test uses a
+ * ticket with an authored start so its forward-and-back gesture restores the
+ * exact original dates, rather than promoting an inferred start as a side
+ * effect of the coverage itself. */
+export interface TimelineCard {
+  id: string
+  x: number
+  y: number
+}
+
+export async function visibleTimelineCard(page: Page): Promise<TimelineCard | null> {
+  const card = page.locator('[data-timeline-card-id][data-timeline-has-start-date="true"]').first()
+  if ((await card.count()) === 0) return null
+  await card.scrollIntoViewIfNeeded()
+  const box = await card.boundingBox()
+  if (!box) return null
+  return {
+    id: await card.getAttribute('data-timeline-card-id') ?? '',
+    x: Math.round(box.x + box.width / 2),
+    y: Math.round(box.y + box.height / 2),
+  }
+}
+
 /**
  * A card to drive a gesture against, scrolling it into view if needed.
  *

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -42,6 +42,12 @@ export const PROJECT_TIMELINE = 3
 /** No scheduled work, so the timeline's empty state is reachable. */
 export const PROJECT_SPARSE = 1
 
+/**
+ * Where `auth.setup.ts` parks the signed-in session for the other projects.
+ * Gitignored: it holds live session cookies.
+ */
+export const AUTH_STATE = 'playwright/.auth/user.json'
+
 export async function login(page: Page): Promise<void> {
   await page.goto('/login', { waitUntil: 'domcontentloaded' })
   await page.waitForSelector('input[type="email"]')

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -7,10 +7,40 @@ import type { BrowserContext, Page } from '@playwright/test'
 export const DEMO_EMAIL = 'noah@demo.nosdesk.test'
 export const DEMO_PASSWORD = 'Demo1234!'
 
-/** Demo projects. `WITH_TICKETS` has tickets spread across several columns,
- *  which is what makes the landing and drag specs meaningful. */
-export const PROJECT_WITH_TICKETS = 3
-export const PROJECT_SPARSE = 2
+/**
+ * Demo projects, split by SURFACE, because that is what determines whether one
+ * spec's writes can hurt another's assertions.
+ *
+ * Kanban drags move a card between columns. That is harmless to board
+ * assertions — a card in any column is still on the board — but it is fatal to
+ * timeline assertions, because cards drift monotonically toward `done` and
+ * terminal work is filtered out of the timeline. Repeated runs emptied the
+ * timeline of whichever project the drag spec shared with it.
+ *
+ * So the boards and the timeline get different projects. Restoring the card
+ * through a second drag was tried and abandoned: the board auto-pans mid-drag,
+ * so any drop coordinate computed beforehand is stale, and the restore missed
+ * by a column. Housekeeping should not be a second flaky gesture.
+ *
+ * The shapes these names promise are asserted once, up front, by
+ * `seed-contract.spec.ts` — so a seed change fails there with a plain message
+ * instead of surfacing as a timeout inside an unrelated spec.
+ *
+ * Shapes are stated as what `DEMO_EMAIL` can SEE, not what the database holds.
+ * That account is a member, so it sees only its own tickets: project 2 holds 16
+ * but shows this user 3, and only project 3's planned work belongs to them.
+ * Reading the raw table instead is what made a first pass at this hand the
+ * mutable project to one whose timeline is empty for the test user.
+ */
+/** Board specs, including the drags. They rearrange its columns freely; no
+ *  assertion here depends on which column a card is in. */
+export const PROJECT_BOARD = 2
+/** Timeline specs. The only project whose planned blocks are visible to this
+ *  user, so nothing may push its tickets into a terminal state. The reschedule
+ *  spec restores the dates it moves. */
+export const PROJECT_TIMELINE = 3
+/** No scheduled work, so the timeline's empty state is reachable. */
+export const PROJECT_SPARSE = 1
 
 export async function login(page: Page): Promise<void> {
   await page.goto('/login', { waitUntil: 'domcontentloaded' })
@@ -201,6 +231,21 @@ function firstOnScreenCard(page: Page): Promise<BoardCard | null> {
  * card and taking the first ancestor in a plausible width range picked up the
  * wrong heading and reported a column the card was never in.
  */
+/**
+ * Locate one specific card by id, scrolling it into view first.
+ *
+ * `visibleCard` finds *a* card; this finds *the* card, which is what a restore
+ * step needs — after a move it sits in a different column, often off-screen.
+ */
+export async function cardById(page: Page, id: string): Promise<BoardCard | null> {
+  const el = page.locator(`[data-card-id="${id}"]`).first()
+  if ((await el.count()) === 0) return null
+  await el.scrollIntoViewIfNeeded()
+  const box = await el.boundingBox()
+  if (!box) return null
+  return { id, x: Math.round(box.x + box.width / 2), y: Math.round(box.y + box.height / 2) }
+}
+
 export function columnOfCard(page: Page, id: string): Promise<string | null> {
   return page.evaluate(
     ({ sel, id }) => {
@@ -228,6 +273,38 @@ export function columnOfCard(page: Page, id: string): Promise<string | null> {
  * ask for is impossible. Choosing the direction also keeps the data balanced:
  * cards oscillate instead of drifting to an edge.
  */
+/**
+ * Viewport x of a column's centre, by its heading, scrolling it into view.
+ *
+ * A restore step cannot reverse the forward gesture by the same pixel delta:
+ * columns are ~74% of a phone viewport, so a fixed 200px nudge that was enough
+ * to leave a column is not necessarily enough to re-enter the original one, and
+ * the card lands one short. Targeting the column itself is width-independent.
+ */
+export async function columnCenterX(page: Page, heading: string): Promise<number | null> {
+  return page.evaluate(
+    ({ sel, heading }) => {
+      const inner = document.querySelector(sel)?.firstElementChild
+      if (!inner) return null
+      for (const column of [...inner.children]) {
+        const h = column.querySelector('h2, h3')?.textContent?.trim()
+        if (h !== heading) continue
+        const board = document.querySelector(sel) as HTMLElement
+        const r = column.getBoundingClientRect()
+        const br = board.getBoundingClientRect()
+        // Bring it fully on screen so the drop coordinate is reachable.
+        if (r.left < br.left || r.right > br.right) {
+          board.scrollLeft += r.left - br.left - 8
+        }
+        const after = column.getBoundingClientRect()
+        return Math.round(after.left + after.width / 2)
+      }
+      return null
+    },
+    { sel: BOARD, heading },
+  )
+}
+
 export function dragDirection(page: Page, id: string): Promise<number> {
   return page.evaluate(
     ({ sel, id }) => {

--- a/frontend/e2e/project-views-mobile.spec.ts
+++ b/frontend/e2e/project-views-mobile.spec.ts
@@ -6,7 +6,6 @@ import {
   PROJECT_TIMELINE,
   Touch,
   gotoAndSettle,
-  login,
   visibleTimelineCard,
 } from './helpers'
 
@@ -29,7 +28,6 @@ test.describe('project views on a phone', () => {
 
   for (const [name, path] of PROJECT_ROUTES(PROJECT_SPARSE)) {
     test(`${name} does not overflow the viewport`, async ({ page }) => {
-      await login(page)
       await gotoAndSettle(page, path)
 
       // The cardinal mobile bug: the page itself scrolling sideways. Content
@@ -45,7 +43,6 @@ test.describe('project views on a phone', () => {
   }
 
   test('no control renders outside the viewport', async ({ page }) => {
-    await login(page)
     await gotoAndSettle(page, '/projects')
 
     // Regression: `hidden lg:inline-flex` passed to a component merged with the
@@ -80,7 +77,6 @@ test.describe('project views on a phone', () => {
   })
 
   test('the board opens on a column that has work in it', async ({ page }) => {
-    await login(page)
     await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`, '[data-card-id]')
 
     // Separated from the visibility check on purpose: without this, a pool that
@@ -113,7 +109,6 @@ test.describe('project views on a phone', () => {
   })
 
   test('the gantt keeps its empty state on screen', async ({ page }) => {
-    await login(page)
     await gotoAndSettle(page, `/projects/${PROJECT_SPARSE}/gantt`)
 
     // Regression: the hint carried a 240px minimum against a ~190px visible
@@ -130,7 +125,6 @@ test.describe('project views on a phone', () => {
   })
 
   test('holding and moving a planned timeline block reschedules it, then restores it', async ({ page, context }) => {
-    await login(page)
     await gotoAndSettle(page, `/projects/${PROJECT_TIMELINE}/gantt`, '[data-timeline-card-id]')
 
     // Not a skip. `seed-contract.spec.ts` already guarantees this project has a

--- a/frontend/e2e/project-views-mobile.spec.ts
+++ b/frontend/e2e/project-views-mobile.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test'
 import {
   BOARD,
+  PROJECT_BOARD,
   PROJECT_SPARSE,
-  PROJECT_WITH_TICKETS,
+  PROJECT_TIMELINE,
   Touch,
   gotoAndSettle,
   login,
@@ -80,7 +81,7 @@ test.describe('project views on a phone', () => {
 
   test('the board opens on a column that has work in it', async ({ page }) => {
     await login(page)
-    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}`, '[data-card-id]')
+    await gotoAndSettle(page, `/projects/${PROJECT_BOARD}`, '[data-card-id]')
 
     // Separated from the visibility check on purpose: without this, a pool that
     // had not hydrated yet reads as "the board opened on the wrong column",
@@ -91,13 +92,15 @@ test.describe('project views on a phone', () => {
     // Columns render in workflow order, so the board would otherwise open on
     // Triage / Backlog — routinely empty — with the tickets several swipes away.
     //
-    // Intersection, not full containment. `board-touch-drag.spec.ts` drives this
-    // same project and moves cards between columns, so which column the landing
-    // scroll targets varies by the time this runs; demanding a card sit ENTIRELY
-    // inside the viewport failed whenever the board came to rest between two
-    // columns, which is a snap position rather than a bug. Anything off-screen
-    // still reads as zero, so this keeps catching the case it exists for: the
-    // board opening on an empty column with the work several swipes away.
+    // Intersection, not full containment: the board snaps to columns, so it can
+    // legitimately come to rest between two with a card straddling the edge.
+    // Anything genuinely off-screen still reads as zero, so this keeps catching
+    // the case it exists for — the board opening on an empty column with the
+    // work several swipes away.
+    //
+    // The drag spec shares this project and rearranges its columns, which is
+    // deliberate and harmless here: this asserts that the board lands on a
+    // populated column, whichever one that happens to be.
     const cardsOnScreen = await page.evaluate((sel) => {
       const board = document.querySelector(sel)
       if (!board) return -1
@@ -128,10 +131,13 @@ test.describe('project views on a phone', () => {
 
   test('holding and moving a planned timeline block reschedules it, then restores it', async ({ page, context }) => {
     await login(page)
-    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}/gantt`, '[data-timeline-card-id]')
+    await gotoAndSettle(page, `/projects/${PROJECT_TIMELINE}/gantt`, '[data-timeline-card-id]')
 
+    // Not a skip. `seed-contract.spec.ts` already guarantees this project has a
+    // planned block, so an absence here is a real failure — and the old skip was
+    // unreachable anyway, because the selector wait above it timed out first.
     const card = await visibleTimelineCard(page)
-    if (!card) test.skip(true, 'seed project has no planned timeline block to move')
+    expect(card, 'seed contract guarantees a planned timeline block').not.toBeNull()
 
     const selector = `[data-timeline-card-id="${card!.id}"]`
     const before = await page.locator(selector).boundingBox()

--- a/frontend/e2e/project-views-mobile.spec.ts
+++ b/frontend/e2e/project-views-mobile.spec.ts
@@ -1,5 +1,13 @@
 import { test, expect } from '@playwright/test'
-import { BOARD, PROJECT_SPARSE, PROJECT_WITH_TICKETS, gotoAndSettle, login } from './helpers'
+import {
+  BOARD,
+  PROJECT_SPARSE,
+  PROJECT_WITH_TICKETS,
+  Touch,
+  gotoAndSettle,
+  login,
+  visibleTimelineCard,
+} from './helpers'
 
 const PROJECT_ROUTES = (id: number): Array<[string, string]> => [
   ['projects list', '/projects'],
@@ -116,5 +124,49 @@ test.describe('project views on a phone', () => {
     const vw = page.viewportSize()!.width
     expect(box!.x, 'hint starts on screen').toBeGreaterThanOrEqual(0)
     expect(box!.x + box!.width, 'hint ends on screen').toBeLessThanOrEqual(vw + 1)
+  })
+
+  test('holding and moving a planned timeline block reschedules it, then restores it', async ({ page, context }) => {
+    await login(page)
+    await gotoAndSettle(page, `/projects/${PROJECT_WITH_TICKETS}/gantt`, '[data-timeline-card-id]')
+
+    const card = await visibleTimelineCard(page)
+    if (!card) test.skip(true, 'seed project has no planned timeline block to move')
+
+    const selector = `[data-timeline-card-id="${card!.id}"]`
+    const before = await page.locator(selector).boundingBox()
+    expect(before).not.toBeNull()
+
+    // The timeline's scale is 36px/day. Two days clears the touch slop and
+    // makes a snapped change unmistakable without running into the viewport
+    // edge, where the intentionally-enabled auto-scroll would be a different
+    // behaviour under test.
+    const delta = 72
+    const move = async (fromY: number, by: number): Promise<void> => {
+      const pushed = page.waitForRequest((request) =>
+        request.url().endsWith('/api/sync/push')
+          && request.method() === 'POST'
+          && request.postData()?.includes(`\"model_id\":\"${card!.id}\"`) === true
+          && request.postData()?.includes('start_date') === true
+          && request.postData()?.includes('due_date') === true,
+      )
+      const touch = await Touch.create(context, page)
+      await touch.start(card!.x, fromY)
+      await page.waitForTimeout(500)
+      for (let i = 1; i <= 8; i++) {
+        await touch.move(card!.x, fromY + (by * i) / 8)
+        await page.waitForTimeout(16)
+      }
+      await touch.end()
+      await pushed
+    }
+
+    await move(card!.y, delta)
+    await expect.poll(async () => (await page.locator(selector).boundingBox())?.y).toBeGreaterThan(before!.y + 40)
+
+    const moved = await page.locator(selector).boundingBox()
+    expect(moved).not.toBeNull()
+    await move(Math.round(moved!.y + moved!.height / 2), -delta)
+    await expect.poll(async () => (await page.locator(selector).boundingBox())?.y).toBeLessThan(before!.y + 8)
   })
 })

--- a/frontend/e2e/seed-contract.spec.ts
+++ b/frontend/e2e/seed-contract.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { PROJECT_TIMELINE, PROJECT_SPARSE, PROJECT_BOARD, login } from './helpers'
+import { PROJECT_TIMELINE, PROJECT_SPARSE, PROJECT_BOARD } from './helpers'
 
 /**
  * The shape contract the rest of the suite is written against.
@@ -26,7 +26,6 @@ import { PROJECT_TIMELINE, PROJECT_SPARSE, PROJECT_BOARD, login } from './helper
  */
 test.describe('seed contract', () => {
   test('PROJECT_BOARD has board cards to land on', async ({ page }) => {
-    await login(page)
     await page.goto(`/projects/${PROJECT_BOARD}`, { waitUntil: 'domcontentloaded' })
     await expect(
       page.locator('[data-card-id]').first(),
@@ -35,7 +34,6 @@ test.describe('seed contract', () => {
   })
 
   test('PROJECT_TIMELINE has a planned timeline block', async ({ page }) => {
-    await login(page)
     await page.goto(`/projects/${PROJECT_TIMELINE}/gantt`, { waitUntil: 'domcontentloaded' })
     // A *planned* block: start AND due. A due-only ticket renders as a day-tall
     // marker, which is too short to grab and drag.
@@ -46,7 +44,6 @@ test.describe('seed contract', () => {
   })
 
   test('PROJECT_SPARSE has no scheduled work', async ({ page }) => {
-    await login(page)
     await page.goto(`/projects/${PROJECT_SPARSE}/gantt`, { waitUntil: 'domcontentloaded' })
     // Asserted through the empty state rather than "count is 0", so this waits
     // for a positive signal. A zero count would also be satisfied by a page that

--- a/frontend/e2e/seed-contract.spec.ts
+++ b/frontend/e2e/seed-contract.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+import { PROJECT_TIMELINE, PROJECT_SPARSE, PROJECT_BOARD, login } from './helpers'
+
+/**
+ * The shape contract the rest of the suite is written against.
+ *
+ * `seed_demo` is a product demo dataset, not a test fixture — it never promised
+ * any particular shape, and the suite quietly assumed one. When that assumption
+ * broke, the symptom was a 30-second `waitForSelector` timeout inside an
+ * unrelated reschedule spec, which reads like a product bug rather than missing
+ * data. (It was missing data: the seed set no due or start dates at all, so the
+ * timeline had nothing to draw and the spec could never pass on a clean DB.)
+ *
+ * These assertions turn that into one plain failure, up front. This runs as a
+ * Playwright *setup project*, so if the seed does not hold up its end, the phone
+ * and desktop suites are skipped rather than producing a cascade downstream.
+ *
+ * If one of these fails, fix the seed (`backend/seeds/demo.json` +
+ * `backend/src/bin/seed_demo.rs`) or the constants in `helpers.ts` — not the
+ * spec that happened to notice.
+ *
+ * Every assertion here is an auto-retrying `expect` on a locator rather than a
+ * count taken after a fixed sleep: the sync pool hydrates asynchronously, and a
+ * fixed settle makes the gate itself flaky, which is the one thing a gate must
+ * never be.
+ */
+test.describe('seed contract', () => {
+  test('PROJECT_BOARD has board cards to land on', async ({ page }) => {
+    await login(page)
+    await page.goto(`/projects/${PROJECT_BOARD}`, { waitUntil: 'domcontentloaded' })
+    await expect(
+      page.locator('[data-card-id]').first(),
+      `project ${PROJECT_BOARD} must have tickets on its board — the landing-scroll spec needs a populated column`,
+    ).toBeVisible()
+  })
+
+  test('PROJECT_TIMELINE has a planned timeline block', async ({ page }) => {
+    await login(page)
+    await page.goto(`/projects/${PROJECT_TIMELINE}/gantt`, { waitUntil: 'domcontentloaded' })
+    // A *planned* block: start AND due. A due-only ticket renders as a day-tall
+    // marker, which is too short to grab and drag.
+    await expect(
+      page.locator('[data-timeline-card-id][data-timeline-has-start-date="true"]').first(),
+      `project ${PROJECT_TIMELINE} must have a ticket with both start_date and due_date — the reschedule spec drags one`,
+    ).toBeVisible()
+  })
+
+  test('PROJECT_SPARSE has no scheduled work', async ({ page }) => {
+    await login(page)
+    await page.goto(`/projects/${PROJECT_SPARSE}/gantt`, { waitUntil: 'domcontentloaded' })
+    // Asserted through the empty state rather than "count is 0", so this waits
+    // for a positive signal. A zero count would also be satisfied by a page that
+    // simply had not rendered yet.
+    await expect(
+      page.locator('p', { hasText: /scheduled|due date/i }).first(),
+      `project ${PROJECT_SPARSE} must have NO scheduled tickets — the empty-state spec asserts this hint renders`,
+    ).toBeVisible()
+    await expect(page.locator('[data-timeline-card-id]')).toHaveCount(0)
+  })
+})

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -42,12 +42,29 @@ export default defineConfig({
   },
   projects: [
     {
+      // Setup project: asserts the demo seed still has the shape the suite is
+      // written against. The phone/desktop projects DEPEND on it, so a seed
+      // that drifts skips them with one plain message instead of surfacing as
+      // an unrelated timeout deep in a spec. Phone viewport because the
+      // vertical timeline it probes only renders below `md`.
+      name: 'seed-contract',
+      testMatch: /seed-contract\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 390, height: 844 },
+        hasTouch: true,
+        isMobile: true,
+      },
+    },
+    {
       // Spelled out rather than using an `iPhone` preset: those imply WebKit,
       // and the touch specs drive real gestures through CDP
       // (`Input.dispatchTouchEvent`), which is Chromium-only. A preset would
       // silently switch engines and fail to launch. 390x844 is the iPhone 14
       // viewport, which is what the layout numbers in these specs refer to.
       name: 'phone',
+      dependencies: ['seed-contract'],
+      testIgnore: /seed-contract\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 390, height: 844 },
@@ -58,6 +75,8 @@ export default defineConfig({
     },
     {
       name: 'desktop',
+      dependencies: ['seed-contract'],
+      testIgnore: /seed-contract\.spec\.ts/,
       use: { ...devices['Desktop Chrome'], viewport: { width: 1680, height: 1000 } },
     },
   ],

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
 
+/** Saved session from `auth.setup.ts`; mirrors `AUTH_STATE` in e2e/helpers.ts. */
+const AUTH_STATE = 'playwright/.auth/user.json'
+
 /**
  * End-to-end tests against the running dev stack.
  *
@@ -42,6 +45,18 @@ export default defineConfig({
   },
   projects: [
     {
+      // Logs in once and saves the session. Everything downstream reuses it, so
+      // no spec drives the auth flow just to reach the page it actually tests.
+      name: 'auth',
+      testMatch: /auth\.setup\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 390, height: 844 },
+        hasTouch: true,
+        isMobile: true,
+      },
+    },
+    {
       // Setup project: asserts the demo seed still has the shape the suite is
       // written against. The phone/desktop projects DEPEND on it, so a seed
       // that drifts skips them with one plain message instead of surfacing as
@@ -49,11 +64,13 @@ export default defineConfig({
       // vertical timeline it probes only renders below `md`.
       name: 'seed-contract',
       testMatch: /seed-contract\.spec\.ts/,
+      dependencies: ['auth'],
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 390, height: 844 },
         hasTouch: true,
         isMobile: true,
+        storageState: AUTH_STATE,
       },
     },
     {
@@ -64,20 +81,27 @@ export default defineConfig({
       // viewport, which is what the layout numbers in these specs refer to.
       name: 'phone',
       dependencies: ['seed-contract'],
-      testIgnore: /seed-contract\.spec\.ts/,
+      testIgnore: /(seed-contract\.spec|auth\.setup)\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 390, height: 844 },
         hasTouch: true,
         isMobile: true,
         deviceScaleFactor: 3,
+        // After the device spread, not before: a preset key would otherwise
+        // win and silently drop the saved session.
+        storageState: AUTH_STATE,
       },
     },
     {
       name: 'desktop',
       dependencies: ['seed-contract'],
-      testIgnore: /seed-contract\.spec\.ts/,
-      use: { ...devices['Desktop Chrome'], viewport: { width: 1680, height: 1000 } },
+      testIgnore: /(seed-contract\.spec|auth\.setup)\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1680, height: 1000 },
+        storageState: AUTH_STATE,
+      },
     },
   ],
 })

--- a/frontend/scripts/scan-button-colors.mjs
+++ b/frontend/scripts/scan-button-colors.mjs
@@ -1,0 +1,93 @@
+/**
+ * Scan for <button> elements painted with raw Tailwind palette colours instead
+ * of the app's semantic tokens (see components/common/Button.vue for the
+ * canonical variants).
+ *
+ * Reports two separate things, because they are different severities:
+ *
+ *   RAW    a literal palette colour (`bg-blue-600`, `text-gray-400`, `#1f2937`).
+ *          These ignore the theme entirely and are the real defect.
+ *   ONACC  `text-white` sitting on `bg-accent`. The on-accent foreground is
+ *          theme-aware — the injector picks black or white per theme by WCAG
+ *          luminance against the actual accent — so hardcoding white is
+ *          invisible on a light accent (brand orange resolves to BLACK).
+ *
+ * Diagnostic only; not wired into `lint`.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const ROOT = new URL('../src', import.meta.url).pathname
+const REPO = new URL('..', import.meta.url).pathname
+
+/** Tailwind palette families that are never semantic in this codebase. */
+const PALETTE =
+  'slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose'
+const RAW_CLASS = new RegExp(`\\b(?:bg|text|border|ring|from|to|via)-(?:${PALETTE})-\\d{2,3}\\b`, 'g')
+const RAW_HEX = /#[0-9a-fA-F]{3,8}\b/g
+
+/**
+ * User-chosen entity colours (a group's or category's colour, stored per row
+ * and applied via inline style) are data, not chrome. `#6366f1` is the shared
+ * fallback for "this entity has no colour set" and is not a theme violation.
+ */
+const ENTITY_COLOR_FALLBACK = /#6366f1/i
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name)
+    const s = statSync(p)
+    if (s.isDirectory()) walk(p, out)
+    else if (name.endsWith('.vue')) out.push(p)
+  }
+  return out
+}
+
+/** Extract each `<button ...>` open tag, with its line number. */
+function buttonTags(src) {
+  const out = []
+  const re = /<button\b[\s\S]*?>/g
+  let m
+  while ((m = re.exec(src)) !== null) {
+    out.push({ tag: m[0], line: src.slice(0, m.index).split('\n').length })
+  }
+  return out
+}
+
+const findings = []
+for (const file of walk(ROOT)) {
+  const src = readFileSync(file, 'utf8')
+  const rel = relative(REPO, file)
+  for (const { tag, line } of buttonTags(src)) {
+    const raw = [
+      ...new Set([...(tag.match(RAW_CLASS) ?? []), ...(tag.match(RAW_HEX) ?? [])]),
+    ].filter((c) => !ENTITY_COLOR_FALLBACK.test(c))
+    // Per class-group, not per tag: a ternary often puts `bg-accent
+    // text-on-accent` in one branch and `bg-status-warning text-white` in the
+    // other, and testing the whole tag reports that correct code as a finding.
+    //
+    // Single-quoted groups are the unit, because a `:class="[...]"` attribute's
+    // own double quotes wrap every branch at once — testing those is no better
+    // than testing the whole tag.
+    const singles = tag.match(/'[^']*'/g) ?? []
+    const doubles = (tag.match(/"[^"]*"/g) ?? []).filter((s) => !s.includes("'"))
+    const onAccent = [...singles, ...doubles].some(
+      (s) => /\bbg-accent\b/.test(s) && /\btext-white\b/.test(s),
+    )
+    if (raw.length) findings.push({ kind: 'RAW', file: rel, line, detail: raw.join(' ') })
+    if (onAccent) findings.push({ kind: 'ONACC', file: rel, line, detail: 'text-white on bg-accent' })
+  }
+}
+
+const byKind = (k) => findings.filter((f) => f.kind === k)
+for (const kind of ['RAW', 'ONACC']) {
+  const rows = byKind(kind)
+  console.log(`\n=== ${kind}: ${rows.length}`)
+  const byFile = new Map()
+  for (const r of rows) byFile.set(r.file, [...(byFile.get(r.file) ?? []), r])
+  for (const [file, rs] of [...byFile].sort((a, b) => b[1].length - a[1].length)) {
+    console.log(`  ${file} (${rs.length})`)
+    for (const r of rs.slice(0, 6)) console.log(`      :${r.line}  ${r.detail}`)
+  }
+}
+console.log(`\ntotal findings: ${findings.length}`)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -346,10 +346,8 @@ onMounted(async () => {
   try {
     // Only check if not already on onboarding or login pages
     if (route.name !== 'onboarding' && route.name !== 'login') {
-      console.log('🔄 App: Checking setup status on initialization...');
       const setupStatus = await authService.checkSetupStatus();
       if (setupStatus.requires_setup) {
-        console.log('🔄 App: System requires setup, redirecting to onboarding');
         router.push({ name: 'onboarding' });
       }
     }

--- a/frontend/src/components/CollaborativeEditor.vue
+++ b/frontend/src/components/CollaborativeEditor.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { logger } from '@nosdesk/core/utils/logger'
 // Collaborative Editor with Yjs for real-time document editing
 //
 // Logging behavior:
@@ -277,11 +278,8 @@ const showRevisionHistory = ref(false);
 
 // Extract ticket ID from docId (format: "ticket-123")
 const ticketId = computed(() => {
-    console.log('[CollaborativeEditor] docId:', props.docId);
     const match = props.docId.match(/ticket-(\d+)/);
-    const id = match ? parseInt(match[1], 10) : 0;
-    console.log('[CollaborativeEditor] Extracted ticketId:', id);
-    return id;
+    return match ? parseInt(match[1], 10) : 0;
 });
 
 // Toggle revision history sidebar
@@ -419,8 +417,10 @@ let updateV2DiagnosticHandler: ((update: Uint8Array) => void) | null = null;
 
 // Enhanced logging
 const log = {
+    // `logger.debug`, not `console.log`: the shared logger is level-gated
+    // (DEBUG is dropped in prod) and redacts token-ish context keys.
     info: (message: string, ...args: unknown[]) =>
-        console.log(`[YJS-Editor] ${message}`, ...args),
+        logger.debug(`[YJS-Editor] ${message}`, { args }),
     error: (message: string, ...args: unknown[]) =>
         console.error(`[YJS-Editor] ${message}`, ...args),
     debug: (message: string, ...args: unknown[]) => {
@@ -2352,11 +2352,6 @@ defineExpose({
                             connectedUser.user.uuid
                                 ? $t('editor-toolbar-user-title-uuid', { name: connectedUser.user.name, uuid: connectedUser.user.uuid })
                                 : $t('editor-toolbar-user-title', { name: connectedUser.user.name })
-                        "
-                        @click="
-                            () => {
-                                console.log('User data:', connectedUser.user);
-                            }
                         "
                     >
                         <UserAvatar

--- a/frontend/src/components/SiteHeader.vue
+++ b/frontend/src/components/SiteHeader.vue
@@ -87,13 +87,6 @@ const isDeviceView = computed(() => {
 
 // Only log in development mode
 if (import.meta.env.DEV) {
-  console.log("SiteHeader rendering with:", {
-    isTicketView: isTicketView.value,
-    isDocumentView: isDocumentView.value,
-    ticket: props.ticket,
-    document: props.document,
-    title: props.title,
-  });
 }
 
 // Use the provided title if available
@@ -110,7 +103,6 @@ const avatarSize = computed(() => isMobile.value ? 'lg' : 'md')
 const handleUpdateDocumentTitle = (newTitle: string) => {
   if (props.document) {
     if (import.meta.env.DEV) {
-      console.log(`SiteHeader: Updating document title to "${newTitle}" for document:`, props.document);
     }
     emit("updateDocumentTitle", newTitle);
   }
@@ -119,7 +111,6 @@ const handleUpdateDocumentTitle = (newTitle: string) => {
 const handlePreviewDocumentTitle = (newTitle: string) => {
   if (props.document) {
     if (import.meta.env.DEV) {
-      console.log(`SiteHeader: Previewing document title as "${newTitle}" for document:`, props.document);
     }
     emit("previewDocumentTitle", newTitle);
   }
@@ -134,7 +125,6 @@ const handleUpdateDocumentIcon = (newIcon: string) => {
 const handleUpdateTicketTitle = (newTitle: string) => {
   if (props.ticket) {
     if (import.meta.env.DEV) {
-      console.log(`SiteHeader: Updating ticket title to "${newTitle}" for ticket:`, props.ticket);
     }
     emit("updateTicketTitle", newTitle);
   }

--- a/frontend/src/components/common/BaseDropdown.vue
+++ b/frontend/src/components/common/BaseDropdown.vue
@@ -146,7 +146,21 @@ const allSelected = computed(() => {
 const sizeClasses = computed(() => {
   switch (props.size) {
     case 'xs':
-      return { button: 'px-1.5 py-0.5 text-sm', menu: 'text-sm', option: 'px-3 py-1.5' }
+      // `py-0.5` gives a 26px-tall trigger, well under the 44px a finger needs,
+      // and `xs` is what the toolbars use — it was the only sub-44px control in
+      // the project views. Grow the target on a coarse pointer without touching
+      // the dense desktop size. Keyed on pointer type rather than a breakpoint
+      // so a narrow desktop window does not get touch sizing it has no use for.
+      //
+      // `min-h` rather than more padding: the trigger is already `flex
+      // items-center`, so stating the 44px floor once is exact, where padding
+      // arithmetic has to be re-derived whenever the font metrics move (2.5
+      // landed it on 42px).
+      return {
+        button: 'px-1.5 py-0.5 text-sm pointer-coarse:min-h-[44px] pointer-coarse:px-3',
+        menu: 'text-sm',
+        option: 'px-3 py-1.5 pointer-coarse:min-h-[44px]',
+      }
     case 'sm':
       return { button: 'px-3 py-1.5 text-sm', menu: 'text-sm', option: 'px-3 py-2' }
     case 'lg':

--- a/frontend/src/components/common/MenuList.vue
+++ b/frontend/src/components/common/MenuList.vue
@@ -90,7 +90,7 @@ const emit = defineEmits<{
       class="w-full px-3 py-2.5 md:py-1.5 text-sm md:text-xs text-left flex items-center gap-2 min-h-[44px] md:min-h-0 transition-colors disabled:opacity-40 disabled:pointer-events-none"
       :class="
         item.danger
-          ? 'text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30'
+          ? 'text-status-error hover:bg-status-error/10'
           : item.active
             ? 'text-accent hover:text-accent-hover hover:bg-surface-hover'
             : 'text-secondary hover:text-primary hover:bg-surface-hover'

--- a/frontend/src/components/cycles/CycleBurnupChart.vue
+++ b/frontend/src/components/cycles/CycleBurnupChart.vue
@@ -400,14 +400,22 @@ const readoutLeft = computed(() => xPct(hoverX.value) <= 55)
           >
 
           <!-- Direct end-of-line labels (one per series), anchored to the
-               right edge so they never overflow. -->
+               right edge so they never overflow.
+
+               On a plate, because anchoring to the edge only guarantees they
+               stay inside the frame, not that they stay off the lines: the
+               right gutter is 30 of 640 viewBox units, which is ~15px on a
+               phone, so a label several times that wide extends back over the
+               plot and the series stroke runs straight through the text. The
+               plate masks the stroke; it helps on a desktop too, where the two
+               series converge at the end of a finished cycle. -->
           <span
-            class="absolute right-0 -translate-y-1/2 font-medium text-secondary"
+            class="absolute right-0 -translate-y-1/2 rounded-sm bg-surface px-1 font-medium text-secondary"
             :style="{ top: `${yPct(labelYs.grey)}%` }"
             >{{ hasFuture ? t('cycle-burnup-label-pace') : t('cycle-burnup-legend-scope') }}</span
           >
           <span
-            class="absolute right-0 -translate-y-1/2 font-semibold text-accent"
+            class="absolute right-0 -translate-y-1/2 rounded-sm bg-surface px-1 font-semibold text-accent"
             :style="{ top: `${yPct(labelYs.accent)}%` }"
             >{{ hasFuture ? t('cycle-burnup-label-forecast') : t('cycle-burnup-legend-completed') }}</span
           >

--- a/frontend/src/components/documentationComponents/DocumentAuthorBadge.vue
+++ b/frontend/src/components/documentationComponents/DocumentAuthorBadge.vue
@@ -97,7 +97,7 @@ async function unverify() {
     ref="triggerRef"
     type="button"
     class="inline-flex items-center gap-1 rounded px-1 -mx-1 hover:bg-surface-hover transition-colors text-secondary"
-    :class="{ 'text-emerald-700 dark:text-emerald-400': state === 'fresh' }"
+    :class="{ 'text-status-success': state === 'fresh' }"
     :title="state === 'fresh'
       ? $t('docs-author-badge-title-verified', { author: authorName, relative: formatRelativeTime(page.verified_at!) })
       : $t('docs-author-badge-title-basic', { author: authorName })"

--- a/frontend/src/components/editor/imageUploadPlugin.ts
+++ b/frontend/src/components/editor/imageUploadPlugin.ts
@@ -40,7 +40,6 @@ async function handleImageFiles(
   pos: number,
   options: ImageUploadPluginOptions
 ): Promise<void> {
-  console.log('[ImageUpload] handleImageFiles called with', files.length, 'files');
   const { schema } = view.state;
   const imageType = schema.nodes.image;
 
@@ -53,16 +52,13 @@ async function handleImageFiles(
 
   for (const file of files) {
     if (!file.type.startsWith('image/')) {
-      console.log('[ImageUpload] Skipping non-image file:', file.type);
       continue;
     }
 
-    console.log('[ImageUpload] Uploading file:', file.name, file.type, file.size, 'bytes');
 
     try {
       // Upload the image with ticket context if available
       const result = await uploadEditorImage(file, { ticketId: options.ticketId });
-      console.log('[ImageUpload] Upload successful, URL:', result.url);
 
       // Create the image node with the URL
       const imageNode = imageType.create({
@@ -74,7 +70,6 @@ async function handleImageFiles(
       // Insert the image at the position
       const tr = view.state.tr.insert(pos, imageNode);
       view.dispatch(tr);
-      console.log('[ImageUpload] Image node inserted at position', pos);
 
       // Update position for next image
       pos += imageNode.nodeSize;

--- a/frontend/src/components/ticketComponents/AssetSelectionModal.vue
+++ b/frontend/src/components/ticketComponents/AssetSelectionModal.vue
@@ -60,12 +60,10 @@ const scrollContainer = ref<HTMLElement | null>(null);
 // Load requester's devices first (for immediate display at top)
 const loadRequesterDevices = async () => {
   if (import.meta.env.DEV) {
-    console.log('DeviceSelectionModal: loadRequesterDevices called with requesterUuid:', props.requesterUuid);
   }
   
   if (!props.requesterUuid) {
     if (import.meta.env.DEV) {
-      console.log('DeviceSelectionModal: No requester UUID provided, skipping requester devices load');
     }
     return;
   }
@@ -73,13 +71,11 @@ const loadRequesterDevices = async () => {
   loadingRequesterDevices.value = true;
   try {
     if (import.meta.env.DEV) {
-      console.log(`DeviceSelectionModal: Fetching devices for requester ${props.requesterUuid}`);
     }
     
     const devices = await getAssetsByUser(props.requesterUuid);
     
     if (import.meta.env.DEV) {
-      console.log(`DeviceSelectionModal: Received ${devices.length} devices from getAssetsByUser:`, devices);
     }
     
     // Filter out already assigned devices
@@ -90,15 +86,12 @@ const loadRequesterDevices = async () => {
       );
       
       if (import.meta.env.DEV) {
-        console.log(`DeviceSelectionModal: Filtered out existing devices. ${devices.length} -> ${filteredDevices.length} devices`);
-        console.log('DeviceSelectionModal: Existing device IDs:', props.existingDeviceIds);
       }
     }
     
     requesterDevices.value = filteredDevices;
     
     if (import.meta.env.DEV) {
-      console.log(`DeviceSelectionModal: Set requesterDevices to ${filteredDevices.length} devices:`, filteredDevices);
     }
   } catch (err) {
     console.error('DeviceSelectionModal: Error loading requester devices:', err);
@@ -152,7 +145,6 @@ const loadDevices = async (page: number = 1, search: string = '', append: boolea
     hasMore.value = page < response.totalPages;
     currentPage.value = page;
     
-    console.log(`Loaded page ${page}: ${response.data.length} devices, total: ${response.total}`);
   } catch (err) {
     console.error('Error loading devices:', err);
     error.value = t('asset-modal-load-failed');
@@ -219,12 +211,6 @@ const allDevicesForDisplay = computed(() => {
   ];
   
   if (import.meta.env.DEV) {
-    console.log('DeviceSelectionModal: allDevicesForDisplay computed:', {
-      requesterDevicesCount: requesterDevices.value.length,
-      paginatedDevicesCount: devices.value.length,
-      totalCombined: combinedDevices.length,
-      combinedDevices
-    });
   }
   
   return combinedDevices;
@@ -244,11 +230,6 @@ const hasDevicesToShow = computed(() => {
 watch(() => props.show, (newValue) => {
   if (newValue) {
     if (import.meta.env.DEV) {
-      console.log('DeviceSelectionModal: Modal opened, initializing...', {
-        requesterUuid: props.requesterUuid,
-        existingDeviceIds: props.existingDeviceIds,
-        currentTicketId: props.currentTicketId
-      });
     }
     
     // Reset state
@@ -263,7 +244,6 @@ watch(() => props.show, (newValue) => {
     // Load initial data
     nextTick(() => {
       if (import.meta.env.DEV) {
-        console.log('DeviceSelectionModal: Starting data load in nextTick');
       }
       loadRequesterDevices();
       loadDevices(1, '', false);

--- a/frontend/src/components/ticketComponents/AttachmentPreview.vue
+++ b/frontend/src/components/ticketComponents/AttachmentPreview.vue
@@ -32,11 +32,6 @@ const props = withDefaults(defineProps<Props>(), {
   compact: false
 });
 
-// Debug logging
-if (props.attachment.transcription) {
-  console.log('[AttachmentPreview] Has transcription:', props.attachment.transcription);
-}
-
 const emit = defineEmits<{
   (e: 'delete'): void;
   (e: 'submit'): void;

--- a/frontend/src/components/ticketComponents/CollaborativeTicketArticle.vue
+++ b/frontend/src/components/ticketComponents/CollaborativeTicketArticle.vue
@@ -99,7 +99,6 @@ const handleSelectRevision = async (revisionNumber: number | null) => {
 
     // Display the revision in the editor (read-only mode)
     editorRef.value.viewSnapshot(revisionData);
-    console.log('Revision data received:', revisionData);
   } catch (error) {
     console.error('Failed to fetch revision:', error);
   }
@@ -211,7 +210,6 @@ const confirmPromote = async () => {
         <RevisionList
           :ticket-id="ticketId"
           @select-revision="handleSelectRevision"
-          @restored="() => console.log('Revision restored')"
         />
       </aside>
     </div>

--- a/frontend/src/components/ticketComponents/CommentsAndAttachments.vue
+++ b/frontend/src/components/ticketComponents/CommentsAndAttachments.vue
@@ -272,7 +272,6 @@ const handleRecordingComplete = (recording: {
     duration: number;
     transcription?: string;
 }) => {
-    console.log('[CommentsAndAttachments] Recording complete, transcription:', recording.transcription);
 
     // Auto-stage the voice note as an attachment. The extension follows the
     // recorded format (iOS records mp4/m4a, others webm) so playback works and
@@ -291,11 +290,9 @@ const handleRecordingComplete = (recording: {
 
     if (recording.transcription) {
         (audioFile as any)._transcription = recording.transcription;
-        console.log('[CommentsAndAttachments] Attached transcription to file');
     }
 
     newAttachments.value = [...newAttachments.value, audioFile];
-    console.log('[CommentsAndAttachments] File _transcription:', (audioFile as any)._transcription);
     showRecordingInterface.value = false;
 };
 

--- a/frontend/src/components/ticketComponents/CommentsAndAttachments.vue
+++ b/frontend/src/components/ticketComponents/CommentsAndAttachments.vue
@@ -698,7 +698,12 @@ const handlePastedFiles = async (files: File[]) => {
                                         ? 'bg-surface-hover text-tertiary cursor-not-allowed'
                                         : isInternal
                                             ? 'bg-status-warning text-white hover:opacity-90'
-                                            : 'bg-accent text-white hover:opacity-90'
+                                            // `text-on-accent`, not `text-white`: the accent
+                                            // foreground is picked per theme by luminance, and
+                                            // brand orange resolves to BLACK. White here was
+                                            // low-contrast on the default theme and unreadable
+                                            // on the light-accent presets (everforest, gruvbox).
+                                            : 'bg-accent text-on-accent hover:opacity-90'
                                 ]"
                                 :aria-label="isInternal ? $t('ticket-comments-submit-note') : $t('ticket-comments-submit-reply')"
                                 :title="isInternal ? $t('ticket-comments-submit-note') : $t('ticket-comments-submit-reply')"

--- a/frontend/src/components/ticketComponents/TicketGapFlag.vue
+++ b/frontend/src/components/ticketComponents/TicketGapFlag.vue
@@ -41,16 +41,16 @@ async function unflag() {
 <template>
   <div
     v-if="isFlagged && gap"
-    class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 flex items-start gap-2 print:hidden"
+    class="rounded-lg border border-status-warning/30 bg-status-warning-muted px-3 py-2 flex items-start gap-2 print:hidden"
   >
-    <Icon name="warning" class="text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+    <Icon name="warning" class="text-status-warning flex-shrink-0 mt-0.5" />
     <div class="flex-1 min-w-0">
-      <p class="text-xs font-medium text-amber-800 dark:text-amber-200">
+      <p class="text-xs font-medium text-status-warning">
         {{ t('ticket-chip-gap-flagged') }}
       </p>
       <RouterLink
         :to="`/documentation/gaps/${gap.id}`"
-        class="text-[11px] text-amber-700 dark:text-amber-300 hover:underline"
+        class="text-[11px] text-status-warning hover:underline"
       >
         {{ t('ticket-chip-gap-view-queue') }}
       </RouterLink>

--- a/frontend/src/components/ticketComponents/VideoPlayer.vue
+++ b/frontend/src/components/ticketComponents/VideoPlayer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { logger } from '@nosdesk/core/utils/logger'
 import { ref, onMounted, onUnmounted, computed } from 'vue';
 import { useFluent } from 'fluent-vue';
 import ProgressBar from '@/components/ticketComponents/ProgressBar.vue';
@@ -44,7 +45,7 @@ const formatTime = (seconds: number): string => {
 const log = (event: string, details?: any) => {
   // Only log critical events, not mouse movements
   if (!event.includes('mousemove') && !event.includes('showControls')) {
-    console.log(`[VideoPlayer] ${event}`, details || '');
+    logger.debug(`[VideoPlayer] ${event}`, { details });
   }
 };
 

--- a/frontend/src/components/ticketComponents/VoiceRecorder.vue
+++ b/frontend/src/components/ticketComponents/VoiceRecorder.vue
@@ -361,9 +361,7 @@ const startRecording = async () => {
     if (speechSupported.value) {
       resetSpeech();
       startSpeech();
-      console.log('[VoiceRecorder] Speech recognition started');
     } else {
-      console.log('[VoiceRecorder] Speech recognition not supported');
     }
   } catch (error) {
     console.error("Error accessing microphone:", error);
@@ -389,7 +387,6 @@ const stopRecording = () => {
         return;
       }
 
-      console.log('[VoiceRecorder] Emitting with transcription:', finalTranscription);
       emit('recordingComplete', {
         blob: audioBlob,
         duration: recordingTime.value,

--- a/frontend/src/components/views/FilterPill.vue
+++ b/frontend/src/components/views/FilterPill.vue
@@ -6,8 +6,11 @@
  *  - Body click  -> opens the value picker (re-edit selection)
  *  - X button    -> removes the filter entirely
  *
- * Style mirrors the reference design: bordered amber/accent pill
- * with the facet label, a colon, and a short value summary.
+ * Styled as an active control: the same `border-accent/40 bg-accent/10
+ * text-accent` treatment GroupByMenu uses for an active axis, so an
+ * applied filter and an applied grouping read as one system. It was
+ * hardcoded amber, which drifted from the accent beside it and ignored
+ * the theme entirely — the accent is per-theme and workspace-brandable.
  *
  * Title-facet pills get a text input in the popover instead of
  * the checkbox list, so search lives in the same affordance as
@@ -73,12 +76,12 @@ function onRemove(e: MouseEvent): void {
   <div class="inline-flex">
     <div
       ref="triggerRef"
-      class="inline-flex items-center h-6 rounded-md border border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300 text-[11px] overflow-hidden"
+      class="inline-flex items-center h-6 rounded-md border border-accent/40 bg-accent/10 text-accent text-[11px] overflow-hidden"
     >
       <button
         type="button"
         class="inline-flex items-center gap-1 pl-2 pr-1.5 h-full transition-colors"
-        :class="open ? 'bg-amber-500/20' : 'hover:bg-amber-500/15'"
+        :class="open ? 'bg-accent/20' : 'hover:bg-accent/15'"
         :aria-expanded="open"
         aria-haspopup="menu"
         @click="open = !open"
@@ -88,7 +91,7 @@ function onRemove(e: MouseEvent): void {
       </button>
       <button
         type="button"
-        class="inline-flex items-center justify-center h-full pr-1.5 pl-0.5 hover:bg-amber-500/15 transition-colors"
+        class="inline-flex items-center justify-center h-full pr-1.5 pl-0.5 hover:bg-accent/15 transition-colors"
         :title="$t('views-filter-pill-remove-tooltip', { label })"
         @click="onRemove"
       >

--- a/frontend/src/composables/useSpeechRecognition.ts
+++ b/frontend/src/composables/useSpeechRecognition.ts
@@ -94,7 +94,6 @@ export function useSpeechRecognition() {
       }
       interimTranscript.value = interimText
       if (import.meta.env.DEV) {
-        console.log('[useSpeechRecognition] Result:', { final: finalText, interim: interimText })
       }
     }
 

--- a/frontend/src/sync/views/KanbanBoard.vue
+++ b/frontend/src/sync/views/KanbanBoard.vue
@@ -887,7 +887,13 @@ function affectedDevicesTooltip(card: CardData): string {
       @dragover="onExternalDragOver"
       @drop="onExternalDrop"
     >
-      <div class="kanban-board-inner flex min-h-full min-w-min gap-3 p-3 items-start max-md:scroll-px-3">
+      <!-- `items-start` sizes each column to its content, which is right on a
+           desktop where every column is on screen and a ragged bottom edge
+           reads as "this one has less in it". Below `md` one column fills the
+           viewport, so content-sizing instead leaves a stunted white box
+           floating in grey — an empty lane rendered as 352px of nothing. Stretch
+           there so the column you are looking at occupies the screen. -->
+      <div class="kanban-board-inner flex min-h-full min-w-min gap-3 p-3 items-start max-md:items-stretch max-md:scroll-px-3">
       <div
         v-for="lane in lanes"
         :key="lane.id"

--- a/frontend/src/sync/views/gantt/GanttBoard.vue
+++ b/frontend/src/sync/views/gantt/GanttBoard.vue
@@ -34,7 +34,7 @@ import {
 import type { CardData } from '@nosdesk/core/sync/views/types'
 import type { DependencyEdge } from '@nosdesk/core/services/dependenciesService'
 import { TERMINAL_CATEGORIES, coarseStatusBucket } from '@nosdesk/core/types/workflow'
-import { GANTT_ZOOMS, startOfDay, type GanttViewport } from '@/composables/useGanttViewport'
+import { GANTT_ZOOMS, daysBetween, startOfDay, type GanttViewport } from '@/composables/useGanttViewport'
 import EmptyState from '@/components/common/EmptyState.vue'
 import Icon from '@/components/common/Icon.vue'
 import HoverCard from '@/components/common/HoverCard.vue'
@@ -44,6 +44,14 @@ import GanttBarHoverCard from './GanttBarHoverCard.vue'
 import TicketDragPreview from '@/components/common/TicketDragPreview.vue'
 import { useDragDrop } from '@/sync/views/drag'
 import { useBarDrag } from './useBarDrag'
+import type { GanttCycle } from './types'
+import { naiveDay } from './types'
+import {
+  cycleBodyClass,
+  cycleStripClass,
+  datedCycleSpans,
+  projectCycleBand,
+} from './cycleSpans'
 import type { UseListGrouping } from '@/composables/useListGrouping'
 import type { Density } from '@/composables/useTicketsDensity'
 import {
@@ -59,16 +67,8 @@ import { buildRows, splitSchedule, type GanttRow, type ScheduledCard } from './r
 const fluent = useFluent()
 const t = (k: string, args?: Record<string, string | number>) => fluent.$t(k, args)
 
-/** The slice of a cycle the board renders (bands + grouping labels).
- *  Structural, so both the REST DTO and the pool row satisfy it. */
-export interface GanttCycle {
-  id: number
-  uuid: string
-  name: string
-  state: 'planned' | 'active' | 'completed'
-  start_at?: string | null
-  end_at?: string | null
-}
+// Re-export so existing importers of the board's cycle type keep working.
+export type { GanttCycle } from './types'
 
 const props = withDefaults(defineProps<{
   cards: readonly CardData[]
@@ -320,6 +320,9 @@ const todayInRange = computed(
 const todayX = computed(() => xOf(today.value))
 
 // ===================== Cycle bands =====================
+// Date-space spans are shared with the vertical timeline; this view
+// maps them through `xOf` (which is itself `days * pxPerDay` from the
+// canvas origin, so projectCycleBand + dayOffset matches xOf exactly).
 
 interface CycleBand {
   key: string
@@ -329,41 +332,21 @@ interface CycleBand {
   state: GanttCycle['state']
 }
 
-/** Cycles with both dates become shaded bands spanning their range.
- *  end_at is inclusive, so the band runs through the end of that day. */
 const cycleBands = computed<CycleBand[]>(() => {
   const max = totalWidth.value
-  const out: CycleBand[] = []
-  for (const c of props.cycles) {
-    if (!c.start_at || !c.end_at) continue
-    const rawLeft = xOf(startOfDay(new Date(c.start_at)))
-    const rawRight = xOf(addDays(startOfDay(new Date(c.end_at)), 1))
-    if (rawRight <= 0 || rawLeft >= max) continue
-    const left = Math.max(0, rawLeft)
-    out.push({
-      key: c.uuid,
-      left,
-      width: Math.max(1, Math.min(max, rawRight) - left),
-      label: c.name,
-      state: c.state,
-    })
-  }
-  return out
+  // projectCycleBand + daysBetween is exactly xOf for each edge.
+  return datedCycleSpans(props.cycles).flatMap((span) => {
+    const band = projectCycleBand(span, canvasStart.value, max, pxPerDay.value, daysBetween)
+    if (!band) return []
+    return [{
+      key: band.key,
+      left: band.offset,
+      width: band.extent,
+      label: band.label,
+      state: band.state,
+    }]
+  })
 })
-
-/** Strip-label tint by cycle state: active stands out, planned is
- *  neutral, completed is muted. */
-function cycleStripClass(state: GanttCycle['state']): string {
-  if (state === 'active') return 'bg-accent/15 text-accent border-accent/40'
-  if (state === 'planned') return 'bg-surface-hover text-secondary border-subtle'
-  return 'bg-surface-alt text-tertiary border-subtle'
-}
-
-/** Body shading: a faint wash so the band reads behind the bars
- *  without competing with them. */
-function cycleBodyClass(state: GanttCycle['state']): string {
-  return state === 'active' ? 'bg-accent/5' : 'bg-surface-hover/30'
-}
 
 // ===================== Bars =====================
 
@@ -398,14 +381,6 @@ watch(
 )
 onUnmounted(() => vp.attachScroller(null))
 
-/** Naive local-midnight datetime (no tz suffix). Dates round-trip
- *  through the backend's NaiveDateTime model, whose deserialiser
- *  rejects a trailing `Z`; sending the local day also keeps the bar
- *  anchored to the day the user dropped it on. */
-function naiveDay(d: Date): string {
-  return `${format(d, 'yyyy-MM-dd')}T00:00:00`
-}
-
 // Declared before `bars` because the visibleCount watchEffect below
 // evaluates that computed synchronously at setup.
 const barDrag = useBarDrag({
@@ -413,6 +388,7 @@ const barDrag = useBarDrag({
   canvasStart,
   bodyEl,
   scroller: scrollerEl,
+  axis: 'x',
   onDragStart: () => hover.dismiss(),
   onCommit: ({ cardId, mode, start, end }) => {
     if (mode === 'due') props.onReschedule?.(cardId, { due_date: naiveDay(end) })

--- a/frontend/src/sync/views/gantt/VerticalTimeline.vue
+++ b/frontend/src/sync/views/gantt/VerticalTimeline.vue
@@ -36,7 +36,7 @@
  * preserves duration. No edge handles — a 36px day marker cannot host one —
  * and no tray-to-canvas drop. One verb, the same `useBarDrag` model, time on Y.
  */
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useFluent } from 'fluent-vue'
 import { addDays, differenceInCalendarDays, format, startOfDay, startOfMonth, startOfWeek } from 'date-fns'
 import type { CardData } from '@nosdesk/core/sync/views/types'
@@ -49,7 +49,7 @@ import {
   laneCount as countLanes,
   laneWidth as widthForLanes,
 } from './verticalLayout'
-import { computeTimelineWindow } from './timelineWindow'
+import { computeTimelineWindow, landingScrollTop } from './timelineWindow'
 import type { GanttCycle } from './types'
 import { naiveDay } from './types'
 import {
@@ -278,6 +278,59 @@ const todayY = computed(() => {
   return offset * PX_PER_DAY
 })
 
+/**
+ * Open where the work is.
+ *
+ * Cycles expand the window, so a project whose cycles began months ago gets a
+ * canvas several screens tall with every live ticket at the bottom; opening at
+ * the top showed an empty calendar (measured: 6 bars, 0 visible, the first one
+ * 2988px down). The desktop board has the same hazard and solves it with
+ * `scrollToFirstPopulatedLane`; this is that, with time on Y.
+ *
+ * Fires on the first render that actually HAS bars, not on mount: the sync pool
+ * fills in after mount, so on mount there is nothing to aim at. Runs once — the
+ * `landed` latch keeps a later scroll from being yanked back.
+ */
+function landOnTheWork(): void {
+  const el = scrollerEl.value
+  if (!el) return
+  const tops = placed.value.map((p) => differenceInCalendarDays(p.item.start, window_.value.start) * PX_PER_DAY)
+  const bottoms = placed.value.map(
+    (p, i) => tops[i] + blockHeight(p),
+  )
+  el.scrollTop = landingScrollTop({
+    // Unclamped on purpose: outside the canvas is how an all-past or
+    // all-future plan is detected.
+    todayY: differenceInCalendarDays(startOfDay(new Date()), window_.value.start) * PX_PER_DAY,
+    firstBarTop: tops.length ? Math.min(...tops) : null,
+    lastBarBottom: bottoms.length ? Math.max(...bottoms) : null,
+    viewportHeight: el.clientHeight,
+    canvasHeight: canvasHeight.value,
+  })
+}
+
+/**
+ * Set the moment the reader takes control, after which nothing moves the
+ * canvas under them again.
+ *
+ * Latching on "we have landed once" is not enough. The sync pool streams bars
+ * in and the window is derived from that data, so the first bar to arrive lands
+ * on a 684px canvas which then grows to 3276px as the rest follow — a landing
+ * that was correct for a canvas which no longer exists, and measurably left the
+ * view at scrollTop 0. Re-landing on each change until the reader intervenes is
+ * what makes it settle in the right place.
+ */
+const userTookOver = ref(false)
+
+watch(
+  [() => placed.value.length, canvasHeight],
+  ([count]) => {
+    if (userTookOver.value || count === 0) return
+    void nextTick(landOnTheWork)
+  },
+  { immediate: true },
+)
+
 function blockStyle(p: { item: ScheduledCard; lane: number }) {
   const top = differenceInCalendarDays(p.item.start, window_.value.start) * PX_PER_DAY
   const height = blockHeight(p)
@@ -392,6 +445,9 @@ function onResize(el: HTMLElement | null): void {
       v-else
       ref="scrollerEl"
       class="flex-1 min-h-0 overflow-auto overscroll-contain"
+      @wheel.passive="userTookOver = true"
+      @touchstart.passive="userTookOver = true"
+      @pointerdown="userTookOver = true"
     >
       <!-- Canvas. Height is proportional to the window's duration, so vertical
            distance is time; nothing here is a fixed-height row. Width is the

--- a/frontend/src/sync/views/gantt/VerticalTimeline.vue
+++ b/frontend/src/sync/views/gantt/VerticalTimeline.vue
@@ -31,6 +31,10 @@
  * `created_at` when a ticket has no authored `start_date`, which is a
  * low-precision guess presented as fact. Inferred starts render hatched so a
  * plan does not masquerade as a measurement.
+ *
+ * Write path (deliberately narrower than desktop): hold-to-move the block
+ * preserves duration. No edge handles — a 36px day marker cannot host one —
+ * and no tray-to-canvas drop. One verb, the same `useBarDrag` model, time on Y.
  */
 import { computed, ref } from 'vue'
 import { useFluent } from 'fluent-vue'
@@ -45,6 +49,17 @@ import {
   laneCount as countLanes,
   laneWidth as widthForLanes,
 } from './verticalLayout'
+import { computeTimelineWindow } from './timelineWindow'
+import type { GanttCycle } from './types'
+import { naiveDay } from './types'
+import {
+  cycleBodyClass,
+  cycleStripClass,
+  datedCycleSpans,
+  projectCycleBand,
+} from './cycleSpans'
+import { useBarDrag } from './useBarDrag'
+import { daysBetween } from '@/composables/useGanttViewport'
 import { TERMINAL_CATEGORIES, coarseStatusBucket } from '@nosdesk/core/types/workflow'
 import PriorityIndicator from '@/components/common/PriorityIndicator.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
@@ -54,8 +69,23 @@ const t = (k: string, args?: Record<string, string | number>) => fluent.$t(k, ar
 
 const props = withDefaults(defineProps<{
   cards: readonly CardData[]
+  /** Project cycles, rendered as shaded context bands (dated ones only). */
+  cycles?: readonly GanttCycle[]
   onCardClick?: (cardId: number) => void
-}>(), { onCardClick: undefined })
+  /**
+   * Direct-manipulation write-back for body drag (moves start + due).
+   * Omitting the prop keeps the timeline read-only, same contract as
+   * the desktop board.
+   */
+  onReschedule?: (
+    cardId: number,
+    patch: { start_date?: string; due_date?: string },
+  ) => void
+}>(), {
+  cycles: () => [],
+  onCardClick: undefined,
+  onReschedule: undefined,
+})
 
 /** Vertical scale. 36px/day keeps a fortnight on ~500px, which is one
  *  comfortable scroll, and leaves a single-day block tall enough to letter. */
@@ -68,6 +98,8 @@ const PX_PER_DAY = 36
 const MIN_TICK_PX = 30
 
 const rootEl = ref<HTMLElement | null>(null)
+const scrollerEl = ref<HTMLElement | null>(null)
+const bodyEl = ref<HTMLElement | null>(null)
 const width = ref(390)
 const viewportHeight = ref(600)
 
@@ -100,41 +132,107 @@ const scheduled = computed<ScheduledCard[]>(() =>
 )
 const unscheduled = computed(() => split.value.unscheduled)
 
-/** Window covering everything scheduled, padded a day each side so bars do not
- *  sit flush against the ends. */
+const cycleSpans = computed(() => datedCycleSpans(props.cycles))
+
+/** Window covering scheduled work and dated cycles, padded and never
+ *  shorter than a screenful. Cycles expand the canvas so a framing
+ *  cycle is never clipped just because no ticket sits on its edges. */
 const window_ = computed(() => {
-  const items = scheduled.value
-  if (items.length === 0) {
-    const today = startOfDay(new Date())
-    return { start: addDays(today, -1), days: 14 }
-  }
-  let min = items[0].start
-  let max = items[0].end
-  for (const it of items) {
-    if (it.start < min) min = it.start
-    if (it.end > max) max = it.end
-  }
-  const start = addDays(startOfDay(min), -1)
-  // Always cover at least a screenful of time. A tight window ended the canvas
-  // two-thirds up the display and left a large blank below it, which reads as a
-  // view that failed to finish loading rather than as a plan that finishes
-  // early. Extending the window keeps the ruler running to the bottom edge.
-  const spanned = differenceInCalendarDays(max, start) + 2
-  const screenful = Math.ceil(viewportHeight.value / PX_PER_DAY)
-  return { start, days: Math.max(3, spanned, screenful) }
+  const spans = [
+    ...scheduled.value.map((s) => ({ start: s.start, end: s.end })),
+    ...cycleSpans.value.map((c) => ({ start: c.start, end: c.endExclusive })),
+  ]
+  return computeTimelineWindow(spans, {
+    viewportHeight: viewportHeight.value,
+    pxPerDay: PX_PER_DAY,
+  })
 })
 
 const canvasHeight = computed(() => window_.value.days * PX_PER_DAY)
 
+// ---- drag (move-only; axis Y) ------------------------------------------
+// Same model as the desktop board. Handles are intentionally absent: a
+// day-tall mark cannot host an edge grip, and duration-preserving move
+// is the high-value mobile verb ("this slipped a week").
+const pxPerDayRef = computed(() => PX_PER_DAY)
+const canvasStartRef = computed(() => window_.value.start)
+
+const barDrag = useBarDrag({
+  pxPerDay: pxPerDayRef,
+  canvasStart: canvasStartRef,
+  bodyEl,
+  scroller: scrollerEl,
+  axis: 'y',
+  onCommit: ({ cardId, start, end }) => {
+    // Body move always writes both edges (promotes an inferred start).
+    props.onReschedule?.(cardId, {
+      start_date: naiveDay(start),
+      due_date: naiveDay(end),
+    })
+  },
+})
+
+/** Scheduled items with the live drag preview applied, so the moving
+ *  block and its lane reassignment track the finger. */
+const scheduledLive = computed<ScheduledCard[]>(() => {
+  const p = barDrag.preview.value
+  if (!p) return scheduled.value
+  return scheduled.value.map((s) =>
+    s.card.id === p.cardId ? { ...s, start: p.start, end: p.end } : s,
+  )
+})
+
 // Lane assignment + the fidelity ladder live in ./verticalLayout as pure
 // functions so the concurrency ceiling can be asserted in a unit test rather
 // than inferred from a screenshot of whatever the data happens to hold.
-const placed = computed(() => assignLanes(scheduled.value))
+const placed = computed(() => assignLanes(scheduledLive.value))
 const lanes = computed(() => countLanes(placed.value))
 const laneWidth = computed(() => widthForLanes(width.value, lanes.value))
 /** Equals the viewport until concurrency pushes columns onto their legibility
  *  floor, past which the canvas is wider and the view pans sideways. */
 const canvasW = computed(() => canvasWidth(width.value, lanes.value))
+
+const cycleBands = computed(() =>
+  cycleSpans.value.flatMap((span) => {
+    const band = projectCycleBand(
+      span,
+      window_.value.start,
+      canvasHeight.value,
+      PX_PER_DAY,
+      daysBetween,
+    )
+    return band ? [band] : []
+  }),
+)
+
+/** Ghost of the pre-drag span so the move reads as a translation.
+ *  Lane comes from the pre-drag layout (scheduled, not live) so the
+ *  outline stays put while the block reflows under the finger. */
+const dragGhost = computed(() => {
+  const p = barDrag.preview.value
+  if (!p) return null
+  const top = daysBetween(window_.value.start, p.origStart) * PX_PER_DAY
+  const height = Math.max(22, daysBetween(p.origStart, p.origEnd) * PX_PER_DAY)
+  const origLane =
+    assignLanes(scheduled.value).find((x) => x.item.card.id === p.cardId)?.lane ?? 0
+  // Chip rides the live leading edge so it tracks the drop day.
+  const liveLane =
+    placed.value.find((x) => x.item.card.id === p.cardId)?.lane ?? origLane
+  const colW = Math.max(14, laneWidth.value - 4)
+  return {
+    top,
+    height,
+    left: GUTTER + origLane * laneWidth.value,
+    width: colW,
+    chipLabel: format(p.start, 'MMM d'),
+    chipTop: daysBetween(window_.value.start, p.start) * PX_PER_DAY,
+    chipLeft: GUTTER + liveLane * laneWidth.value + colW / 2,
+  }
+})
+
+const canReschedule = computed(() => !!props.onReschedule)
+/** Card currently under a live drag preview (template-friendly). */
+const draggingCardId = computed(() => barDrag.preview.value?.cardId ?? null)
 
 /** Fidelity for a block, given the room its column and duration give it. */
 function fidelity(heightPx: number): 'full' | 'compact' | 'mark' {
@@ -247,6 +345,22 @@ function inferredStart(card: CardData): boolean {
   return !card.start_date
 }
 
+function beginMove(p: { item: ScheduledCard }, event: PointerEvent): void {
+  if (!props.onReschedule) return
+  // Committed span only — never seed a drag from a live preview residual.
+  const base = scheduled.value.find((s) => s.card.id === p.item.card.id) ?? p.item
+  barDrag.begin(
+    'move',
+    { cardId: base.card.id, start: base.start, end: base.end },
+    event,
+  )
+}
+
+function onBlockClick(cardId: number): void {
+  if (barDrag.shouldSuppressClick()) return
+  props.onCardClick?.(cardId)
+}
+
 function onResize(el: HTMLElement | null): void {
   if (!el) return
   rootEl.value = el
@@ -264,7 +378,7 @@ function onResize(el: HTMLElement | null): void {
     <!-- Nothing scheduled: say so plainly rather than presenting an empty
          ruler, which reads as a broken view. -->
     <div
-      v-if="scheduled.length === 0"
+      v-if="scheduled.length === 0 && cycleBands.length === 0"
       class="flex-1 min-h-0 flex items-center justify-center px-8 text-center"
     >
       <p class="text-sm text-tertiary max-w-[16rem]">{{ t('gantt-nothing-scheduled') }}</p>
@@ -274,12 +388,20 @@ function onResize(el: HTMLElement | null): void {
          time, across is concurrency and stays put entirely below five parallel
          tickets. Touch pans a single element diagonally, so no nested scrollers
          compete for the gesture. -->
-    <div v-else class="flex-1 min-h-0 overflow-auto overscroll-contain">
+    <div
+      v-else
+      ref="scrollerEl"
+      class="flex-1 min-h-0 overflow-auto overscroll-contain"
+    >
       <!-- Canvas. Height is proportional to the window's duration, so vertical
            distance is time; nothing here is a fixed-height row. Width is the
            viewport unless concurrency has outgrown it. -->
       <!-- pb keeps the last block clear of the tab bar and the home indicator. -->
-      <div class="relative pb-16" :style="{ height: `${canvasHeight}px`, width: `${canvasW}px` }">
+      <div
+        ref="bodyEl"
+        class="relative pb-16"
+        :style="{ height: `${canvasHeight}px`, width: `${canvasW}px` }"
+      >
         <!-- Weekends. Drawn under the measure so the grid reads as a calendar.
              Banding starts after the gutter: the bands belong to the plotting
              area, and keeping the ruler a clean strip is what lets its labels
@@ -291,11 +413,24 @@ function onResize(el: HTMLElement | null): void {
           :style="{ top: `${w.y}px`, height: `${w.h}px`, left: `${GUTTER}px` }"
         />
 
+        <!-- Cycle band washes (behind bars, same nesting rule as weekends). -->
+        <div
+          v-for="band in cycleBands"
+          :key="`shade-${band.key}`"
+          class="absolute right-0 border-t border-b border-subtle/60 pointer-events-none"
+          :class="cycleBodyClass(band.state)"
+          :style="{
+            top: `${band.offset}px`,
+            height: `${band.extent}px`,
+            left: `${GUTTER}px`,
+          }"
+        />
+
         <!-- Adaptive civic measure. -->
         <div
           v-for="tick in ticks"
           :key="tick.y"
-          class="absolute left-0 right-0 flex items-start gap-2"
+          class="absolute left-0 right-0 flex items-start gap-2 pointer-events-none"
           :style="{ top: `${tick.y}px` }"
         >
           <!-- Pinned: the ruler is the reference for everything on the canvas,
@@ -310,6 +445,26 @@ function onResize(el: HTMLElement | null): void {
           />
         </div>
 
+        <!-- Cycle labels at the leading edge of each band. Sticky left so
+             pan-across-concurrency keeps the name; pointer-events-none so
+             they never steal a block's hold-to-drag. -->
+        <div
+          v-for="band in cycleBands"
+          :key="`label-${band.key}`"
+          class="absolute z-[5] pointer-events-none"
+          :style="{
+            top: `${band.offset + 2}px`,
+            left: `${GUTTER + 4}px`,
+            maxWidth: `${Math.max(48, canvasW - GUTTER - 12)}px`,
+          }"
+        >
+          <span
+            class="sticky left-12 inline-block max-w-full truncate rounded px-1.5 py-0.5 text-[10px] font-medium border"
+            :class="cycleStripClass(band.state)"
+            :title="band.label"
+          >{{ band.label }}</span>
+        </div>
+
         <!-- Now. Starts after the gutter so it never strikes through a ruler
              label, and carries a dot so it reads as a marker not a divider. -->
         <div
@@ -321,20 +476,48 @@ function onResize(el: HTMLElement | null): void {
           <span class="flex-1 border-t border-accent/60" />
         </div>
 
+        <!-- Ghost of the pre-drag position. -->
+        <div
+          v-if="dragGhost"
+          class="absolute rounded-md border border-dashed border-default/60 bg-surface/40 pointer-events-none z-[15]"
+          :style="{
+            top: `${dragGhost.top}px`,
+            height: `${dragGhost.height}px`,
+            left: `${dragGhost.left}px`,
+            width: `${dragGhost.width}px`,
+          }"
+        />
+
+        <!-- Live date chip while moving. -->
+        <div
+          v-if="dragGhost"
+          class="absolute z-30 pointer-events-none rounded-full bg-accent px-1.5 py-px text-[10px] font-semibold text-on-accent tabular-nums whitespace-nowrap"
+          :style="{
+            top: `${dragGhost.chipTop}px`,
+            left: `${dragGhost.chipLeft}px`,
+            transform: 'translate(-50%, -50%)',
+          }"
+        >{{ dragGhost.chipLabel }}</div>
+
         <!-- Tickets. Height is duration; column is a concurrency lane. -->
         <button
           v-for="p in placed"
           :key="p.item.card.id"
           type="button"
-          class="absolute rounded-md border text-left overflow-hidden motion-safe:transition-[box-shadow,filter] motion-safe:duration-150 active:brightness-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          :data-timeline-card-id="p.item.card.id"
+          :data-timeline-has-start-date="p.item.card.start_date ? 'true' : 'false'"
+          class="absolute rounded-md border text-left overflow-hidden motion-safe:transition-[box-shadow,filter] motion-safe:duration-150 active:brightness-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent z-[12]"
           :class="[
             statusClass(p.item.card),
             priorityEdgeClass(p.item.card.priority),
             inferredStart(p.item.card) ? 'nd-inferred-start' : '',
+            canReschedule ? 'cursor-grab active:cursor-grabbing' : '',
+            draggingCardId === p.item.card.id ? 'shadow-md ring-1 ring-accent/40' : '',
           ]"
           :style="blockStyle(p)"
           :title="`#${p.item.card.id} ${p.item.card.title}`"
-          @click="onCardClick?.(p.item.card.id)"
+          @pointerdown="beginMove(p, $event)"
+          @click="onBlockClick(p.item.card.id)"
         >
           <template v-if="fidelity(blockHeight(p)) === 'full'">
             <div class="px-1.5 py-1 flex flex-col gap-1 h-full">

--- a/frontend/src/sync/views/gantt/cycleSpans.spec.ts
+++ b/frontend/src/sync/views/gantt/cycleSpans.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { differenceInCalendarDays } from 'date-fns'
+import {
+  cycleBodyClass,
+  cycleStripClass,
+  datedCycleSpans,
+  projectCycleBand,
+} from './cycleSpans'
+import type { GanttCycle } from './types'
+
+const cycle = (partial: Partial<GanttCycle> & Pick<GanttCycle, 'uuid' | 'name'>): GanttCycle => ({
+  id: 1,
+  state: 'active',
+  ...partial,
+})
+
+describe('datedCycleSpans', () => {
+  it('skips cycles missing either date', () => {
+    expect(
+      datedCycleSpans([
+        cycle({ uuid: 'a', name: 'A', start_at: '2026-08-01' }),
+        cycle({ uuid: 'b', name: 'B', end_at: '2026-08-14' }),
+        cycle({ uuid: 'c', name: 'C' }),
+      ]),
+    ).toEqual([])
+  })
+
+  it('treats end_at as inclusive (half-open end is the next day)', () => {
+    const [span] = datedCycleSpans([
+      cycle({
+        uuid: 's1',
+        name: 'Sprint 1',
+        start_at: '2026-08-10T00:00:00',
+        end_at: '2026-08-14T00:00:00',
+        state: 'active',
+      }),
+    ])
+    expect(span.label).toBe('Sprint 1')
+    expect(span.state).toBe('active')
+    // 10,11,12,13,14 = 5 inclusive days → exclusive end is the 15th.
+    expect(differenceInCalendarDays(span.endExclusive, span.start)).toBe(5)
+    expect(span.start.getDate()).toBe(10)
+    expect(span.endExclusive.getDate()).toBe(15)
+  })
+
+  it('drops inverted or zero-length ranges', () => {
+    expect(
+      datedCycleSpans([
+        cycle({
+          uuid: 'bad',
+          name: 'Bad',
+          start_at: '2026-08-14',
+          end_at: '2026-08-10',
+        }),
+      ]),
+    ).toEqual([])
+  })
+})
+
+describe('projectCycleBand', () => {
+  const dayOffset = (from: Date, to: Date) => differenceInCalendarDays(to, from)
+  const canvasStart = new Date(2026, 7, 1) // 1 Aug local
+  const px = 36
+
+  it('projects a fully in-window span', () => {
+    const [span] = datedCycleSpans([
+      cycle({
+        uuid: 's',
+        name: 'S',
+        start_at: '2026-08-03',
+        end_at: '2026-08-05',
+      }),
+    ])
+    // 3 days inclusive → 3 * 36 = 108px, offset 2 days = 72.
+    const band = projectCycleBand(span, canvasStart, 30 * px, px, dayOffset)
+    expect(band).toMatchObject({ offset: 72, extent: 108, label: 'S' })
+  })
+
+  it('clips to the canvas and skips fully outside spans', () => {
+    const [inside] = datedCycleSpans([
+      cycle({
+        uuid: 'in',
+        name: 'In',
+        start_at: '2026-07-28',
+        end_at: '2026-08-02',
+      }),
+    ])
+    // Starts before canvas (Jul 28); inclusive end Aug 2 → exclusive Aug 3.
+    // On a canvas from Aug 1 that is two days: Aug 1 and Aug 2 → 2 * 36.
+    const clipped = projectCycleBand(inside, canvasStart, 30 * px, px, dayOffset)
+    expect(clipped?.offset).toBe(0)
+    expect(clipped?.extent).toBe(2 * px)
+
+    const [outside] = datedCycleSpans([
+      cycle({
+        uuid: 'out',
+        name: 'Out',
+        start_at: '2026-09-01',
+        end_at: '2026-09-10',
+      }),
+    ])
+    expect(projectCycleBand(outside, canvasStart, 14 * px, px, dayOffset)).toBeNull()
+  })
+})
+
+describe('cycle style helpers', () => {
+  it('marks active stronger than planned or completed', () => {
+    expect(cycleStripClass('active')).toContain('accent')
+    expect(cycleBodyClass('active')).toContain('accent')
+    expect(cycleStripClass('planned')).not.toContain('accent')
+    expect(cycleBodyClass('completed')).not.toContain('accent')
+  })
+})

--- a/frontend/src/sync/views/gantt/cycleSpans.ts
+++ b/frontend/src/sync/views/gantt/cycleSpans.ts
@@ -1,0 +1,90 @@
+/**
+ * Cycle spans in date-space. Pure: no pixels, no Vue.
+ *
+ * Desktop maps with `xOf`; the vertical timeline maps with
+ * `days * pxPerDay`. Both read the same half-open span so inclusive
+ * `end_at` days never drift between the two renderers.
+ */
+import { addDays } from 'date-fns'
+import { startOfDay } from '@/composables/useGanttViewport'
+import type { GanttCycle } from './types'
+
+export interface CycleSpan {
+  key: string
+  start: Date
+  /** Exclusive end (day after the inclusive end_at). */
+  endExclusive: Date
+  label: string
+  state: GanttCycle['state']
+}
+
+/**
+ * Cycles with both dates become spans covering their inclusive range.
+ * Undated cycles are context for grouping, not canvas geometry.
+ */
+export function datedCycleSpans(cycles: readonly GanttCycle[]): CycleSpan[] {
+  const out: CycleSpan[] = []
+  for (const c of cycles) {
+    if (!c.start_at || !c.end_at) continue
+    const start = startOfDay(new Date(c.start_at))
+    const endExclusive = addDays(startOfDay(new Date(c.end_at)), 1)
+    if (endExclusive.getTime() <= start.getTime()) continue
+    out.push({
+      key: c.uuid,
+      start,
+      endExclusive,
+      label: c.name,
+      state: c.state,
+    })
+  }
+  return out
+}
+
+/** Strip-label tint by cycle state: active stands out, planned is
+ *  neutral, completed is muted. */
+export function cycleStripClass(state: GanttCycle['state']): string {
+  if (state === 'active') return 'bg-accent/15 text-accent border-accent/40'
+  if (state === 'planned') return 'bg-surface-hover text-secondary border-subtle'
+  return 'bg-surface-alt text-tertiary border-subtle'
+}
+
+/** Body shading: a faint wash so the band reads behind the bars
+ *  without competing with them. */
+export function cycleBodyClass(state: GanttCycle['state']): string {
+  return state === 'active' ? 'bg-accent/5' : 'bg-surface-hover/30'
+}
+
+export interface ProjectedBand {
+  key: string
+  /** Offset along the time axis (px). */
+  offset: number
+  /** Extent along the time axis (px). */
+  extent: number
+  label: string
+  state: GanttCycle['state']
+}
+
+/**
+ * Project a date-space span onto a 1D canvas of `pxPerDay`, clipped
+ * to `[0, canvasExtent]`. Returns null when the span is entirely
+ * outside the canvas (same skip rule desktop uses for off-canvas cycles).
+ */
+export function projectCycleBand(
+  span: CycleSpan,
+  canvasStart: Date,
+  canvasExtentPx: number,
+  pxPerDay: number,
+  dayOffset: (from: Date, to: Date) => number,
+): ProjectedBand | null {
+  const rawStart = dayOffset(canvasStart, span.start) * pxPerDay
+  const rawEnd = dayOffset(canvasStart, span.endExclusive) * pxPerDay
+  if (rawEnd <= 0 || rawStart >= canvasExtentPx) return null
+  const offset = Math.max(0, rawStart)
+  return {
+    key: span.key,
+    offset,
+    extent: Math.max(1, Math.min(canvasExtentPx, rawEnd) - offset),
+    label: span.label,
+    state: span.state,
+  }
+}

--- a/frontend/src/sync/views/gantt/timelineWindow.spec.ts
+++ b/frontend/src/sync/views/gantt/timelineWindow.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeTimelineWindow } from './timelineWindow'
+import { computeTimelineWindow, landingScrollTop } from './timelineWindow'
 
 const day = (n: number): Date => new Date(2026, 7, 10 + n)
 
@@ -48,5 +48,94 @@ describe('computeTimelineWindow', () => {
       { viewportHeight, pxPerDay, now: day(0) },
     )
     expect(w.days).toBeGreaterThanOrEqual(Math.ceil(viewportHeight / pxPerDay))
+  })
+})
+
+/**
+ * Regression: the mobile gantt opened at the top of a canvas whose start is
+ * dragged back by old cycle bands, so the live work sat several screens down.
+ * Measured before the fix: 6 bars, 0 visible on open, first bar 2988px down.
+ */
+describe('landingScrollTop', () => {
+  const viewportHeight = 650
+  const canvasHeight = 3420
+
+  it('opens on today when the work is around now', () => {
+    const todayY = 2000
+    const top = landingScrollTop({
+      todayY,
+      firstBarTop: 1950,
+      lastBarBottom: 2400,
+      viewportHeight,
+      canvasHeight,
+    })
+    // On screen, and below the top edge rather than pinned to it, so a little
+    // history stays visible for context.
+    expect(todayY).toBeGreaterThan(top)
+    expect(todayY).toBeLessThan(top + viewportHeight)
+  })
+
+  it('puts the first bar on screen in the case that regressed', () => {
+    const top = landingScrollTop({
+      todayY: 3000,
+      firstBarTop: 2988,
+      lastBarBottom: 3300,
+      viewportHeight,
+      canvasHeight,
+    })
+    expect(2988).toBeGreaterThanOrEqual(top)
+    expect(2988).toBeLessThanOrEqual(top + viewportHeight)
+  })
+
+  it('opens on the last bar when every plan is in the past', () => {
+    const top = landingScrollTop({
+      todayY: 9999,
+      firstBarTop: 400,
+      lastBarBottom: 900,
+      viewportHeight,
+      canvasHeight,
+    })
+    expect(900).toBeGreaterThanOrEqual(top)
+    expect(900).toBeLessThanOrEqual(top + viewportHeight)
+  })
+
+  it('opens on the first bar when every plan is still ahead', () => {
+    const top = landingScrollTop({
+      todayY: -500,
+      firstBarTop: 1800,
+      lastBarBottom: 2200,
+      viewportHeight,
+      canvasHeight,
+    })
+    expect(1800).toBeGreaterThanOrEqual(top)
+    expect(1800).toBeLessThanOrEqual(top + viewportHeight)
+  })
+
+  it('falls back to today when nothing is scheduled', () => {
+    const todayY = 720
+    const top = landingScrollTop({
+      todayY,
+      firstBarTop: null,
+      lastBarBottom: null,
+      viewportHeight,
+      canvasHeight,
+    })
+    expect(todayY).toBeGreaterThan(top)
+    expect(todayY).toBeLessThan(top + viewportHeight)
+  })
+
+  it('never scrolls past either end of the canvas', () => {
+    expect(
+      landingScrollTop({ todayY: 0, firstBarTop: null, lastBarBottom: null, viewportHeight, canvasHeight }),
+    ).toBe(0)
+    expect(
+      landingScrollTop({ todayY: 99999, firstBarTop: null, lastBarBottom: null, viewportHeight, canvasHeight }),
+    ).toBe(canvasHeight - viewportHeight)
+  })
+
+  it('does not scroll a canvas that fits the viewport', () => {
+    expect(
+      landingScrollTop({ todayY: 200, firstBarTop: 100, lastBarBottom: 300, viewportHeight: 650, canvasHeight: 500 }),
+    ).toBe(0)
   })
 })

--- a/frontend/src/sync/views/gantt/timelineWindow.spec.ts
+++ b/frontend/src/sync/views/gantt/timelineWindow.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { computeTimelineWindow } from './timelineWindow'
+
+const day = (n: number): Date => new Date(2026, 7, 10 + n)
+
+describe('computeTimelineWindow', () => {
+  const pxPerDay = 36
+  const viewportHeight = 360 // 10 screenful days
+
+  it('falls back to a fortnight when nothing is dated', () => {
+    const w = computeTimelineWindow([], {
+      viewportHeight,
+      pxPerDay,
+      now: day(0),
+    })
+    expect(w.days).toBe(14)
+  })
+
+  it('covers ticket spans with one-day padding', () => {
+    const w = computeTimelineWindow(
+      [{ start: day(0), end: day(4) }],
+      { viewportHeight: 100, pxPerDay, now: day(0) },
+    )
+    // start = day(-1); end pad +2 on max → at least 4 - (-1) + 2 = 7
+    expect(w.start.getDate()).toBe(9)
+    expect(w.days).toBeGreaterThanOrEqual(7)
+  })
+
+  it('expands to include cycle extents beyond tickets', () => {
+    const ticketsOnly = computeTimelineWindow(
+      [{ start: day(0), end: day(2) }],
+      { viewportHeight: 100, pxPerDay, now: day(0) },
+    )
+    const withCycle = computeTimelineWindow(
+      [
+        { start: day(0), end: day(2) },
+        { start: day(-5), end: day(20) },
+      ],
+      { viewportHeight: 100, pxPerDay, now: day(0) },
+    )
+    expect(withCycle.days).toBeGreaterThan(ticketsOnly.days)
+    expect(withCycle.start.getTime()).toBeLessThan(ticketsOnly.start.getTime())
+  })
+
+  it('never shorter than a screenful of time', () => {
+    const w = computeTimelineWindow(
+      [{ start: day(0), end: day(1) }],
+      { viewportHeight, pxPerDay, now: day(0) },
+    )
+    expect(w.days).toBeGreaterThanOrEqual(Math.ceil(viewportHeight / pxPerDay))
+  })
+})

--- a/frontend/src/sync/views/gantt/timelineWindow.ts
+++ b/frontend/src/sync/views/gantt/timelineWindow.ts
@@ -1,0 +1,40 @@
+/**
+ * Vertical-timeline window: the date range the canvas covers.
+ *
+ * Pure so "cycles expand the canvas, tickets do not have to" is an
+ * assertion rather than an eyeball of whatever demo data is loaded.
+ */
+import { addDays, differenceInCalendarDays, startOfDay } from 'date-fns'
+
+export interface DateSpan {
+  start: Date
+  end: Date
+}
+
+/**
+ * Window covering every provided span, padded a day each side, and
+ * never shorter than a screenful of time so a short plan does not
+ * leave a blank two-thirds of the display.
+ *
+ * `spans` is tickets and cycle extents; callers decide the union.
+ * Empty input falls back to a fortnight around today.
+ */
+export function computeTimelineWindow(
+  spans: readonly DateSpan[],
+  opts: { viewportHeight: number; pxPerDay: number; now?: Date },
+): { start: Date; days: number } {
+  const today = startOfDay(opts.now ?? new Date())
+  if (spans.length === 0) {
+    return { start: addDays(today, -1), days: 14 }
+  }
+  let min = spans[0].start
+  let max = spans[0].end
+  for (const s of spans) {
+    if (s.start < min) min = s.start
+    if (s.end > max) max = s.end
+  }
+  const start = addDays(startOfDay(min), -1)
+  const spanned = differenceInCalendarDays(max, start) + 2
+  const screenful = Math.ceil(opts.viewportHeight / opts.pxPerDay)
+  return { start, days: Math.max(3, spanned, screenful) }
+}

--- a/frontend/src/sync/views/gantt/timelineWindow.ts
+++ b/frontend/src/sync/views/gantt/timelineWindow.ts
@@ -1,5 +1,6 @@
 /**
- * Vertical-timeline window: the date range the canvas covers.
+ * Vertical-timeline window: the date range the canvas covers, and where
+ * to open inside it.
  *
  * Pure so "cycles expand the canvas, tickets do not have to" is an
  * assertion rather than an eyeball of whatever demo data is loaded.
@@ -37,4 +38,43 @@ export function computeTimelineWindow(
   const spanned = differenceInCalendarDays(max, start) + 2
   const screenful = Math.ceil(opts.viewportHeight / opts.pxPerDay)
   return { start, days: Math.max(3, spanned, screenful) }
+}
+
+/** Fraction of the viewport left above the anchor, so the thing you opened
+ *  for sits just below the top edge with a little history for context. */
+const LEAD = 0.25
+
+/**
+ * Where the canvas should be scrolled to on open.
+ *
+ * The window is bounded by cycles as well as tickets, so a project whose
+ * cycles began months ago gets a canvas several screens tall with all the
+ * live work at the bottom. Opening at the top then shows an empty calendar:
+ * measured at 6 bars, 0 of them visible, the first one 2988px down. Cycle
+ * bands expanding the window is deliberate, so the fix belongs here rather
+ * than in the window.
+ *
+ * Anchors on today, then clamps that anchor into the range the work actually
+ * occupies. One rule covers every case: today near the work opens on today,
+ * an all-past plan opens on its last bar, an all-future plan on its first,
+ * and a project with nothing scheduled opens on today.
+ *
+ * `todayY` is unclamped — it may sit outside the canvas, which is exactly how
+ * an all-past or all-future plan is detected.
+ */
+export function landingScrollTop(opts: {
+  todayY: number
+  firstBarTop: number | null
+  lastBarBottom: number | null
+  viewportHeight: number
+  canvasHeight: number
+}): number {
+  const { todayY, firstBarTop, lastBarBottom, viewportHeight, canvasHeight } = opts
+  let anchor = todayY
+  if (firstBarTop !== null && lastBarBottom !== null) {
+    if (anchor < firstBarTop) anchor = firstBarTop
+    else if (anchor > lastBarBottom) anchor = lastBarBottom
+  }
+  const maxScroll = Math.max(0, canvasHeight - viewportHeight)
+  return Math.min(maxScroll, Math.max(0, Math.round(anchor - viewportHeight * LEAD)))
 }

--- a/frontend/src/sync/views/gantt/types.ts
+++ b/frontend/src/sync/views/gantt/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared gantt types and the one encoding used for date write-back.
+ *
+ * Structural on purpose: REST DTOs and pool rows both satisfy
+ * `GanttCycle` without adaptation.
+ */
+import { format } from 'date-fns'
+
+/** The slice of a cycle the board renders (bands + grouping labels). */
+export interface GanttCycle {
+  id: number
+  uuid: string
+  name: string
+  state: 'planned' | 'active' | 'completed'
+  start_at?: string | null
+  end_at?: string | null
+}
+
+/**
+ * Naive local-midnight datetime (no tz suffix). Dates round-trip
+ * through the backend's NaiveDateTime model, whose deserialiser
+ * rejects a trailing `Z`; sending the local day also keeps the bar
+ * anchored to the day the user dropped it on.
+ */
+export function naiveDay(d: Date): string {
+  return `${format(d, 'yyyy-MM-dd')}T00:00:00`
+}

--- a/frontend/src/sync/views/gantt/useBarDrag.spec.ts
+++ b/frontend/src/sync/views/gantt/useBarDrag.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { dayOffsetAt } from './useBarDrag'
+
+describe('dayOffsetAt', () => {
+  it('snaps to whole days from the axis origin', () => {
+    // origin at 100px, 36px/day: client 100 → day 0, 118 → day 0, 119 → day 1
+    expect(dayOffsetAt(100, 100, 36)).toBe(0)
+    expect(dayOffsetAt(100 + 17, 100, 36)).toBe(0)
+    expect(dayOffsetAt(100 + 18, 100, 36)).toBe(1)
+    expect(dayOffsetAt(100 + 36 * 3, 100, 36)).toBe(3)
+  })
+
+  it('works equally for a vertical origin (top) as for left', () => {
+    // Pure of axis: only the numbers matter. Vertical passes rect.top.
+    expect(dayOffsetAt(400, 200, 36)).toBe(Math.round(200 / 36))
+  })
+})

--- a/frontend/src/sync/views/gantt/useBarDrag.ts
+++ b/frontend/src/sync/views/gantt/useBarDrag.ts
@@ -7,6 +7,10 @@
  * continuous geometry with no lane and no click threshold on the
  * handles; the two models share nothing but pointer events.
  *
+ * Axis-agnostic: desktop runs time on X, the vertical timeline on Y.
+ * The drag model is identical; only which client coordinate maps to
+ * a day changes.
+ *
  * Semantics ("respect the data" rule):
  * - `due` handle: moves `due_date`, clamped after the start.
  * - `start` handle: moves `start_date`, clamped before the due.
@@ -27,9 +31,8 @@ import { createDragEdgeScroller } from '@/composables/useDragEdgeScroll'
 import { daysBetween } from '@/composables/useGanttViewport'
 import { createTouchHold } from '@/sync/views/touchHold'
 
-
-
 export type BarDragMode = 'move' | 'start' | 'due'
+export type BarDragAxis = 'x' | 'y'
 
 export interface BarDragPreview {
   cardId: number
@@ -49,17 +52,36 @@ export interface BarDragCommit {
   end: Date
 }
 
+/**
+ * Day offset (from canvasStart) under a client coordinate on the
+ * time axis. Pure so vertical and horizontal projection share one
+ * snap rule.
+ */
+export function dayOffsetAt(
+  client: number,
+  origin: number,
+  pxPerDay: number,
+): number {
+  return Math.round((client - origin) / pxPerDay)
+}
+
 export function useBarDrag(options: {
   pxPerDay: Ref<number>
   canvasStart: Ref<Date>
-  /** Timeline body cell; its rect's left edge is canvas x = 0. */
+  /** Timeline body; its rect's time-axis edge is canvas offset 0. */
   bodyEl: Ref<HTMLElement | null>
-  /** The two-axis scroll container, for edge auto-scroll. */
+  /** The scroll container, for edge auto-scroll. */
   scroller: Ref<HTMLElement | null>
+  /**
+   * Which client axis is time. Default `x` preserves the desktop
+   * board; the vertical timeline passes `y`.
+   */
+  axis?: BarDragAxis
   onCommit: (commit: BarDragCommit) => void
   /** Fired when a press becomes an actual drag (dismiss hover). */
   onDragStart?: () => void
 }) {
+  const axis: BarDragAxis = options.axis ?? 'x'
   const preview = ref<BarDragPreview | null>(null)
 
   let pointerId: number | null = null
@@ -76,21 +98,29 @@ export function useBarDrag(options: {
   const edgeScroller = createDragEdgeScroller({
     getTargets: () => {
       const el = options.scroller.value
-      return el ? [{ el, axes: 'x' as const }] : []
+      // Vertical canvas pans on both axes once concurrency exceeds the
+      // legibility floor; desktop gantt only edge-scrolls time (X).
+      const axes = axis === 'y' ? ('both' as const) : ('x' as const)
+      return el ? [{ el, axes }] : []
     },
-    onTick: (clientX) => {
+    onTick: (clientX, clientY) => {
       // Scrolling under a stationary pointer changes the day under
       // it; re-derive the preview.
-      if (dragging) applyPointer(clientX)
+      if (dragging) applyPointer(axisCoord(clientX, clientY))
     },
   })
 
-  /** Day offset (from canvasStart) under a client x. */
-  function dayAt(clientX: number): number {
+  function axisCoord(clientX: number, clientY: number): number {
+    return axis === 'y' ? clientY : clientX
+  }
+
+  /** Day offset (from canvasStart) under the pointer on the time axis. */
+  function dayAt(client: number): number {
     const body = options.bodyEl.value
     if (!body) return 0
     const rect = body.getBoundingClientRect()
-    return Math.round((clientX - rect.left) / options.pxPerDay.value)
+    const origin = axis === 'y' ? rect.top : rect.left
+    return dayOffsetAt(client, origin, options.pxPerDay.value)
   }
 
   function begin(
@@ -103,7 +133,7 @@ export function useBarDrag(options: {
     mode = m
     downX = event.clientX
     downY = event.clientY
-    downDay = dayAt(event.clientX)
+    downDay = dayAt(axisCoord(event.clientX, event.clientY))
     dragging = m !== 'move' // handles drag immediately; body waits for threshold
     preview.value = {
       cardId: bar.cardId,
@@ -133,19 +163,19 @@ export function useBarDrag(options: {
     })
   }
 
-  function applyPointer(clientX: number): void {
+  function applyPointer(client: number): void {
     const p = preview.value
     if (!p || !mode) return
     if (mode === 'due') {
-      let end = addDays(options.canvasStart.value, dayAt(clientX))
+      let end = addDays(options.canvasStart.value, dayAt(client))
       if (end.getTime() <= p.origStart.getTime()) end = addDays(p.origStart, 1)
       preview.value = { ...p, end }
     } else if (mode === 'start') {
-      let start = addDays(options.canvasStart.value, dayAt(clientX))
+      let start = addDays(options.canvasStart.value, dayAt(client))
       if (start.getTime() >= p.origEnd.getTime()) start = addDays(p.origEnd, -1)
       preview.value = { ...p, start }
     } else {
-      const delta = dayAt(clientX) - downDay
+      const delta = dayAt(client) - downDay
       preview.value = {
         ...p,
         start: addDays(p.origStart, delta),
@@ -160,17 +190,18 @@ export function useBarDrag(options: {
       // On touch, movement before the hold completes is a pan, not a drag.
       // Abandon the press so the browser keeps the gesture.
       if (touchHold.isTouch) {
-        if (touchHold.exceedsSlop(event.clientX - downX)) teardown()
+        if (touchHold.exceedsSlop(event.clientX - downX, event.clientY - downY)) teardown()
         return
       }
-      if (Math.abs(event.clientX - downX) <= 4) return
+      const delta = axis === 'y' ? event.clientY - downY : event.clientX - downX
+      if (Math.abs(delta) <= 4) return
       dragging = true
       options.onDragStart?.()
       edgeScroller.start()
       document.body.style.userSelect = 'none'
     }
     if (!dragging) return
-    applyPointer(event.clientX)
+    applyPointer(axisCoord(event.clientX, event.clientY))
     edgeScroller.update(event.clientX, event.clientY)
   }
 

--- a/frontend/src/utils/errorTracking.ts
+++ b/frontend/src/utils/errorTracking.ts
@@ -12,17 +12,18 @@
  */
 
 import type { App } from 'vue'
+import { logger } from '@nosdesk/core/utils/logger'
 // import * as Sentry from '@sentry/vue'
 // import router from '@/router'
 
 export function initErrorTracking(_app: App) {
   if (!import.meta.env.PROD) {
-    console.log('Error tracking disabled in development mode')
+    logger.debug('Error tracking disabled in development mode')
     return
   }
 
   // Stub implementation - will log to console in production for now
-  console.log('Error tracking initialized (stub)')
+  logger.info('Error tracking initialized (stub)')
 
   /*
   // To enable Sentry, uncomment this block:
@@ -103,7 +104,7 @@ export const ErrorTracker = {
   captureMessage: (message: string, level: 'info' | 'warning' | 'error' = 'info') => {
     if (import.meta.env.PROD) {
       // Stub implementation - log to console
-      console.log(`[ErrorTracker] ${level.toUpperCase()}:`, message)
+      logger.debug(`[ErrorTracker] ${level.toUpperCase()}: ${message}`)
 
       /*
       // To enable Sentry, uncomment this:
@@ -115,7 +116,7 @@ export const ErrorTracker = {
   setUser: (user: { id: string; username?: string; email?: string }) => {
     if (import.meta.env.PROD) {
       // Stub implementation - log to console
-      console.log('[ErrorTracker] User set:', user.id)
+      logger.debug('[ErrorTracker] User set', { id: user.id })
 
       /*
       // To enable Sentry, uncomment this:
@@ -127,7 +128,7 @@ export const ErrorTracker = {
   clearUser: () => {
     if (import.meta.env.PROD) {
       // Stub implementation - log to console
-      console.log('[ErrorTracker] User cleared')
+      logger.debug('[ErrorTracker] User cleared')
 
       /*
       // To enable Sentry, uncomment this:

--- a/frontend/src/views/DocumentView.vue
+++ b/frontend/src/views/DocumentView.vue
@@ -607,7 +607,7 @@ watch(documentObj, (newDocument) => {
         <button
           v-if="document && document.status !== 'published'"
           @click="handlePublishPage"
-          class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-emerald-600 text-white hover:bg-emerald-700 transition-colors"
+          class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-status-success text-white hover:opacity-90 transition-colors"
         >
           <Icon name="check" />
           <span class="hidden sm:inline">{{ $t('doc-detail-publish') }}</span>
@@ -618,7 +618,7 @@ watch(documentObj, (newDocument) => {
           v-if="isDocumentPage"
           @click="isStarred ? handleUnstar() : handleStar()"
           class="p-1.5 rounded-md hover:bg-surface-hover transition-colors"
-          :class="isStarred ? 'text-amber-500' : 'text-secondary hover:text-primary'"
+          :class="isStarred ? 'text-brand-gold' : 'text-secondary hover:text-primary'"
           :title="isStarred ? $t('doc-detail-unstar') : $t('doc-detail-star')"
         >
           <svg class="w-5 h-5" :fill="isStarred ? 'currentColor' : 'none'" stroke="currentColor" viewBox="0 0 24 24">
@@ -634,7 +634,7 @@ watch(documentObj, (newDocument) => {
           :title="copiedLink ? $t('doc-detail-copied') : $t('doc-detail-copy-link')"
         >
           <Icon v-if="!copiedLink" name="link" size="md" />
-          <Icon v-else name="check" size="md" class="text-emerald-500" />
+          <Icon v-else name="check" size="md" class="text-status-success" />
         </button>
 
         <!-- Document actions menu -->
@@ -707,8 +707,8 @@ watch(documentObj, (newDocument) => {
                 <!-- Metadata -->
                 <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-tertiary">
                   <!-- Status Badge -->
-                  <span v-if="document.status === 'draft'" class="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300 font-medium">{{ $t('doc-detail-status-draft') }}</span>
-                  <span v-else-if="document.status === 'archived'" class="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 dark:bg-gray-700/50 dark:text-gray-300 font-medium">{{ $t('doc-detail-status-archived') }}</span>
+                  <span v-if="document.status === 'draft'" class="text-[10px] px-1.5 py-0.5 rounded bg-status-warning-muted text-status-warning font-medium">{{ $t('doc-detail-status-draft') }}</span>
+                  <span v-else-if="document.status === 'archived'" class="text-[10px] px-1.5 py-0.5 rounded bg-surface-alt text-secondary font-medium">{{ $t('doc-detail-status-archived') }}</span>
 
                   <!--
                     Verification status chip — sits next to the
@@ -734,7 +734,7 @@ watch(documentObj, (newDocument) => {
                   <button
                     v-else-if="document.is_stale"
                     type="button"
-                    class="text-[10px] px-1.5 py-0.5 rounded font-medium bg-amber-500/15 text-amber-700 dark:text-amber-300 hover:bg-amber-500/25 transition-colors flex items-center gap-1 animate-pulse"
+                    class="text-[10px] px-1.5 py-0.5 rounded font-medium bg-status-warning-muted text-status-warning hover:bg-status-warning/25 transition-colors flex items-center gap-1 animate-pulse"
                     :title="$t('doc-detail-verification-stale-title')"
                     @click="verificationOpen = true"
                   >

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -136,7 +136,6 @@ const handleLogin = async () => {
 
     // Check if MFA setup is required and redirect to MFA setup view
     if (authStore.mfaSetupRequired) {
-      console.log('🔄 MFA setup required, redirecting to MFA setup view');
 
       // Store credentials securely in memory-only Pinia store
       mfaSetupStore.setCredentials(email.value, password.value, 'login');

--- a/frontend/src/views/MFASetupView.vue
+++ b/frontend/src/views/MFASetupView.vue
@@ -196,7 +196,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
-import { useRouter, useRoute } from 'vue-router';
+import { useRouter } from 'vue-router';
 import { landAfterLogin } from '@/router';
 import { useFluent } from 'fluent-vue';
 import { useAuthStore } from '@/stores/auth';
@@ -209,7 +209,6 @@ import LogoIcon from '@/components/icons/LogoIcon.vue';
 import Icon from '@/components/common/Icon.vue';
 
 const router = useRouter();
-const route = useRoute();
 const authStore = useAuthStore();
 const mfaSetupStore = useMfaSetupStore();
 const fluent = useFluent();
@@ -269,15 +268,9 @@ const backButtonText = computed(() => {
 
 // Security check and credential setup
 onMounted(async () => {
-  console.log('🔍 MFA Setup - Checking for credentials:', {
-    hasValidCredentials: mfaSetupStore.hasValidCredentials,
-    isAuthenticated: !!authStore.user,
-    route: route.fullPath
-  });
 
   // If user is already fully authenticated, redirect to dashboard
   if (authStore.user && !authStore.mfaSetupRequired) {
-    console.log('✅ User already authenticated, redirecting to dashboard');
     mfaSetupStore.clearCredentials();
     await landAfterLogin();
     return;
@@ -287,14 +280,12 @@ onMounted(async () => {
   if (mfaSetupStore.hasValidCredentials) {
     const creds = mfaSetupStore.getCredentials;
     if (creds) {
-      console.log('✅ Found valid setup credentials from:', creds.source);
       return;
     }
   }
 
   // No valid credentials - redirect back to login
   if (authStore.mfaSetupRequired && authStore.mfaUserUuid) {
-    console.log('🔄 No credentials found, but auth store indicates MFA setup required');
     errorMessage.value = t('mfa-setup-error-session-expired');
     setTimeout(() => {
       mfaSetupStore.clearCredentials();

--- a/frontend/src/views/PDFViewerView.vue
+++ b/frontend/src/views/PDFViewerView.vue
@@ -55,7 +55,6 @@ onMounted(() => {
 });
 
 const handlePdfReady = () => {
-  console.log('PDF loaded successfully');
 };
 
 const handlePdfError = (error: unknown) => {
@@ -73,7 +72,6 @@ const shareDocument = async () => {
   try {
     await navigator.clipboard.writeText(window.location.href);
     // Could add a toast notification here
-    console.log('Link copied to clipboard');
   } catch (err) {
     console.error('Failed to copy link:', err);
   }

--- a/frontend/src/views/ProjectGanttView.vue
+++ b/frontend/src/views/ProjectGanttView.vue
@@ -213,7 +213,9 @@ const headerSubtitle = computed(() => {
       v-if="isMobile"
       class="flex-1 min-h-0"
       :cards="cards"
+      :cycles="cycles"
       :on-card-click="openCard"
+      :on-reschedule="reschedule"
     />
     <GanttBoard
       v-else

--- a/frontend/src/views/UserProfileView.vue
+++ b/frontend/src/views/UserProfileView.vue
@@ -267,7 +267,6 @@ const saveUser = async () => {
             }
 
             const newUser = await userService.createUser(userData);
-            console.log('✅ User created successfully:', newUser);
 
             if (!newUser?.uuid) {
                 console.error('User created but no UUID returned:', newUser);
@@ -276,9 +275,7 @@ const saveUser = async () => {
             }
 
             // Navigate to the newly created user (replace history so back button goes to users list)
-            console.log('🔄 Navigating to user:', `/users/${newUser.uuid}`);
             await router.replace(`/users/${newUser.uuid}`);
-            console.log('✅ Navigation complete');
         } else {
             // Update existing user
             if (!userProfile.value) return;


### PR DESCRIPTION
Three passes over the mobile project views and the button colour system, plus a
`console.log` sweep. All verified against the running app, not just type-checked.

## The mobile gantt opened where the work isn't

Cycles legitimately expand the timeline window, so a project whose cycles began
months ago gets a canvas five screens tall with every live ticket at the bottom.
Measured before the fix: **6 bars, 0 of them visible on open**, the first one
2988px down.

`landingScrollTop` (new, in `timelineWindow.ts`, 7 tests) anchors on today and
clamps that anchor into the range the work occupies. One rule covers every case:
today near the work opens on today, an all-past plan opens on its last bar, an
all-future plan on its first, and a project with nothing scheduled opens on today.

The first attempt didn't work, and finding out why produced the more interesting
half. The sync pool streams bars in and the window is derived from that data, so
the first bar to arrive lands on a 684px canvas that then grows to 3276px — a
landing that was correct for a canvas which no longer existed, leaving the view at
scrollTop 0. It now re-lands on every change until the reader touches the scroller,
then never moves again. "Latch after the first landing", copied from the kanban,
is wrong when the geometry itself is still arriving.

After: project 3 shows 4 of 4 bars on open, project 2 shows 6 of 6.

## Board, dropdown, chart

- **Board columns stretch below `md`.** `items-start` sizes a column to its content,
  right on a desktop where every column is visible; on a phone the one column
  filling the viewport rendered as a stunted 352px box floating in grey.
- **`BaseDropdown` size `xs` gets a 44px floor on coarse pointers.** It was the only
  sub-44px target left in the project views, at 26px. `min-h` rather than padding, so
  the floor doesn't have to be re-derived when font metrics move (`py-2.5` landed on
  42px — 2px short).
- **Burnup series labels sit on a plate.** The right gutter is 30 of 640 viewBox
  units, ~15px on a phone, so a label several times that wide extends back over the
  plot and the series stroke ran straight through the text.

## Button colours back on the token system

Accent is per-theme and workspace-brandable — 14 presets, 17 distinct accents from
`#000000` to light greens — so a hardcoded colour ignores the theme entirely.

The real defect: the ticket comment submit button used `bg-accent text-white`. The
accent foreground is picked per theme by WCAG luminance and brand orange resolves to
**black**, so white was low-contrast on the default theme and worse on the
light-accent presets.

Most other violations sat **directly beside correct code** — `MenuList`'s danger
branch was raw red while the active branch of the same ternary was tokenised;
`FilterPill` was a hardcoded amber copy of the exact treatment `GroupByMenu` uses for
an active axis; `TicketGapFlag` wrapped raw amber around a dismiss button already
using `text-status-error`. Since tokens are theme-aware, the paired `dark:` overrides
these sites carried are gone rather than translated.

`frontend/scripts/scan-button-colors.mjs` found them and now reports 0. It separates a
raw palette colour from the subtler `text-white` on `bg-accent`, skips the shared
`#6366f1` fallback for user-chosen entity colours, and reads class groups per branch
so a ternary isn't reported for the branch it got right. Self-tested against known-bad
markup — "0 findings" and "broken scanner" look identical otherwise.

## console.log sweep

56 live calls, none level-gated, all running in production. Now 4, each guarded by
`DEBUG_SSE`, `import.meta.env.DEV`, or inside a commented-out block.

Three of the removed ones put user data in the production console: `MFASetupView`
logged the MFA setup credential object, `CollaborativeEditor` had a leftover `@click`
on the presence avatars that logged the connected user, and `AttachmentPreview` logged
transcription text.

The two unguarded logging *shims* now route through `@nosdesk/core/utils/logger`,
which drops DEBUG in prod and redacts token-ish context keys, rather than being
deleted — they're real diagnostic channels.

## Verification

Type-check, lint (313 templates), 33 unit tests, and the full e2e suite (12 passed,
14 skipped) including the existing timeline-reschedule spec, so the landing scroll
doesn't disturb drag. Every changed surface driven in a browser at 390px: all four
project views now report 0px page overflow, 0 controls past the right edge, and 0
sub-44px tap targets.
